### PR TITLE
defining paste event

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -206,4 +206,7 @@ pub enum ReedlineEvent {
 
     /// Search the history for a string
     SearchHistory,
+
+    /// Paste event
+    Paste(Vec<ReedlineEvent>),
 }


### PR DESCRIPTION
A paste event is defined which allows to copy and paste into a prompt faster