### PR TITLE
Attempt at consolidating offset calculations and streamlining the painting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fn main() {
                 println!("We processed: {}", buffer);
             }
             Signal::CtrlD | Signal::CtrlC => {
-                line_editor.print_crlf().unwrap();
+                println!("\nAborted!");
                 break;
             }
             Signal::CtrlL => {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -430,15 +430,13 @@ impl Reedline {
             }
             ReedlineEvent::ClearScreen => Ok(Some(Signal::CtrlL)),
             ReedlineEvent::Enter | ReedlineEvent::HandleTab => {
-                self.queue_prompt_indicator(prompt)?;
-
                 if let Some(string) = self.history.string_at_cursor() {
                     self.editor.set_buffer(string);
                     self.editor.remember_undo_state(true);
                 }
 
                 self.input_mode = InputMode::Regular;
-                self.repaint(prompt)?;
+                self.full_repaint(prompt)?;
                 Ok(None)
             }
             ReedlineEvent::Edit(commands) => {
@@ -804,19 +802,6 @@ impl Reedline {
         } else {
             self.editor.move_line_down();
         }
-    }
-
-    /// Display only the prompt components preceding the buffer
-    ///
-    /// Used to restore the prompt indicator after a search etc. that affected
-    /// the prompt
-    fn queue_prompt_indicator(&mut self, prompt: &dyn Prompt) -> Result<()> {
-        // print our prompt
-        let prompt_mode = self.prompt_edit_mode();
-        self.painter
-            .queue_prompt_indicator(prompt, prompt_mode, self.use_ansi_coloring)?;
-
-        Ok(())
     }
 
     /// *Partial* repaint of either the buffer or the parts for reverse history search

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -310,13 +310,6 @@ impl Reedline {
         self.painter.paint_line(msg)
     }
 
-    /// Goes to the beginning of the next line
-    ///
-    /// Also works in raw mode
-    pub fn print_crlf(&mut self) -> Result<()> {
-        self.painter.paint_crlf()
-    }
-
     /// Clear the screen by printing enough whitespace to start the prompt or
     /// other output back at the first line of the terminal.
     pub fn clear_screen(&mut self) -> Result<()> {
@@ -510,7 +503,7 @@ impl Reedline {
                 if matches!(self.validator.validate(&buffer), ValidationResult::Complete) {
                     self.append_to_history();
                     self.run_edit_commands(&[EditCommand::Clear], prompt)?;
-                    self.print_crlf()?;
+                    self.painter.print_crlf()?;
                     self.editor.reset_undo_stack();
 
                     Ok(Some(Signal::Success(buffer)))

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -446,7 +446,7 @@ impl Reedline {
             }
             ReedlineEvent::Mouse => Ok(None),
             ReedlineEvent::Resize(width, height) => {
-                self.painter.handle_resize(width, height)?;
+                self.painter.handle_resize(width, height);
                 self.full_repaint(prompt)?;
                 Ok(None)
             }
@@ -533,7 +533,7 @@ impl Reedline {
             }
             ReedlineEvent::Mouse => Ok(None),
             ReedlineEvent::Resize(width, height) => {
-                self.painter.handle_resize(width, height)?;
+                self.painter.handle_resize(width, height);
                 self.full_repaint(prompt)?;
                 Ok(None)
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -832,8 +832,11 @@ impl Reedline {
 
             let prompt_history_search = PromptHistorySearch::new(status, substring);
 
-            self.painter
-                .queue_history_search_indicator(prompt, prompt_history_search)?;
+            self.painter.queue_history_search_indicator(
+                prompt,
+                prompt_history_search,
+                self.use_ansi_coloring,
+            )?;
 
             match self.history.string_at_cursor() {
                 Some(string) => {

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -31,15 +31,15 @@ impl Highlighter for DefaultHighlighter {
             .iter()
             .any(|x| line.contains(x))
         {
-            let matches: Vec<String> = self
+            let matches: Vec<&str> = self
                 .external_commands
                 .iter()
                 .filter(|c| line.contains(*c))
-                .map(|c| c.to_string())
+                .map(std::ops::Deref::deref)
                 .collect();
-            let longest_match = matches.iter().fold("".to_string(), |acc, item| {
+            let longest_match = matches.iter().fold("".to_string(), |acc, &item| {
                 if item.len() > acc.len() {
-                    item.clone()
+                    item.to_string()
                 } else {
                     acc
                 }
@@ -55,10 +55,10 @@ impl Highlighter for DefaultHighlighter {
                 Style::new().bold().fg(self.neutral_color),
                 buffer_split[1].to_string(),
             ));
-        } else if !self.external_commands.is_empty() {
-            styled_text.push((Style::new().fg(self.notmatch_color), line.to_string()));
-        } else {
+        } else if self.external_commands.is_empty() {
             styled_text.push((Style::new().fg(self.neutral_color), line.to_string()));
+        } else {
+            styled_text.push((Style::new().fg(self.notmatch_color), line.to_string()));
         }
 
         styled_text

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!              println!("We processed: {}", buffer);
 //!          }
 //!          Ok(Signal::CtrlD) | Ok(Signal::CtrlC) => {
-//!              let _ = line_editor.print_crlf();
+//!              println!("\nAborted!");
 //!              break;
 //!          }
 //!          Ok(Signal::CtrlL) => {

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -7,7 +7,7 @@ use {
     },
     crossterm::{
         cursor::{self, position, MoveTo, MoveToColumn, RestorePosition, SavePosition},
-        style::{Color, Print, ResetColor, SetForegroundColor},
+        style::{Print, ResetColor, SetForegroundColor},
         terminal::{self, Clear, ClearType},
         QueueableCommand, Result,
     },
@@ -83,21 +83,17 @@ impl Painter {
     ) -> Result<()> {
         let (screen_width, _) = self.terminal_size;
 
+        self.stdout.queue(MoveToColumn(0))?;
         if use_ansi_coloring {
             // print our prompt with color
             self.stdout
-                .queue(MoveToColumn(0))?
-                .queue(SetForegroundColor(prompt.get_prompt_color()))?
-                .queue(Print(prompt.render_prompt(screen_width as usize)))?
-                .queue(Print(prompt.render_prompt_indicator(prompt_mode)))?
-                .queue(ResetColor)?;
-        } else {
-            // print our prompt without color
-            self.stdout
-                .queue(MoveToColumn(0))?
-                .queue(Print(prompt.render_prompt(screen_width as usize)))?
-                .queue(Print(prompt.render_prompt_indicator(prompt_mode)))?
-                .queue(ResetColor)?;
+                .queue(SetForegroundColor(prompt.get_prompt_color()))?;
+        }
+        self.stdout
+            .queue(Print(prompt.render_prompt(screen_width as usize)))?
+            .queue(Print(prompt.render_prompt_indicator(prompt_mode)))?;
+        if use_ansi_coloring {
+            self.stdout.queue(ResetColor)?;
         }
 
         Ok(())
@@ -331,16 +327,20 @@ impl Painter {
         &mut self,
         prompt: &dyn Prompt,
         prompt_search: PromptHistorySearch,
+        use_ansi_coloring: bool,
     ) -> Result<()> {
         // print search prompt
-        self.stdout
-            .queue(MoveToColumn(0))?
-            .queue(SetForegroundColor(Color::Blue))?
-            .queue(Print(
-                prompt.render_prompt_history_search_indicator(prompt_search),
-            ))?
-            .queue(ResetColor)?;
-
+        self.stdout.queue(MoveToColumn(0))?;
+        if use_ansi_coloring {
+            self.stdout
+                .queue(SetForegroundColor(prompt.get_prompt_color()))?;
+        }
+        self.stdout.queue(Print(
+            prompt.render_prompt_history_search_indicator(prompt_search),
+        ))?;
+        if use_ansi_coloring {
+            self.stdout.queue(ResetColor)?;
+        }
         Ok(())
     }
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -94,7 +94,7 @@ impl Painter {
         &mut self,
         highlighted_line: (String, String),
         hint: String,
-        prompt_offset: (u16, u16),
+        input_start: (u16, u16),
     ) -> Result<()> {
         let (before_cursor, after_cursor) = highlighted_line;
 
@@ -112,9 +112,7 @@ impl Painter {
             after_cursor.split("\n")
         };
 
-        let mut commands = self
-            .stdout
-            .queue(MoveTo(prompt_offset.0, prompt_offset.1))?;
+        let mut commands = self.stdout.queue(MoveTo(input_start.0, input_start.1))?;
 
         for (idx, before_cursor_line) in before_cursor_lines.enumerate() {
             if idx != 0 {
@@ -155,23 +153,23 @@ impl Painter {
         &mut self,
         prompt: &dyn Prompt,
         prompt_mode: PromptEditMode,
-        prompt_origin: (u16, u16),
+        prompt_start: (u16, u16),
         highlighted_line: (String, String),
         hint: String,
         terminal_size: (u16, u16),
         use_ansi_coloring: bool,
     ) -> Result<(u16, u16)> {
         self.stdout.queue(cursor::Hide)?;
-        self.queue_move_to(prompt_origin.0, prompt_origin.1)?;
+        self.queue_move_to(prompt_start.0, prompt_start.1)?;
         self.queue_prompt(prompt, prompt_mode, terminal_size, use_ansi_coloring)?;
         self.flush()?;
         // set where the input begins
-        let prompt_offset = position()?;
-        self.queue_buffer(highlighted_line, hint, prompt_offset)?;
+        let input_start = position()?;
+        self.queue_buffer(highlighted_line, hint, input_start)?;
         self.stdout.queue(cursor::Show)?;
         self.flush()?;
 
-        Ok(prompt_offset)
+        Ok(input_start)
     }
 
     pub fn queue_history_search_indicator(

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -206,7 +206,7 @@ impl Painter {
     }
 
     /// Updates prompt origin and offset to handle a screen resize event
-    pub(crate) fn handle_resize(&mut self, width: u16, height: u16) -> Result<()> {
+    pub(crate) fn handle_resize(&mut self, width: u16, height: u16) {
         let prev_terminal_size = self.terminal_size;
 
         self.terminal_size = (width, height);
@@ -232,8 +232,6 @@ impl Painter {
                 current_origin.1 + (height - prev_terminal_size.1),
             );
         }
-
-        Ok(())
     }
 
     /// TODO! FIX the naming and provide an accurate doccomment

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -103,33 +103,6 @@ impl Painter {
         Ok(())
     }
 
-    /// Queue prompt components preceding the buffer to display
-    ///
-    /// Used to restore the prompt indicator after a search etc. that affected
-    /// the prompt
-    pub fn queue_prompt_indicator(
-        &mut self,
-        prompt: &dyn Prompt,
-        prompt_mode: PromptEditMode,
-        use_ansi_coloring: bool,
-    ) -> Result<()> {
-        if use_ansi_coloring {
-            // print our prompt with color
-            self.stdout
-                .queue(MoveToColumn(0))?
-                .queue(SetForegroundColor(prompt.get_prompt_color()))?
-                .queue(Print(prompt.render_prompt_indicator(prompt_mode)))?
-                .queue(ResetColor)?;
-        } else {
-            // print our prompt without color
-            self.stdout
-                .queue(MoveToColumn(0))?
-                .queue(Print(prompt.render_prompt_indicator(prompt_mode)))?
-                .queue(ResetColor)?;
-        }
-        Ok(())
-    }
-
     /// Repaint logic for the normal input prompt buffer
     ///
     /// Requires coordinates where the input buffer begins after the prompt.

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -158,25 +158,30 @@ impl Painter {
         Ok(())
     }
 
-    /// Performs full repaint and sets the prompt and input origin position.
-    ///
-    /// Prints prompt (and buffer)
+    /// Sets the prompt origin position.
     pub(crate) fn initialize_prompt_position(&mut self) -> Result<()> {
+        // Cursor positions are 0 based here.
         let (column, row) = cursor::position()?;
-        let new_row = {
-            if (column, row) == (0, 0) {
-                0
-            } else if row + 1 == self.terminal_rows() {
-                self.paint_carriage_return()?;
-                row.saturating_sub(1)
-            } else if row + 2 == self.terminal_rows() {
-                self.paint_carriage_return()?;
-                row
-            } else {
-                row + 1
-            }
+        // Assumption: if the cursor is not on the zeroth column,
+        // there is content we want to leave intact, thus advance to the next row
+        let new_row = if column > 0 { row + 1 } else { row };
+        // TODO: support more than just two line prompts!
+        //  If we are on the last line or would move beyond the last line due to
+        //  the condition above, we need to make room for the multiline prompt.
+        //  Otherwise printing the prompt would scroll of the stored prompt
+        //  origin, causing issues after repaints.
+        let new_row = if new_row == self.terminal_rows() {
+            // Would exceed the terminal height, we need space for two lines
+            self.print_crlf()?;
+            self.print_crlf()?;
+            new_row.saturating_sub(2)
+        } else if new_row == self.terminal_rows() - 1 {
+            // Safe on the last line make space for the 2 line prompt
+            self.print_crlf()?;
+            new_row.saturating_sub(1)
+        } else {
+            new_row
         };
-
         self.prompt_coords.set_prompt_start(0, new_row);
         Ok(())
     }
@@ -371,16 +376,11 @@ impl Painter {
     /// Goes to the beginning of the next line
     ///
     /// Also works in raw mode
-    pub fn paint_crlf(&mut self) -> Result<()> {
-        self.stdout.queue(Print("\n"))?.queue(MoveToColumn(1))?;
+    pub(crate) fn print_crlf(&mut self) -> Result<()> {
+        self.stdout.queue(Print("\r\n"))?;
         self.stdout.flush()?;
 
         Ok(())
-    }
-
-    // Printing carriage return
-    pub fn paint_carriage_return(&mut self) -> Result<()> {
-        self.stdout.queue(Print("\r\n\r\n"))?.flush()
     }
 
     /// Clear the screen by printing enough whitespace to start the prompt or
@@ -396,7 +396,7 @@ impl Painter {
         Ok(())
     }
 
-    pub fn clear_until_newline(&mut self) -> Result<()> {
+    pub(crate) fn clear_until_newline(&mut self) -> Result<()> {
         self.stdout.queue(Clear(ClearType::UntilNewLine))?;
         self.stdout.flush()?;
 


### PR DESCRIPTION
### Motivation:
Keeping correct track of coordinates on the terminal screen is paramount to not cause artifacts. Those calculations have to take into account wrapping, new lines and resizing of the terminal. 

### Current situation:
In several locations in `src/engine.rs` such computations are performed and then executed in the `Painter`. Some magical comparisons and offsetting operations are not clearly documented, making it difficult to debug problems and adding new functionality that might require moving around multiple lines.

# Changes for now
* Rename `PromptWidget` to `PromptCoordinates`
* Explicit setters for `PromptCoordinates`
* Set offset implicitly on `Reedline::full_repaint`
* move the terminal size and prompt coordinate information into `Painter`
* Account for some issues with history search
* Make sure that the prompt is painted on the next free line and no spare lines are printed