### PR TITLE
Apply history on tab

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -39,6 +39,9 @@ pub enum EditCommand {
     /// Insert a character at the current insertion point
     InsertChar(char),
 
+    /// Insert a string at the current insertion point
+    InsertString(String),
+
     /// Backspace delete from the current insertion point
     Backspace,
 
@@ -106,6 +109,7 @@ impl EditCommand {
 
             // Coalesceable insert
             EditCommand::InsertChar(_) => UndoBehavior::Coalesce,
+            EditCommand::InsertString(_) => UndoBehavior::Coalesce,
 
             // Full edits
             EditCommand::Backspace

--- a/src/hinter.rs
+++ b/src/hinter.rs
@@ -14,6 +14,9 @@ pub trait Hinter {
         history: &dyn History,
         use_ansi_coloring: bool,
     ) -> String;
+
+    /// Return the current hint being shown to the user
+    fn current_hint(&self) -> String;
 }
 
 /// A default example hinter that use the completions or the history to show a hint to the user
@@ -22,6 +25,7 @@ pub struct DefaultHinter {
     history: bool,
     style: Style,
     inside_line: bool,
+    current_hint: String,
 }
 
 impl Hinter for DefaultHinter {
@@ -48,8 +52,14 @@ impl Hinter for DefaultHinter {
                 let span = completions[0].0;
                 hint.replace_range(0..(span.end - span.start), "");
 
+                self.current_hint = hint.clone();
+
                 output = self.style.paint(hint).to_string();
+            } else {
+                self.current_hint = String::new();
             }
+        } else {
+            self.current_hint = String::new();
         }
 
         if use_ansi_coloring {
@@ -60,6 +70,10 @@ impl Hinter for DefaultHinter {
             output
         }
     }
+
+    fn current_hint(&self) -> String {
+        self.current_hint.clone()
+    }
 }
 
 impl Default for DefaultHinter {
@@ -69,6 +83,7 @@ impl Default for DefaultHinter {
             history: false,
             style: Style::new().fg(Color::LightGray),
             inside_line: false,
+            current_hint: String::new(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,13 +59,14 @@ fn main() -> Result<()> {
         .with_edit_mode(edit_mode)
         .with_highlighter(Box::new(DefaultHighlighter::new(commands)))
         .with_completion_action_handler(Box::new(
-            ListCompletionHandler::default().with_completer(completer.clone()),
+            ListCompletionHandler::default().with_completer(completer),
         ))
         .with_hinter(Box::new(
             DefaultHinter::default()
-                .with_completer(completer) // or .with_history()
+                .with_history()
+                // .with_completer(completer) // or .with_history()
                 // .with_inside_line()
-                .with_style(Style::new().italic().fg(Color::LightGray)),
+                .with_style(Style::new().fg(Color::DarkGray)),
         ))
         .with_ansi_colors(true);
 


### PR DESCRIPTION
This lets you hit the tab key and accept the current history hint. If there is no hint, you'll get the normal completions.