### PR TITLE
Experimenting with Undo redo

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -1,13 +1,14 @@
 use crate::core_editor::get_default_clipboard;
 
-use super::{Clipboard, LineBuffer};
+use super::{
+    undo_stack::{BasicUndoStack, UndoStack},
+    Clipboard, LineBuffer,
+};
 
 pub struct Editor {
     line_buffer: LineBuffer,
     cut_buffer: Box<dyn Clipboard>,
-
-    edits: Vec<LineBuffer>,
-    index_undo: usize,
+    undo_stack: Box<dyn UndoStack<LineBuffer>>,
 }
 
 impl Default for Editor {
@@ -15,10 +16,7 @@ impl Default for Editor {
         Editor {
             line_buffer: LineBuffer::new(),
             cut_buffer: Box::new(get_default_clipboard()),
-
-            // Note: Using list-zipper we can reduce these to one field
-            edits: vec![],
-            index_undo: 2,
+            undo_stack: Box::new(BasicUndoStack::new()),
         }
     }
 }
@@ -30,86 +28,107 @@ impl Editor {
 
     pub fn set_line_buffer(&mut self, line_buffer: LineBuffer) {
         self.line_buffer = line_buffer;
+        self.insert_to_undo_stack();
     }
 
     pub fn move_to_start(&mut self) {
-        self.line_buffer.move_to_start()
+        self.line_buffer.move_to_start();
+        self.insert_to_undo_stack();
     }
 
     pub fn move_to_end(&mut self) {
-        self.line_buffer.move_to_end()
+        self.line_buffer.move_to_end();
+        self.insert_to_undo_stack();
     }
 
     pub fn move_left(&mut self) {
-        self.line_buffer.move_left()
+        self.line_buffer.move_left();
+        self.insert_to_undo_stack();
     }
 
     pub fn move_right(&mut self) {
-        self.line_buffer.move_right()
+        self.line_buffer.move_right();
+        self.insert_to_undo_stack();
     }
 
     pub fn move_word_left(&mut self) {
         self.line_buffer.move_word_left();
+        self.insert_to_undo_stack();
     }
 
     pub fn move_word_right(&mut self) {
         self.line_buffer.move_word_right();
+        self.insert_to_undo_stack();
     }
 
     pub fn move_line_up(&mut self) {
         self.line_buffer.move_line_up();
+        self.insert_to_undo_stack();
     }
 
     pub fn move_line_down(&mut self) {
         self.line_buffer.move_line_down();
+        self.insert_to_undo_stack();
     }
 
     pub fn insert_char(&mut self, c: char) {
-        self.line_buffer.insert_char(c)
+        self.line_buffer.insert_char(c);
+        self.insert_to_undo_stack();
     }
 
     pub fn backspace(&mut self) {
         self.line_buffer.delete_left_grapheme();
+        self.insert_to_undo_stack();
     }
 
     pub fn delete(&mut self) {
         self.line_buffer.delete_right_grapheme();
+        self.insert_to_undo_stack();
     }
 
     pub fn backspace_word(&mut self) {
         self.line_buffer.delete_word_left();
+        self.insert_to_undo_stack();
     }
 
     pub fn delete_word(&mut self) {
         self.line_buffer.delete_word_right();
+        self.insert_to_undo_stack();
     }
 
     pub fn clear(&mut self) {
         self.line_buffer.clear();
+        self.insert_to_undo_stack();
     }
 
     pub fn uppercase_word(&mut self) {
         self.line_buffer.uppercase_word();
+        self.insert_to_undo_stack();
     }
 
     pub fn lowercase_word(&mut self) {
         self.line_buffer.lowercase_word();
+        self.insert_to_undo_stack();
     }
 
     pub fn capitalize_char(&mut self) {
         self.line_buffer.capitalize_char();
+        self.insert_to_undo_stack();
     }
 
     pub fn swap_words(&mut self) {
         self.line_buffer.swap_words();
+        self.insert_to_undo_stack();
     }
 
     pub fn swap_graphemes(&mut self) {
         self.line_buffer.swap_graphemes();
+        self.insert_to_undo_stack();
     }
 
     pub fn set_insertion_point(&mut self, pos: usize) {
-        self.line_buffer.set_insertion_point(pos)
+        self.line_buffer.set_insertion_point(pos);
+        self.insert_to_undo_stack();
     }
 
     pub fn get_buffer(&self) -> &str {
@@ -117,22 +136,26 @@ impl Editor {
     }
 
     pub fn set_buffer(&mut self, buffer: String) {
-        self.line_buffer.set_buffer(buffer)
+        self.line_buffer.set_buffer(buffer);
+        self.insert_to_undo_stack();
     }
 
     pub fn clear_to_end(&mut self) {
-        self.line_buffer.clear_to_end()
+        self.line_buffer.clear_to_end();
+        self.insert_to_undo_stack();
     }
 
     pub fn clear_to_insertion_point(&mut self) {
-        self.line_buffer.clear_to_insertion_point()
+        self.line_buffer.clear_to_insertion_point();
+        self.insert_to_undo_stack();
     }
 
     pub fn clear_range<R>(&mut self, range: R)
     where
         R: std::ops::RangeBounds<usize>,
     {
-        self.line_buffer.clear_range(range)
+        self.line_buffer.clear_range(range);
+        self.insert_to_undo_stack();
     }
 
     pub fn offset(&self) -> usize {
@@ -164,63 +187,33 @@ impl Editor {
     }
 
     pub fn reset_olds(&mut self) {
-        self.edits = vec![LineBuffer::new()];
-        self.index_undo = 2;
-    }
-
-    fn get_index_undo(&self) -> usize {
-        if let Some(c) = self.edits.len().checked_sub(self.index_undo) {
-            c
-        } else {
-            0
-        }
+        self.undo_stack.reset();
     }
 
     pub fn undo(&mut self) {
-        // NOTE: Try-blocks should help us get rid of this indirection too
-        self.undo_internal();
+        let val = self.undo_stack.undo();
+        self.line_buffer = val.clone();
     }
 
     pub fn redo(&mut self) {
-        // NOTE: Try-blocks should help us get rid of this indirection too
-        self.redo_internal();
+        let val = self.undo_stack.redo();
+        self.line_buffer = val.clone();
     }
 
-    fn redo_internal(&mut self) -> Option<()> {
-        if self.index_undo > 2 {
-            self.index_undo = self.index_undo.checked_sub(2)?;
-            self.undo_internal()
-        } else {
-            None
-        }
-    }
-
-    fn undo_internal(&mut self) -> Option<()> {
-        self.line_buffer = self.edits.get(self.get_index_undo())?.clone();
-
-        if self.index_undo <= self.edits.len() {
-            self.index_undo = self.index_undo.checked_add(1)?;
-        }
-        Some(())
-    }
-
-    pub fn set_previous_lines(&mut self, is_after_action: bool) -> Option<()> {
-        self.reset_index_undo();
-
-        if self.edits.len() > 1
-            && self.edits.last()?.word_count() == self.line_buffer.word_count()
-            && !is_after_action
-        {
-            self.edits.pop();
-        }
-        self.edits.push(self.line_buffer.clone());
-
-        Some(())
-    }
-
-    pub fn reset_index_undo(&mut self) {
-        self.index_undo = 2;
-    }
+    // pub fn set_previous_lines(&mut self, is_after_action: bool) -> Option<()> {
+    //     self.reset_index_undo();
+    //
+    //     if self.edits.len() > 1
+    //         && self.edits.last()?.word_count() == self.line_buffer.word_count()
+    //         && !is_after_action
+    //     {
+    //         self.edits.pop();
+    //     }
+    //     self.edits.push(self.line_buffer.clone());
+    //
+    //     Some(())
+    // }
+    //
 
     pub fn cut_from_start(&mut self) {
         let insertion_offset = self.line_buffer.offset();
@@ -265,5 +258,39 @@ impl Editor {
     pub fn insert_cut_buffer(&mut self) {
         let cut_buffer = self.cut_buffer.get();
         self.line_buffer.insert_str(&cut_buffer);
+    }
+
+    fn insert_to_undo_stack(&mut self) {
+        // PERF: Use some strategy to insert into undo stack instead of inserting everything
+        self.undo_stack.insert(self.line_buffer.clone());
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    #[test]
+    fn undo_which_captures_all_operations() {
+        let mut editor = Editor::default();
+
+        editor.insert_char('a');
+        editor.insert_char('b');
+        editor.insert_char(' ');
+        editor.insert_char('c');
+
+        let expected_edits = vec![
+            LineBuffer::new(),
+            LineBuffer::from("a"),
+            LineBuffer::from("ab"),
+            LineBuffer::from("ab "),
+            LineBuffer::from("ab c"),
+        ];
+
+        let actual_edits: Vec<LineBuffer> = editor.undo_stack.edits().cloned().collect();
+
+        assert_eq!(expected_edits, actual_edits);
     }
 }

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -31,6 +31,14 @@ impl Default for LineBuffer {
     }
 }
 
+impl From<&str> for LineBuffer {
+    fn from(input: &str) -> Self {
+        let mut line_buffer = LineBuffer::new();
+        line_buffer.insert_str(input);
+        line_buffer
+    }
+}
+
 impl LineBuffer {
     pub fn new() -> LineBuffer {
         LineBuffer {

--- a/src/core_editor/mod.rs
+++ b/src/core_editor/mod.rs
@@ -1,6 +1,7 @@
 mod clip_buffer;
 mod editor;
 mod line_buffer;
+mod undo_stack;
 
 pub use clip_buffer::{get_default_clipboard, Clipboard};
 pub use editor::Editor;

--- a/src/core_editor/undo_stack.rs
+++ b/src/core_editor/undo_stack.rs
@@ -1,0 +1,142 @@
+/// This outlines the operations (interface) that any data strcuture will need to obey to be useful
+/// to the core_editor as undo/redo stack
+pub trait UndoStack<T>
+where
+    T: Default,
+    T: Clone,
+{
+    /// Go back one point in the undo stack.
+    /// If present on first edit do nothing
+    fn undo(&mut self) -> &T;
+
+    /// Go forward one point in the undo stack.
+    /// If present on the last edit do nothing
+    fn redo(&mut self) -> &T;
+
+    /// Insert a new entry to the undo stack.
+    /// NOTE: (IMP): If we have hit undo a few times then discard all the other values that come
+    /// after the current point
+    fn insert(&mut self, value: T);
+
+    /// Reset the stack to the initial state
+    fn reset(&mut self);
+
+    /// Return the entry currently being pointed to
+    fn current(&mut self) -> &T;
+
+    /// List out all the entries on the undo stack
+    /// Mostly used for debugging. Might remove this one
+    fn edits<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a>;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct BasicUndoStack<T> {
+    internal_list: Vec<T>,
+    index: usize,
+}
+
+impl<T> BasicUndoStack<T> {
+    pub fn new() -> Self
+    where
+        T: Default,
+    {
+        BasicUndoStack {
+            internal_list: vec![T::default()],
+            index: 0,
+        }
+    }
+}
+
+impl<T> UndoStack<T> for BasicUndoStack<T>
+where
+    T: Default,
+    T: Clone,
+{
+    fn undo(&mut self) -> &T {
+        self.index = if self.index == 0 { 0 } else { self.index - 1 };
+        &self.internal_list[self.index]
+    }
+
+    fn redo(&mut self) -> &T {
+        self.index = if self.index == self.internal_list.len() - 1 {
+            self.index
+        } else {
+            self.index + 1
+        };
+        &self.internal_list[self.index]
+    }
+
+    fn insert(&mut self, value: T) {
+        if self.index < self.internal_list.len() - 1 {
+            self.internal_list.resize_with(self.index + 1, || {
+                panic!("Impossible state reached: Bug in UndoStack logic")
+            });
+        }
+        self.internal_list.push(value);
+        self.index += 1;
+    }
+
+    fn reset(&mut self) {
+        self.index = 0;
+        self.internal_list = vec![T::default()];
+    }
+
+    fn edits<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a> {
+        Box::new(self.internal_list.iter().take(self.index + 1))
+    }
+
+    fn current(&mut self) -> &T {
+        &self.internal_list[self.index]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    fn undo_stack<T>(values: &[T], index: usize) -> BasicUndoStack<T>
+    where
+        T: Clone,
+    {
+        BasicUndoStack {
+            internal_list: values.to_vec(),
+            index,
+        }
+    }
+
+    #[rstest]
+    #[case(undo_stack(&[1, 2, 3][..], 2), 2)]
+    #[case(undo_stack(&[1][..], 0), 1)]
+    fn undo_works(#[case] stack: BasicUndoStack<isize>, #[case] value_after_undo: isize) {
+        let mut stack = stack;
+
+        let value = stack.undo();
+        assert_eq!(*value, value_after_undo);
+    }
+
+    #[rstest]
+    #[case(undo_stack(&[1, 2, 3][..], 1), 3)]
+    #[case(undo_stack(&[1][..], 0), 1)]
+    fn redo_works(#[case] stack: BasicUndoStack<isize>, #[case] value_after_undo: isize) {
+        let mut stack = stack;
+
+        let value = stack.redo();
+        assert_eq!(*value, value_after_undo);
+    }
+
+    #[rstest]
+    #[case(undo_stack(&[1, 2, 3][..], 1), 4, undo_stack(&[1, 2, 4], 2))]
+    #[case(undo_stack(&[1, 2, 3][..], 2), 3, undo_stack(&[1, 2, 3, 3], 3))]
+    fn insert_works(
+        #[case] old_stack: BasicUndoStack<isize>,
+        #[case] value_to_insert: isize,
+        #[case] expected_stack: BasicUndoStack<isize>,
+    ) {
+        let mut stack = old_stack;
+
+        stack.insert(value_to_insert);
+        assert_eq!(stack, expected_stack);
+    }
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -803,7 +803,6 @@ impl Reedline {
                     } else {
                         self.editor.insert_char(*c);
                     }
-                    self.editor.set_previous_lines(false);
 
                     self.repaint(prompt)?;
                 }
@@ -824,27 +823,6 @@ impl Reedline {
                 EditCommand::SwapGraphemes => self.editor.swap_graphemes(),
                 EditCommand::Undo => self.editor.undo(),
                 EditCommand::Redo => self.editor.redo(),
-            }
-
-            if [
-                EditCommand::MoveToEnd,
-                EditCommand::MoveToStart,
-                EditCommand::MoveLeft,
-                EditCommand::MoveRight,
-                EditCommand::MoveWordLeft,
-                EditCommand::MoveWordRight,
-                EditCommand::Backspace,
-                EditCommand::Delete,
-                EditCommand::BackspaceWord,
-                EditCommand::DeleteWord,
-                EditCommand::CutFromStart,
-                EditCommand::CutToEnd,
-                EditCommand::CutWordLeft,
-                EditCommand::CutWordRight,
-            ]
-            .contains(command)
-            {
-                self.editor.set_previous_lines(true);
             }
         }
 


### PR DESCRIPTION
The idea here is to make engine not have to worry about the internals of undo-redo (`set_previous_lines`). 
and 2nd have an abstraction that encapsulates index handling etc, out of editor
and 3rd to enable various pluggable strategies for what to track in the undo stack. 

NOTE: THIS IS NOT TESTED YET!