### PR TITLE
[StyleFix] change hinter color

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
             DefaultHinter::default()
                 .with_completer(completer) // or .with_history()
                 // .with_inside_line()
-                .with_style(Style::new().italic().fg(Color::LightGray)),
+                .with_style(Style::new().italic().fg(Color::Fixed(249))),
         ));
 
     let prompt = DefaultPrompt::new(1);


### PR DESCRIPTION
How about changing the default hinter color ?

From:

![Schermata 2021-07-26 alle 10 09 49](https://user-images.githubusercontent.com/51322105/126955515-fd90003b-d033-40ca-88b0-5e6107508609.png)
 To:
 
![Schermata 2021-07-26 alle 10 10 28](https://user-images.githubusercontent.com/51322105/126955609-e2bf3498-22db-40c0-aea6-757886ec9037.png)

I think that the default hinter should be less visible than the actual one.
We can choose any of this, actually I proposed the 249 --> https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg

![](https://user-images.githubusercontent.com/51322105/126955916-511cb220-d7c4-4852-8b4f-10f4defd3c41.png)
