### PR TITLE
vi insert mode default

### DIFF
--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -35,7 +35,7 @@ impl Default for Vi {
             insert_keybindings: default_vi_insert_keybindings(),
             normal_keybindings: default_vi_normal_keybindings(),
             cache: Vec::new(),
-            mode: Mode::Normal,
+            mode: Mode::Insert,
             previous: None,
         }
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -90,7 +90,7 @@ pub struct Reedline {
     // Highlight the edit buffer
     highlighter: Box<dyn Highlighter>,
 
-    // Showcase hints based on various stratiges (history, language-completion, spellcheck, etc)
+    // Showcase hints based on various strategies (history, language-completion, spellcheck, etc)
     hinter: Box<dyn Hinter>,
 
     // Is Some(n) read_line() should repaint prompt every `n` milliseconds


### PR DESCRIPTION
Making vi insert mode default when starting terminal