### PR TITLE
Remove additional line on line clear via Ctrl-C

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -93,8 +93,7 @@ fn main() -> Result<()> {
                 line_editor.print_line(&format!("Our buffer: {}", buffer))?;
             }
             Ok(Signal::CtrlC) => {
-                // We need to move one line down to start with the prompt on a new line
-                line_editor.print_crlf()?;
+                // Prompt has been cleared and should start on the next line
             }
             Ok(Signal::CtrlL) => {
                 line_editor.clear_screen()?;


### PR DESCRIPTION
Only affects behavior of demo app

Additional line was a crutch introduced to counteract misbehavior fixed
in #77

Similar behavior was already sneaked into engine-q with https://github.com/nushell/engine-q/pull/508
