### PR TITLE
Forwarding Prompt's multiline indicator

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1007,6 +1007,7 @@ impl Reedline {
         prompt_origin: (u16, u16),
     ) -> Result<(u16, u16)> {
         let prompt_mode = self.prompt_edit_mode();
+        // let prompt_style = Style::new().fg(nu_ansi_term::Color::LightBlue);
         let buffer_to_paint = self.editor.get_buffer();
         let cursor_position_in_buffer = self.editor.offset();
 

--- a/src/styled_text.rs
+++ b/src/styled_text.rs
@@ -1,3 +1,5 @@
+use std::borrow::{Borrow, Cow};
+
 use nu_ansi_term::{Color, Style};
 
 /// A representation of a buffer with styling, used for doing syntax highlighting
@@ -31,6 +33,7 @@ impl StyledText {
         &self,
         insertion_point: usize,
         // prompt_style: &Style,
+        multiline_prompt: Cow<str>,
     ) -> (String, String) {
         let mut current_idx = 0;
         let mut left_string = String::new();
@@ -38,17 +41,33 @@ impl StyledText {
         let prompt_style = Style::new().fg(Color::LightBlue);
         for pair in &self.buffer {
             if current_idx >= insertion_point {
-                right_string.push_str(&render_as_string(pair, &prompt_style));
+                right_string.push_str(&render_as_string(
+                    pair,
+                    &prompt_style,
+                    multiline_prompt.borrow(),
+                ));
             } else if pair.1.len() + current_idx <= insertion_point {
-                left_string.push_str(&render_as_string(pair, &prompt_style));
+                left_string.push_str(&render_as_string(
+                    pair,
+                    &prompt_style,
+                    multiline_prompt.borrow(),
+                ));
             } else if pair.1.len() + current_idx > insertion_point {
                 let offset = insertion_point - current_idx;
 
                 let left_side = pair.1[..offset].to_string();
                 let right_side = pair.1[offset..].to_string();
 
-                left_string.push_str(&render_as_string(&(pair.0, left_side), &prompt_style));
-                right_string.push_str(&render_as_string(&(pair.0, right_side), &prompt_style));
+                left_string.push_str(&render_as_string(
+                    &(pair.0, left_side),
+                    &prompt_style,
+                    multiline_prompt.borrow(),
+                ));
+                right_string.push_str(&render_as_string(
+                    &(pair.0, right_side),
+                    &prompt_style,
+                    multiline_prompt.borrow(),
+                ));
             }
             current_idx += pair.1.len();
         }
@@ -57,11 +76,16 @@ impl StyledText {
     }
 }
 
-fn render_as_string(renderable: &(Style, String), prompt_style: &Style) -> String {
+fn render_as_string(
+    renderable: &(Style, String),
+    prompt_style: &Style,
+    multiline_prompt: &str,
+) -> String {
     let mut rendered = String::new();
+    let formatted_multiline_prompt = format!("\n{}", multiline_prompt);
     for (line_number, line) in renderable.1.split('\n').enumerate() {
         if line_number != 0 {
-            rendered.push_str(&prompt_style.paint("\n: ").to_string());
+            rendered.push_str(&prompt_style.paint(&formatted_multiline_prompt).to_string());
         }
         rendered.push_str(&renderable.0.paint(line).to_string());
     }

--- a/src/styled_text.rs
+++ b/src/styled_text.rs
@@ -32,7 +32,6 @@ impl StyledText {
     pub fn render_around_insertion_point(
         &self,
         insertion_point: usize,
-        // prompt_style: &Style,
         multiline_prompt: Cow<str>,
     ) -> (String, String) {
         let mut current_idx = 0;

--- a/src/styled_text.rs
+++ b/src/styled_text.rs
@@ -1,4 +1,4 @@
-use nu_ansi_term::Style;
+use nu_ansi_term::{Color, Style};
 
 /// A representation of a buffer with styling, used for doing syntax highlighting
 pub struct StyledText {
@@ -27,24 +27,28 @@ impl StyledText {
     /// place to put the cursor. This assumes a logic that prints the first part of the
     /// string, saves the cursor position, prints the second half, and then restores
     /// the cursor position
-    pub fn render_around_insertion_point(&self, insertion_point: usize) -> (String, String) {
+    pub fn render_around_insertion_point(
+        &self,
+        insertion_point: usize,
+        // prompt_style: &Style,
+    ) -> (String, String) {
         let mut current_idx = 0;
         let mut left_string = String::new();
         let mut right_string = String::new();
-
+        let prompt_style = Style::new().fg(Color::LightBlue);
         for pair in &self.buffer {
             if current_idx >= insertion_point {
-                right_string.push_str(&render_as_string(pair));
+                right_string.push_str(&render_as_string(pair, &prompt_style));
             } else if pair.1.len() + current_idx <= insertion_point {
-                left_string.push_str(&render_as_string(pair));
+                left_string.push_str(&render_as_string(pair, &prompt_style));
             } else if pair.1.len() + current_idx > insertion_point {
                 let offset = insertion_point - current_idx;
 
                 let left_side = pair.1[..offset].to_string();
                 let right_side = pair.1[offset..].to_string();
 
-                left_string.push_str(&render_as_string(&(pair.0, left_side)));
-                right_string.push_str(&render_as_string(&(pair.0, right_side)));
+                left_string.push_str(&render_as_string(&(pair.0, left_side), &prompt_style));
+                right_string.push_str(&render_as_string(&(pair.0, right_side), &prompt_style));
             }
             current_idx += pair.1.len();
         }
@@ -53,11 +57,11 @@ impl StyledText {
     }
 }
 
-fn render_as_string(renderable: &(Style, String)) -> String {
+fn render_as_string(renderable: &(Style, String), prompt_style: &Style) -> String {
     let mut rendered = String::new();
     for (line_number, line) in renderable.1.split('\n').enumerate() {
         if line_number != 0 {
-            rendered.push_str("\n: ");
+            rendered.push_str(&prompt_style.paint("\n: ").to_string());
         }
         rendered.push_str(&renderable.0.paint(line).to_string());
     }

--- a/src/styled_text.rs
+++ b/src/styled_text.rs
@@ -34,21 +34,32 @@ impl StyledText {
 
         for pair in &self.buffer {
             if current_idx >= insertion_point {
-                right_string.push_str(&pair.0.paint(&pair.1).to_string());
+                right_string.push_str(&render_as_string(pair));
             } else if pair.1.len() + current_idx <= insertion_point {
-                left_string.push_str(&pair.0.paint(&pair.1).to_string());
+                left_string.push_str(&render_as_string(pair));
             } else if pair.1.len() + current_idx > insertion_point {
                 let offset = insertion_point - current_idx;
 
                 let left_side = pair.1[..offset].to_string();
                 let right_side = pair.1[offset..].to_string();
 
-                left_string.push_str(&pair.0.paint(&left_side).to_string());
-                right_string.push_str(&pair.0.paint(&right_side).to_string());
+                left_string.push_str(&render_as_string(&(pair.0, left_side)));
+                right_string.push_str(&render_as_string(&(pair.0, right_side)));
             }
             current_idx += pair.1.len();
         }
 
         (left_string, right_string)
     }
+}
+
+fn render_as_string(renderable: &(Style, String)) -> String {
+    let mut rendered = String::new();
+    for (line_number, line) in renderable.1.split('\n').enumerate() {
+        if line_number != 0 {
+            rendered.push_str("\n: ");
+        }
+        rendered.push_str(&renderable.0.paint(line).to_string());
+    }
+    rendered
 }


### PR DESCRIPTION
As requested [here](https://github.com/nushell/reedline/pull/184#issuecomment-977800119) and as a direct follow-up to #184, I tried to "forward" a Prompt parameter to the rendering functions, so that the `render_prompt_multiline_indicator` was available.

I am not sure about how I used `Cow<str>, or that,  from a design standpoint, passing in the multiline prompt is the best idea. I am available to implement any variation, in order to make it better, of course!