### PR TITLE
Improve history internals

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -610,7 +610,7 @@ impl Reedline {
                 // Make sure we are able to undo the result of a reverse history search
                 self.editor.remember_undo_state(true);
 
-                self.search_history();
+                self.enter_history_search();
                 self.repaint(prompt)?;
                 Ok(None)
             }
@@ -651,7 +651,7 @@ impl Reedline {
     }
 
     fn append_to_history(&mut self) {
-        self.history.append(self.editor.get_buffer().to_string());
+        self.history.append(self.editor.get_buffer());
     }
 
     fn previous_history(&mut self) {
@@ -699,7 +699,7 @@ impl Reedline {
     /// Switch into reverse history search mode
     ///
     /// This mode uses a separate prompt and handles keybindings sligthly differently!
-    fn search_history(&mut self) {
+    fn enter_history_search(&mut self) {
         self.input_mode = InputMode::HistorySearch;
         self.history
             .set_navigation(HistoryNavigationQuery::SubstringSearch("".to_string()));

--- a/src/hinter.rs
+++ b/src/hinter.rs
@@ -54,7 +54,7 @@ impl Hinter for DefaultHinter {
                 let span = completions[0].0;
                 hint.replace_range(0..(span.end - span.start), "");
 
-                let hint = hint.replace("<\\n>", "\r\n");
+                let hint = hint.replace("\n", "\r\n");
 
                 self.current_hint = hint.clone();
 

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -18,7 +18,7 @@ pub enum HistoryNavigationQuery {
 /// Interface of a history datastructure that supports stateful navigation via [`HistoryNavigationQuery`].
 pub trait History {
     /// Append entry to the history, if capacity management is part of the implementation may perform that as well
-    fn append(&mut self, entry: String);
+    fn append(&mut self, entry: &str);
 
     /// Chronologic interation over all entries present in the history
     fn iter_chronologic(&self) -> Iter<'_, String>;

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -51,12 +51,12 @@ impl History for FileBackedHistory {
     /// Appends an entry if non-empty and not repetition of the previous entry.
     /// Resets the browsing cursor to the default state in front of the most recent entry.
     ///
-    fn append(&mut self, entry: String) {
+    fn append(&mut self, entry: &str) {
         // Don't append if the preceding value is identical or the string empty
         if self
             .entries
             .back()
-            .map_or(true, |previous| previous != &entry)
+            .map_or(true, |previous| previous != entry)
             && !entry.is_empty()
         {
             if self.entries.len() == self.capacity {
@@ -66,7 +66,7 @@ impl History for FileBackedHistory {
                 self.len_on_disk = self.len_on_disk.saturating_sub(1);
                 self.truncate_file = true;
             }
-            self.entries.push_back(entry);
+            self.entries.push_back(entry.to_string());
         }
         self.reset_cursor();
     }
@@ -312,8 +312,8 @@ mod tests {
     #[test]
     fn going_backwards_bottoms_out() {
         let mut hist = FileBackedHistory::default();
-        hist.append("command1".to_string());
-        hist.append("command2".to_string());
+        hist.append("command1");
+        hist.append("command2");
         hist.back();
         hist.back();
         hist.back();
@@ -325,8 +325,8 @@ mod tests {
     #[test]
     fn going_forwards_bottoms_out() {
         let mut hist = FileBackedHistory::default();
-        hist.append("command1".to_string());
-        hist.append("command2".to_string());
+        hist.append("command1");
+        hist.append("command2");
         hist.forward();
         hist.forward();
         hist.forward();
@@ -338,25 +338,25 @@ mod tests {
     #[test]
     fn appends_only_unique() {
         let mut hist = FileBackedHistory::default();
-        hist.append("unique_old".to_string());
-        hist.append("test".to_string());
-        hist.append("test".to_string());
-        hist.append("unique".to_string());
+        hist.append("unique_old");
+        hist.append("test");
+        hist.append("test");
+        hist.append("unique");
         assert_eq!(hist.entries.len(), 3);
     }
     #[test]
     fn appends_no_empties() {
         let mut hist = FileBackedHistory::default();
-        hist.append("".to_string());
+        hist.append("");
         assert_eq!(hist.entries.len(), 0);
     }
 
     #[test]
     fn prefix_search_works() {
         let mut hist = FileBackedHistory::default();
-        hist.append(String::from("find me as well"));
-        hist.append(String::from("test"));
-        hist.append(String::from("find me"));
+        hist.append("find me as well");
+        hist.append("test");
+        hist.append("find me");
 
         hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
 
@@ -369,9 +369,9 @@ mod tests {
     #[test]
     fn prefix_search_bottoms_out() {
         let mut hist = FileBackedHistory::default();
-        hist.append(String::from("find me as well"));
-        hist.append(String::from("test"));
-        hist.append(String::from("find me"));
+        hist.append("find me as well");
+        hist.append("test");
+        hist.append("find me");
 
         hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
         hist.back();
@@ -387,9 +387,9 @@ mod tests {
     #[test]
     fn prefix_search_returns_to_none() {
         let mut hist = FileBackedHistory::default();
-        hist.append(String::from("find me as well"));
-        hist.append(String::from("test"));
-        hist.append(String::from("find me"));
+        hist.append("find me as well");
+        hist.append("test");
+        hist.append("find me");
 
         hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
         hist.back();
@@ -407,10 +407,10 @@ mod tests {
     #[test]
     fn prefix_search_ignores_consecutive_equivalent_entries_going_backwards() {
         let mut hist = FileBackedHistory::default();
-        hist.append(String::from("find me as well"));
-        hist.append(String::from("find me once"));
-        hist.append(String::from("test"));
-        hist.append(String::from("find me once"));
+        hist.append("find me as well");
+        hist.append("find me once");
+        hist.append("test");
+        hist.append("find me once");
 
         hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
         hist.back();
@@ -422,10 +422,10 @@ mod tests {
     #[test]
     fn prefix_search_ignores_consecutive_equivalent_entries_going_forwards() {
         let mut hist = FileBackedHistory::default();
-        hist.append(String::from("find me once"));
-        hist.append(String::from("test"));
-        hist.append(String::from("find me once"));
-        hist.append(String::from("find me as well"));
+        hist.append("find me once");
+        hist.append("test");
+        hist.append("find me once");
+        hist.append("find me as well");
 
         hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
         hist.back();
@@ -440,11 +440,11 @@ mod tests {
     #[test]
     fn substring_search_works() {
         let mut hist = FileBackedHistory::default();
-        hist.append(String::from("substring"));
-        hist.append(String::from("don't find me either"));
-        hist.append(String::from("prefix substring"));
-        hist.append(String::from("don't find me"));
-        hist.append(String::from("prefix substring suffix"));
+        hist.append("substring");
+        hist.append("don't find me either");
+        hist.append("prefix substring");
+        hist.append("don't find me");
+        hist.append("prefix substring suffix");
 
         hist.set_navigation(HistoryNavigationQuery::SubstringSearch(
             "substring".to_string(),
@@ -466,7 +466,7 @@ mod tests {
     #[test]
     fn substring_search_with_empty_value_returns_none() {
         let mut hist = FileBackedHistory::default();
-        hist.append(String::from("substring"));
+        hist.append("substring");
 
         hist.set_navigation(HistoryNavigationQuery::SubstringSearch("".to_string()));
 
@@ -487,7 +487,7 @@ mod tests {
         {
             let mut hist = FileBackedHistory::with_file(5, histfile.clone()).unwrap();
 
-            entries.iter().for_each(|e| hist.append(e.to_string()));
+            entries.iter().for_each(|e| hist.append(e));
 
             // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
         }


### PR DESCRIPTION
- Move history newline escape to the file IO

This avoids that the newline escape character can be found via search and thus mess upt the search results, also makes the API internally simpler

- Remove unnecessary optional history allocation

Very minor potential improvement
