### PR TITLE
Minimal fix for poll busy loop

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -356,7 +356,7 @@ impl Reedline {
         let mut reedline_events: Vec<ReedlineEvent> = vec![];
 
         loop {
-            if event::poll(Duration::from_millis(self.repaint.unwrap_or(0)))? {
+            if event::poll(Duration::from_millis(self.repaint.unwrap_or(1000)))? {
                 let mut latest_resize = None;
 
                 // There could be multiple events queued up!


### PR DESCRIPTION
Alternative to #188 which would not break API

Addresses nushell/engine-q#386

When disabling the clock animation by not wanting to repaint give poll a
1 sec timeout instead of immediately polling again. Option with time is
still used, using small millisecond timeouts can still turn it into a
busy loop.
Would not necessistate a change on the engine-q side and allow for
playing around with this timeout for debugging but might not be the most
useful feature for general use
