### PR TITLE
`fn queue_buffer` probably didn't mean to flush; Simplified engine->insert_char and removed the need to create a String at each insert.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -796,13 +796,12 @@ impl Reedline {
                 // A simple solution that we can do is to queue up these and perform the wrapping
                 // check after the loop finishes. Will need to sort out the details.
                 EditCommand::InsertChar(c) => {
-
                     self.editor.insert_char(*c);
-                    
+
                     if self.require_wrapping() {
                         let position = cursor::position()?;
                         self.wrap(position)?;
-                    } 
+                    }
 
                     self.editor.remember_undo_state(false);
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -107,8 +107,7 @@ impl Painter {
 
         commands
             .queue(Clear(ClearType::FromCursorDown))?
-            .queue(RestorePosition)?
-            .flush()?;
+            .queue(RestorePosition)?;
 
         Ok(())
     }


### PR DESCRIPTION
Sorry: Still new to all this Github machinery!  

But, have eliminated the need to create a new String at each character insert.
Since we have separated the manipulation of the underlying buffer from the act of painting it, there's no harm in inserting the character into the buffer, then inspecting that.

Moreover, tried to make the code for 'insert char' more readable, and to simplify the interfaces.