### PR TITLE
Disable raw mode with `Drop` for panics

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -108,6 +108,14 @@ pub struct Reedline {
     use_ansi_coloring: bool,
 }
 
+impl Drop for Reedline {
+    fn drop(&mut self) {
+        // Ensures that the terminal is in a good state if we panic semigracefully
+        // Calling `disable_raw_mode()` twice is fine with Linux
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
 impl Reedline {
     /// Create a new [`Reedline`] engine with a local [`History`] that is not synchronized to a file.
     pub fn create() -> io::Result<Reedline> {


### PR DESCRIPTION
Panicking inside reedline (or bubbling up an Err inside reedline's
critical sections that gets unwrapped/expected by the hosting
application) leaves the terminal in a bad state. Workaround that should
also work without cooperation by the consumer would be to include a call
to `disable_raw_mode` in the `Drop` trait. With standard stack-unwinding
panics will call the drop.

Calling `crossterm::terminal::disable_raw_mode` twice seems to be fine
if the program started in non-raw mode (under linux)


@jntrnr or @fdncred could you check if running the demo does not cause a problem due to disabling the raw mode twice
