### PR TITLE
Builder to customize and disable idle animations

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -11,7 +11,7 @@ use {
         text_manipulation, DefaultHighlighter, DefaultValidator, EditCommand, Highlighter, Prompt,
         Signal, ValidationResult, Validator,
     },
-    crossterm::{cursor, terminal, event, Result},
+    crossterm::{cursor, event, terminal, Result},
     std::{io, time::Duration},
 };
 
@@ -107,7 +107,7 @@ pub struct Reedline {
     prompt_widget: PromptWidget,
 
     // Is Some(n) read_line() should repaint prompt every `n` milliseconds
-    repaint: Option<u64>, 
+    repaint: Option<u64>,
 }
 
 impl Reedline {
@@ -1030,4 +1030,3 @@ impl Reedline {
         )
     }
 }
-


### PR DESCRIPTION
Appended an Option<u64> to Reedline struct that allows library users to customize the time waited between repaints.  It is interpreted as milliseconds, and if it is 'None', then no repainting occurs.  Added corresponding builder function.

Ideally, it would be friendlier if we could disable repainting dynamically, especially, when the prompt is not visible, or on 'MouseEventKind::ScrollUp'.  Unfortunately, my terminal (xfce4) would not report mouse events, so I couldn't get that to work.