### PR TITLE
Improvements to handling of incoming events

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -356,13 +356,13 @@ impl Reedline {
         let mut reedline_events: Vec<ReedlineEvent> = vec![];
 
         loop {
-            if event::poll(Duration::from_secs(self.repaint.unwrap_or(0)))? {
+            if event::poll(Duration::from_millis(self.repaint.unwrap_or(0)))? {
                 let mut latest_resize = None;
 
                 // There could be multiple events queued up!
                 // pasting text, resizes, blocking this thread (e.g. during debugging)
                 // We should be able to handle all of them as quickly as possible without causing unnecessary output steps.
-                while event::poll(Duration::from_secs(0))? {
+                while event::poll(Duration::from_millis(0))? {
                     // TODO: Maybe replace with a separate function processing the buffered event
                     match event::read()? {
                         Event::Resize(x, y) => {


### PR DESCRIPTION
To avoid issues with incoming resize events (#166) and improve performance in certain situations (pasting text via terminal facilities) restructure the event input processing:

- Drain all crossterm events currently available
- Prioritize the last resize and discard intermmediates
- Join all EditCommands to be processessed together before handing them to the internal event handler which will trigger a repaint