### PR TITLE
Fix CtrlD/CtrlC and reverse-history-search + stuff

### DIFF
--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -28,7 +28,7 @@ impl Span {
 /// The handler for when the user begins a completion action, often using the tab key
 /// This handler will then present the options to the user, allowing them to navigate the options
 /// and pick the completion they want
-pub trait ComplationActionHandler {
+pub trait CompletionActionHandler {
     /// Handle the completion action from the given line buffer
     fn handle(&mut self, line: &mut LineBuffer);
 }

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -7,8 +7,10 @@ use std::{
 use crate::{Completer, Span};
 
 /// A default completer that can detect keywords
+///
 /// # Example
-/// # Example
+///
+/// ```rust, no_run
 /// use reedline::{DefaultCompleter, DefaultCompletionActionHandler, Reedline};
 ///
 /// let commands = vec![
@@ -19,9 +21,11 @@ use crate::{Completer, Span};
 /// ];
 /// let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 ///
-/// let mut line_editor = Reedline::new().with_completion_action_handler(Box::new(
+/// let mut line_editor = Reedline::create().unwrap()
+///         .with_completion_action_handler(Box::new(
 ///   DefaultCompletionActionHandler::default().with_completer(completer),
 /// ));
+/// ```
 #[derive(Debug, Clone)]
 pub struct DefaultCompleter {
     root: CompletionNode,

--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -2,6 +2,6 @@ mod base;
 mod default;
 mod tab_handler;
 
-pub use base::{ComplationActionHandler, Completer, Span};
+pub use base::{Completer, CompletionActionHandler, Span};
 pub use default::DefaultCompleter;
 pub use tab_handler::DefaultCompletionActionHandler;

--- a/src/completion/tab_handler.rs
+++ b/src/completion/tab_handler.rs
@@ -1,4 +1,4 @@
-use crate::{core_editor::LineBuffer, ComplationActionHandler, Completer, DefaultCompleter};
+use crate::{core_editor::LineBuffer, Completer, CompletionActionHandler, DefaultCompleter};
 
 /// A simple handler that will do a cycle-based rotation through the options given by the Completer
 pub struct DefaultCompletionActionHandler {
@@ -10,7 +10,7 @@ pub struct DefaultCompletionActionHandler {
 }
 
 impl DefaultCompletionActionHandler {
-    /// Build a DefaultCompletionActionHander configured to use a specific completer
+    /// Build a `DefaultCompletionActionHandler` configured to use a specific completer
     ///
     /// # Arguments
     ///
@@ -53,7 +53,7 @@ impl DefaultCompletionActionHandler {
     }
 }
 
-impl ComplationActionHandler for DefaultCompletionActionHandler {
+impl CompletionActionHandler for DefaultCompletionActionHandler {
     // With this function we handle the tab events.
     //
     // If completions vector is not empty we proceed to replace

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -707,4 +707,37 @@ mod test {
 
         assert_eq!(line_buffer, expected);
     }
+
+    #[rstest]
+    #[case("line 1\nline 2\nline 3", 0, true)]
+    #[case("line 1\nline 2\nline 3", 6, true)]
+    #[case("line 1\nline 2\nline 3", 8, false)]
+    fn test_first_line_detection(
+        #[case] input: &str,
+        #[case] in_location: usize,
+        #[case] expected: bool,
+    ) {
+        let mut line_buffer = buffer_with(input);
+        line_buffer.set_insertion_point(in_location);
+
+        assert_eq!(line_buffer.is_cursor_at_first_line(), expected);
+    }
+
+    #[rstest]
+    #[case("line 1\nline 2\nline 3", 8, false)]
+    #[case("line 1\nline 2\nline 3", 13, false)]
+    #[case("line 1\nline 2\nline 3", 14, true)]
+    #[case("line 1\nline 2\nline 3", 20, true)]
+    #[case("line 1\nline 2\nline 3\n", 20, false)]
+    #[case("line 1\nline 2\nline 3\n", 21, true)]
+    fn test_last_line_detection(
+        #[case] input: &str,
+        #[case] in_location: usize,
+        #[case] expected: bool,
+    ) {
+        let mut line_buffer = buffer_with(input);
+        line_buffer.set_insertion_point(in_location);
+
+        assert_eq!(line_buffer.is_cursor_at_last_line(), expected);
+    }
 }

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -52,6 +52,11 @@ impl LineBuffer {
         self.insertion_point.offset
     }
 
+    /// Return cursor
+    fn insertion_point(&self) -> InsertionPoint {
+        self.insertion_point
+    }
+
     pub fn set_insertion_point(&mut self, offset: usize) {
         self.insertion_point = InsertionPoint { offset };
     }
@@ -59,6 +64,13 @@ impl LineBuffer {
     /// Output the current line in the multiline buffer
     pub fn get_buffer(&self) -> &str {
         &self.lines
+    }
+
+    /// Set to a single line of `buffer` and reset the `InsertionPoint` cursor to the end
+    pub fn set_buffer(&mut self, buffer: String) {
+        let offset = buffer.len();
+        self.lines = buffer;
+        self.insertion_point = InsertionPoint { offset };
     }
 
     /// Calculates the current the user is on
@@ -84,13 +96,6 @@ impl LineBuffer {
 
     pub fn ends_with(&self, c: char) -> bool {
         self.lines.ends_with(c)
-    }
-
-    /// Set to a single line of `buffer` and reset the `InsertionPoint` cursor
-    pub fn set_buffer(&mut self, buffer: String) {
-        let offset = buffer.len();
-        self.lines = buffer;
-        self.insertion_point = InsertionPoint { offset };
     }
 
     /// Reset the insertion point to the start of the buffer
@@ -410,17 +415,12 @@ impl LineBuffer {
         }
     }
 
-    /// Return 2D-cursor (line_number, col_in_line)
-    fn insertion_point(&self) -> InsertionPoint {
-        self.insertion_point
-    }
-
     pub fn is_cursor_at_first_line(&self) -> bool {
-        self.get_buffer()[0..self.offset()].contains('\n')
+        !self.get_buffer()[0..self.offset()].contains('\n')
     }
 
     pub fn is_cursor_at_last_line(&self) -> bool {
-        self.get_buffer()[self.offset()..].contains('\n')
+        !self.get_buffer()[self.offset()..].contains('\n')
     }
 }
 

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -8,13 +8,13 @@ use {
     serde::{Deserialize, Serialize},
 };
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct KeyCombination {
     modifier: KeyModifiers,
     key_code: KeyCode,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Keybindings {
     pub bindings: HashMap<KeyCombination, ReedlineEvent>,
 }
@@ -73,7 +73,6 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::CONTROL, KC::Char('c'), ReedlineEvent::CtrlC);
     kb.add_binding(KM::CONTROL, KC::Char('g'), edit_bind(EC::Redo));
     kb.add_binding(KM::CONTROL, KC::Char('z'), edit_bind(EC::Undo));
-    kb.add_binding(KM::CONTROL, KC::Char('d'), edit_bind(EC::Delete));
     kb.add_binding(KM::CONTROL, KC::Char('a'), edit_bind(EC::MoveToStart));
     kb.add_binding(KM::CONTROL, KC::Char('e'), edit_bind(EC::MoveToEnd));
     kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToEnd));
@@ -81,7 +80,6 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::CONTROL, KC::Char('y'), edit_bind(EC::PasteCutBuffer));
     kb.add_binding(KM::CONTROL, KC::Char('b'), edit_bind(EC::MoveLeft));
     kb.add_binding(KM::CONTROL, KC::Char('f'), edit_bind(EC::MoveRight));
-    kb.add_binding(KM::CONTROL, KC::Char('c'), edit_bind(EC::Clear));
     kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
     kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
     kb.add_binding(KM::CONTROL, KC::Char('p'), ReedlineEvent::PreviousHistory);

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -100,10 +100,22 @@ pub enum ReedlineEvent {
     /// Trigger Tab
     HandleTab,
 
-    /// Don't know a better name for this
+    /// Handle EndOfLine event
+    ///
+    /// Expected Behavior:
+    ///
+    /// - On empty line breaks execution to exit with [`Signal::CtrlD`]
+    /// - Secondary behavior [`EditCommand::Delete`]
     CtrlD,
 
-    /// Don't know a better name for this
+    /// Handle SIGTERM key input
+    ///
+    /// Expected behavior:
+    ///
+    /// Abort entry
+    /// Run [`EditCommand::Clear`]
+    /// Clear the current undo
+    /// Bubble up [`Signal::CtrlC`]
     CtrlC,
 
     /// Clears the screen and sets prompt to first line

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ pub use styled_text::StyledText;
 
 mod completion;
 pub use completion::{
-    ComplationActionHandler, Completer, DefaultCompleter, DefaultCompletionActionHandler, Span,
+    Completer, CompletionActionHandler, DefaultCompleter, DefaultCompletionActionHandler, Span,
 };
 
 mod hinter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     // if -k is passed, show the events
     if args.len() > 1 && args[1] == "-k" {
-        println!("Ready to print events:");
+        println!("Ready to print events (Abort with ESC):");
         print_events()?;
         println!();
         return Ok(());

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -124,7 +124,7 @@ impl Prompt for DefaultPrompt {
         // NOTE: magic strings, givent there is logic on how these compose I am not sure if it
         // is worth extracting in to static constant
         Cow::Owned(format!(
-            "({}reverse-search: {})",
+            "({}reverse-search: {}) ",
             prefix, history_search.term
         ))
     }


### PR DESCRIPTION
- `Ctrl+C` and `Ctrl+D` did not work after the changes in #138 and #146
  - Fixed by only registering the `ReedlineEvent` and defering
potentially necessary edits to the `handle_event` stage
  - Defined their behavior for the reverse history search
  - Corrected interactions with undo (as best as I could understand it)
- Reverse history search did not allow for browsing through its results
  - Fixed `handle_history_search_event` and simplified the cases
- Register undo steps for the reverse history search (when entering and
leaving via enter)
- Added comments to similar sounding methods and variants (UPDATE IF
NECESSARY!)
- Moved the repaint stuff closer together in engine.rs for better
readability
- Noncritical stuff that caught my eye