### PR TITLE
Clarify method names for undo-interface

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -163,7 +163,7 @@ impl Editor {
         self.line_buffer.is_cursor_at_last_line()
     }
 
-    pub fn reset_olds(&mut self) {
+    pub fn reset_undo_stack(&mut self) {
         self.edits = vec![LineBuffer::new()];
         self.index_undo = 2;
     }
@@ -204,7 +204,7 @@ impl Editor {
         Some(())
     }
 
-    pub fn set_previous_lines(&mut self, is_after_action: bool) -> Option<()> {
+    pub fn remember_undo_state(&mut self, is_after_action: bool) -> Option<()> {
         self.reset_index_undo();
 
         if self.edits.len() > 1
@@ -218,7 +218,7 @@ impl Editor {
         Some(())
     }
 
-    pub fn reset_index_undo(&mut self) {
+    fn reset_index_undo(&mut self) {
         self.index_undo = 2;
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -370,7 +370,7 @@ impl Reedline {
             ReedlineEvent::CtrlD => {
                 if self.editor.is_empty() {
                     self.input_mode = InputMode::Regular;
-                    self.editor.reset_olds();
+                    self.editor.reset_undo_stack();
                     Ok(Some(Signal::CtrlD))
                 } else {
                     self.run_history_commands(&[EditCommand::Delete]);
@@ -387,7 +387,7 @@ impl Reedline {
 
                 if let Some(string) = self.history.string_at_cursor() {
                     self.editor.set_buffer(string);
-                    self.editor.set_previous_lines(true);
+                    self.editor.remember_undo_state(true);
                 }
 
                 self.input_mode = InputMode::Regular;
@@ -491,7 +491,7 @@ impl Reedline {
             }
             ReedlineEvent::CtrlD => {
                 if self.editor.is_empty() {
-                    self.editor.reset_olds();
+                    self.editor.reset_undo_stack();
                     Ok(Some(Signal::CtrlD))
                 } else {
                     self.run_edit_commands(&[EditCommand::Delete], prompt)?;
@@ -500,7 +500,7 @@ impl Reedline {
             }
             ReedlineEvent::CtrlC => {
                 self.run_edit_commands(&[EditCommand::Clear], prompt)?;
-                self.editor.reset_olds();
+                self.editor.reset_undo_stack();
                 Ok(Some(Signal::CtrlC))
             }
             ReedlineEvent::ClearScreen => Ok(Some(Signal::CtrlL)),
@@ -510,7 +510,7 @@ impl Reedline {
                     self.append_to_history();
                     self.run_edit_commands(&[EditCommand::Clear], prompt)?;
                     self.print_crlf()?;
-                    self.editor.reset_olds();
+                    self.editor.reset_undo_stack();
 
                     Ok(Some(Signal::Success(buffer)))
                 } else {
@@ -567,7 +567,7 @@ impl Reedline {
             }
             ReedlineEvent::SearchHistory => {
                 // Make sure we are able to undo the result of a reverse history search
-                self.editor.set_previous_lines(true);
+                self.editor.remember_undo_state(true);
 
                 self.search_history();
                 self.repaint(prompt)?;
@@ -745,7 +745,7 @@ impl Reedline {
                     } else {
                         self.editor.insert_char(*c);
                     }
-                    self.editor.set_previous_lines(false);
+                    self.editor.remember_undo_state(false);
 
                     self.repaint(prompt)?;
                 }
@@ -786,7 +786,7 @@ impl Reedline {
             ]
             .contains(command)
             {
-                self.editor.set_previous_lines(true);
+                self.editor.remember_undo_state(true);
             }
         }
 


### PR DESCRIPTION
Minimal change to make undo machinery of `Editor` more explicit.