### PR TITLE
Improve undo of EditCommands

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -102,7 +102,7 @@ impl EditCommand {
             | EditCommand::MoveLeft
             | EditCommand::MoveRight
             | EditCommand::MoveWordLeft
-            | EditCommand::MoveWordRight => UndoBehavior::Ignore,
+            | EditCommand::MoveWordRight => UndoBehavior::Full,
 
             // Coalesceable insert
             EditCommand::InsertChar(_) => UndoBehavior::Coalesce,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -91,6 +91,58 @@ pub enum EditCommand {
     Redo,
 }
 
+impl EditCommand {
+    /// Determine if a certain operation should be undoable
+    /// or if the operations should be coalesced for undoing
+    pub fn undo_behavior(&self) -> UndoBehavior {
+        match self {
+            // Cursor moves
+            EditCommand::MoveToStart
+            | EditCommand::MoveToEnd
+            | EditCommand::MoveLeft
+            | EditCommand::MoveRight
+            | EditCommand::MoveWordLeft
+            | EditCommand::MoveWordRight => UndoBehavior::Ignore,
+
+            // Coalesceable insert
+            EditCommand::InsertChar(_) => UndoBehavior::Coalesce,
+
+            // Full edits
+            EditCommand::Backspace
+            | EditCommand::Delete
+            | EditCommand::BackspaceWord
+            | EditCommand::DeleteWord
+            | EditCommand::Clear
+            | EditCommand::CutFromStart
+            | EditCommand::CutToEnd
+            | EditCommand::CutWordLeft
+            | EditCommand::CutWordRight
+            | EditCommand::PasteCutBuffer
+            | EditCommand::UppercaseWord
+            | EditCommand::LowercaseWord
+            | EditCommand::CapitalizeChar
+            | EditCommand::SwapWords
+            | EditCommand::SwapGraphemes => UndoBehavior::Full,
+
+            EditCommand::Undo | EditCommand::Redo => UndoBehavior::Ignore,
+        }
+    }
+}
+
+/// Specifies how the (previously executed) operation should be treated in the Undo stack.
+pub enum UndoBehavior {
+    /// Operation is not affecting the LineBuffers content and should be ignored
+    ///
+    /// e.g. the undo commands themselves are not stored in the undo stack
+    Ignore,
+    /// The operation is one logical unit of work that should be stored in the undo stack
+    Full,
+    /// The operation is a single operation that should be best coalesced in logical units such as words
+    ///
+    /// e.g. insertion of characters by typing
+    Coalesce,
+}
+
 /// Reedline supported actions.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum ReedlineEvent {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ pub use core_editor::LineBuffer;
 mod text_manipulation;
 
 mod enums;
-pub use enums::{EditCommand, ReedlineEvent, Signal};
+pub use enums::{EditCommand, ReedlineEvent, Signal, UndoBehavior};
 
 mod painter;
 


### PR DESCRIPTION
Address #190

Formalize the undo role of different edit commands via exhaustive
matching

Open questions:

- Undo behavior of pure moves #193 
    * Do we want to make them undoable
    * Do we have to register them for accurate undos of true edits
- Manual backspace and delete #194 
    * Do we want to coalesce them if a whole word is manually deleted?
