### PR TITLE
Fix clippy style and remove unecessary stuff

### DIFF
--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -13,6 +13,9 @@ pub struct Span {
 impl Span {
     /// Creates a new `Span` from start and end inputs.
     /// The end parameter must be greater than or equal to the start parameter.
+    ///
+    /// # Panics
+    /// If `end < start`
     pub fn new(start: usize, end: usize) -> Span {
         assert!(
             end >= start,

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -33,19 +33,19 @@ impl Editor {
     }
 
     pub fn move_to_start(&mut self) {
-        self.line_buffer.move_to_start()
+        self.line_buffer.move_to_start();
     }
 
     pub fn move_to_end(&mut self) {
-        self.line_buffer.move_to_end()
+        self.line_buffer.move_to_end();
     }
 
     pub fn move_left(&mut self) {
-        self.line_buffer.move_left()
+        self.line_buffer.move_left();
     }
 
     pub fn move_right(&mut self) {
-        self.line_buffer.move_right()
+        self.line_buffer.move_right();
     }
 
     pub fn move_word_left(&mut self) {
@@ -65,7 +65,7 @@ impl Editor {
     }
 
     pub fn insert_char(&mut self, c: char) {
-        self.line_buffer.insert_char(c)
+        self.line_buffer.insert_char(c);
     }
 
     pub fn backspace(&mut self) {
@@ -109,7 +109,7 @@ impl Editor {
     }
 
     pub fn set_insertion_point(&mut self, pos: usize) {
-        self.line_buffer.set_insertion_point(pos)
+        self.line_buffer.set_insertion_point(pos);
     }
 
     pub fn get_buffer(&self) -> &str {
@@ -117,22 +117,22 @@ impl Editor {
     }
 
     pub fn set_buffer(&mut self, buffer: String) {
-        self.line_buffer.set_buffer(buffer)
+        self.line_buffer.set_buffer(buffer);
     }
 
     pub fn clear_to_end(&mut self) {
-        self.line_buffer.clear_to_end()
+        self.line_buffer.clear_to_end();
     }
 
     pub fn clear_to_insertion_point(&mut self) {
-        self.line_buffer.clear_to_insertion_point()
+        self.line_buffer.clear_to_insertion_point();
     }
 
     pub fn clear_range<R>(&mut self, range: R)
     where
         R: std::ops::RangeBounds<usize>,
     {
-        self.line_buffer.clear_range(range)
+        self.line_buffer.clear_range(range);
     }
 
     pub fn offset(&self) -> usize {

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -306,7 +306,7 @@ impl LineBuffer {
         let insertion_offset = self.insertion_point().offset;
         if left_index < insertion_offset {
             self.clear_range(left_index..insertion_offset);
-            self.insertion_point.offset = left_index
+            self.insertion_point.offset = left_index;
         }
     }
 
@@ -353,9 +353,9 @@ impl LineBuffer {
         let initial_offset = self.insertion_point().offset;
 
         if initial_offset == 0 {
-            self.move_right()
+            self.move_right();
         } else if initial_offset == self.get_buffer().len() {
-            self.move_left()
+            self.move_left();
         }
 
         let updated_offset = self.insertion_point().offset;
@@ -399,7 +399,7 @@ impl LineBuffer {
         self.set_insertion_point(position);
 
         // Move right from this position to the column we were at
-        while &buffer[position..(position + 1)] != "\n" && num_of_move_lefts > 0 {
+        while &buffer[position..=position] != "\n" && num_of_move_lefts > 0 {
             self.move_right();
             position = self.offset();
             num_of_move_lefts -= 1;
@@ -436,7 +436,7 @@ impl LineBuffer {
 
         // Move right from this position to the column we were at
         while position < buffer.len()
-            && &buffer[position..(position + 1)] != "\n"
+            && &buffer[position..=position] != "\n"
             && num_of_move_lefts > 0
         {
             self.move_right();

--- a/src/edit_mode/base.rs
+++ b/src/edit_mode/base.rs
@@ -7,7 +7,7 @@ use crate::{enums::ReedlineEvent, PromptEditMode};
 /// - Emacs
 /// - Vi
 pub trait EditMode {
-    /// Translate the given user input event into what the LineEditor understands
+    /// Translate the given user input event into what the `LineEditor` understands
     fn parse_event(&mut self, event: Event) -> ReedlineEvent;
 
     /// What to display in the prompt indicator

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -7,9 +7,9 @@ pub static DEFAULT_BUFFER_NEUTRAL_COLOR: Color = Color::White;
 pub static DEFAULT_BUFFER_NOTMATCH_COLOR: Color = Color::Red;
 
 /// The syntax highlighting trait. Implementers of this trait will take in the current string and then
-/// return a StyledText object, which represents the contents of the original line as styled strings
+/// return a `StyledText` object, which represents the contents of the original line as styled strings
 pub trait Highlighter {
-    /// The action that will handle the current buffer as a line and return the corresponding StyleText for the buffer
+    /// The action that will handle the current buffer as a line and return the corresponding `StyledText` for the buffer
     fn highlight(&self, line: &str) -> StyledText;
 }
 

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -59,7 +59,7 @@ impl History for FileBackedHistory {
             }
             self.entries.push_back(entry);
         }
-        self.reset_cursor()
+        self.reset_cursor();
     }
 
     fn iter_chronologic(&self) -> Iter<'_, String> {
@@ -74,10 +74,10 @@ impl History for FileBackedHistory {
                 }
             }
             HistoryNavigationQuery::PrefixSearch(prefix) => {
-                self.back_with_criteria(&|entry| entry.starts_with(&prefix))
+                self.back_with_criteria(&|entry| entry.starts_with(&prefix));
             }
             HistoryNavigationQuery::SubstringSearch(substring) => {
-                self.back_with_criteria(&|entry| entry.contains(&substring))
+                self.back_with_criteria(&|entry| entry.contains(&substring));
             }
         }
     }
@@ -90,10 +90,10 @@ impl History for FileBackedHistory {
                 }
             }
             HistoryNavigationQuery::PrefixSearch(prefix) => {
-                self.forward_with_criteria(&|entry| entry.starts_with(&prefix))
+                self.forward_with_criteria(&|entry| entry.starts_with(&prefix));
             }
             HistoryNavigationQuery::SubstringSearch(substring) => {
-                self.forward_with_criteria(&|entry| entry.contains(&substring))
+                self.forward_with_criteria(&|entry| entry.contains(&substring));
             }
         }
     }
@@ -114,6 +114,10 @@ impl History for FileBackedHistory {
 
 impl FileBackedHistory {
     /// Creates a new in-memory history that remembers `n <= capacity` elements
+    ///
+    /// # Panics
+    ///
+    /// If `capacity == usize::MAX`
     pub fn new(capacity: usize) -> Self {
         if capacity == usize::MAX {
             panic!("History capacity too large to be addressed safely");
@@ -199,7 +203,7 @@ impl FileBackedHistory {
                 .find(|(_, entry)| criteria(entry) && previous_match != Some(entry))
             {
                 // set to entry
-                self.cursor = next_cursor
+                self.cursor = next_cursor;
             }
         }
     }
@@ -214,9 +218,9 @@ impl FileBackedHistory {
             .find(|(_, entry)| criteria(entry) && previous_match != Some(entry))
         {
             // set to entry
-            self.cursor = next_cursor
+            self.cursor = next_cursor;
         } else {
-            self.reset_cursor()
+            self.reset_cursor();
         }
     }
 
@@ -262,7 +266,7 @@ impl FileBackedHistory {
 impl Drop for FileBackedHistory {
     /// On drop the content of the [`History`] will be written to the file if specified via [`FileBackedHistory::with_file()`].
     fn drop(&mut self) {
-        let _ = self.flush();
+        let _res = self.flush();
     }
 }
 

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -98,14 +98,15 @@ impl Prompt for DefaultPrompt {
 
     fn render_prompt_indicator(&self, edit_mode: PromptEditMode) -> Cow<str> {
         match edit_mode {
-            PromptEditMode::Default => DEFAULT_PROMPT_INDICATOR.into(),
-            PromptEditMode::Emacs => DEFAULT_PROMPT_INDICATOR.into(),
+            PromptEditMode::Default | PromptEditMode::Emacs => DEFAULT_PROMPT_INDICATOR.into(),
             PromptEditMode::Vi(vi_mode) => match vi_mode {
                 PromptViMode::Normal => DEFAULT_PROMPT_INDICATOR.into(),
                 PromptViMode::Insert => DEFAULT_VI_INSERT_PROMPT_INDICATOR.into(),
                 PromptViMode::Visual => DEFAULT_VI_VISUAL_PROMPT_INDICATOR.into(),
             },
-            PromptEditMode::Custom(str) => self.default_wrapped_custom_string(str).into(),
+            PromptEditMode::Custom(str) => {
+                DefaultPrompt::default_wrapped_custom_string(&str).into()
+            }
         }
     }
 
@@ -178,7 +179,7 @@ impl DefaultPrompt {
         Cow::Owned(prompt_str)
     }
 
-    fn default_wrapped_custom_string(&self, str: String) -> String {
+    fn default_wrapped_custom_string(str: &str) -> String {
         format!("({})", str)
     }
 }

--- a/src/styled_text.rs
+++ b/src/styled_text.rs
@@ -1,5 +1,3 @@
-use std::borrow::{Borrow, Cow};
-
 use nu_ansi_term::{Color, Style};
 
 /// A representation of a buffer with styling, used for doing syntax highlighting
@@ -14,7 +12,7 @@ impl Default for StyledText {
 }
 
 impl StyledText {
-    /// Construct a new StyledText
+    /// Construct a new `StyledText`
     pub fn new() -> Self {
         Self { buffer: vec![] }
     }
@@ -32,7 +30,7 @@ impl StyledText {
     pub fn render_around_insertion_point(
         &self,
         insertion_point: usize,
-        multiline_prompt: Cow<str>,
+        multiline_prompt: &str,
     ) -> (String, String) {
         let mut current_idx = 0;
         let mut left_string = String::new();
@@ -40,17 +38,9 @@ impl StyledText {
         let prompt_style = Style::new().fg(Color::LightBlue);
         for pair in &self.buffer {
             if current_idx >= insertion_point {
-                right_string.push_str(&render_as_string(
-                    pair,
-                    &prompt_style,
-                    multiline_prompt.borrow(),
-                ));
+                right_string.push_str(&render_as_string(pair, &prompt_style, multiline_prompt));
             } else if pair.1.len() + current_idx <= insertion_point {
-                left_string.push_str(&render_as_string(
-                    pair,
-                    &prompt_style,
-                    multiline_prompt.borrow(),
-                ));
+                left_string.push_str(&render_as_string(pair, &prompt_style, multiline_prompt));
             } else if pair.1.len() + current_idx > insertion_point {
                 let offset = insertion_point - current_idx;
 
@@ -60,12 +50,12 @@ impl StyledText {
                 left_string.push_str(&render_as_string(
                     &(pair.0, left_side),
                     &prompt_style,
-                    multiline_prompt.borrow(),
+                    multiline_prompt,
                 ));
                 right_string.push_str(&render_as_string(
                     &(pair.0, right_side),
                     &prompt_style,
-                    multiline_prompt.borrow(),
+                    multiline_prompt,
                 ));
             }
             current_idx += pair.1.len();

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -32,11 +32,11 @@ fn incomplete_brackets(line: &str) -> bool {
 
     for c in line.chars() {
         if c == '{' {
-            balance.push('}')
+            balance.push('}');
         } else if c == '[' {
-            balance.push(']')
+            balance.push(']');
         } else if c == '(' {
-            balance.push(')')
+            balance.push(')');
         } else if ['}', ']', ')'].contains(&c) {
             if let Some(last) = balance.last() {
                 if last == &c {


### PR DESCRIPTION
- remove unused members, found after 1.57
- semicolon termination in void blocks
- other clippy pedantic prompted fixes
