### PR TITLE
Make the editing operations aware of multiline

### DIFF
--- a/src/core_editor/mod.rs
+++ b/src/core_editor/mod.rs
@@ -2,6 +2,6 @@ mod clip_buffer;
 mod editor;
 mod line_buffer;
 
-pub use clip_buffer::{get_default_clipboard, Clipboard};
+pub(crate) use clip_buffer::{get_default_clipboard, Clipboard, ClipboardMode};
 pub use editor::Editor;
 pub use line_buffer::LineBuffer;

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -69,15 +69,21 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::CONTROL, KC::Right, edit_bind(EC::MoveWordRight));
     kb.add_binding(KM::CONTROL, KC::Delete, edit_bind(EC::DeleteWord));
     kb.add_binding(KM::CONTROL, KC::Backspace, edit_bind(EC::BackspaceWord));
+    kb.add_binding(KM::CONTROL, KC::End, edit_bind(EC::MoveToEnd));
+    kb.add_binding(KM::CONTROL, KC::Home, edit_bind(EC::MoveToStart));
     kb.add_binding(KM::CONTROL, KC::Char('d'), ReedlineEvent::CtrlD);
     kb.add_binding(KM::CONTROL, KC::Char('c'), ReedlineEvent::CtrlC);
     kb.add_binding(KM::CONTROL, KC::Char('g'), edit_bind(EC::Redo));
     kb.add_binding(KM::CONTROL, KC::Char('z'), edit_bind(EC::Undo));
-    kb.add_binding(KM::CONTROL, KC::Char('a'), edit_bind(EC::MoveToStart));
-    kb.add_binding(KM::CONTROL, KC::Char('e'), edit_bind(EC::MoveToEnd));
+    kb.add_binding(KM::CONTROL, KC::Char('a'), edit_bind(EC::MoveToLineStart));
+    kb.add_binding(KM::CONTROL, KC::Char('e'), edit_bind(EC::MoveToLineEnd));
     kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToEnd));
     kb.add_binding(KM::CONTROL, KC::Char('u'), edit_bind(EC::CutFromStart));
-    kb.add_binding(KM::CONTROL, KC::Char('y'), edit_bind(EC::PasteCutBuffer));
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Char('y'),
+        edit_bind(EC::PasteCutBufferBefore),
+    );
     kb.add_binding(KM::CONTROL, KC::Char('b'), edit_bind(EC::MoveLeft));
     kb.add_binding(KM::CONTROL, KC::Char('f'), edit_bind(EC::MoveRight));
     kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
@@ -97,10 +103,10 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::ALT, KC::Right, edit_bind(EC::MoveWordRight));
     kb.add_binding(KM::ALT, KC::Delete, edit_bind(EC::DeleteWord));
     kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));
-    kb.add_binding(KM::NONE, KC::Up, ReedlineEvent::Up);
-    kb.add_binding(KM::NONE, KC::End, edit_bind(EC::MoveToEnd));
+    kb.add_binding(KM::NONE, KC::End, edit_bind(EC::MoveToLineEnd));
+    kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToLineStart));
     kb.add_binding(KM::NONE, KC::Tab, ReedlineEvent::HandleTab);
-    kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToStart));
+    kb.add_binding(KM::NONE, KC::Up, ReedlineEvent::Up);
     kb.add_binding(KM::NONE, KC::Down, ReedlineEvent::Down);
     kb.add_binding(KM::NONE, KC::Left, edit_bind(EC::MoveLeft));
     kb.add_binding(KM::NONE, KC::Right, edit_bind(EC::MoveRight));
@@ -127,6 +133,8 @@ pub fn default_vi_insert_keybindings() -> Keybindings {
     keybindings.add_binding(KM::NONE, KC::Right, edit_bind(EC::MoveRight));
     keybindings.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::Backspace));
     keybindings.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
+    keybindings.add_binding(KM::NONE, KC::End, edit_bind(EC::MoveToLineEnd));
+    keybindings.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToLineStart));
 
     keybindings
 }

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -280,13 +280,13 @@ mod tests {
         ReedlineEvent::Edit(vec![EditCommand::MoveLeft]),
         ]))]
     #[case(&['h'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveLeft])]))]
-    #[case(&['0'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToStart])]))]
-    #[case(&['$'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToEnd])]))]
+    #[case(&['0'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineStart])]))]
+    #[case(&['$'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineEnd])]))]
     #[case(&['i'], ReedlineEvent::Multiple(vec![ReedlineEvent::Repaint]))]
-    #[case(&['p'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::PasteCutBuffer])]))]
+    #[case(&['p'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter])]))]
     #[case(&['2', 'p'], ReedlineEvent::Multiple(vec![
-        ReedlineEvent::Edit(vec![EditCommand::PasteCutBuffer]),
-        ReedlineEvent::Edit(vec![EditCommand::PasteCutBuffer])
+        ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter]),
+        ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter])
         ]))]
     #[case(&['u'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::Undo])]))]
     #[case(&['2', 'u'], ReedlineEvent::Multiple(vec![
@@ -294,8 +294,7 @@ mod tests {
         ReedlineEvent::Edit(vec![EditCommand::Undo])
         ]))]
     #[case(&['d', 'd'], ReedlineEvent::Multiple(vec![
-        ReedlineEvent::Edit(vec![EditCommand::MoveToStart]),
-        ReedlineEvent::Edit(vec![EditCommand::CutToEnd])]))]
+        ReedlineEvent::Edit(vec![EditCommand::CutCurrentLine])]))]
     #[case(&['d', 'w'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRight])]))]
     fn test_reedline_move(#[case] input: &[char], #[case] expected: ReedlineEvent) {
         let res = vi_parse(input);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -796,6 +796,8 @@ impl Reedline {
             match command {
                 EditCommand::MoveToStart => self.editor.move_to_start(),
                 EditCommand::MoveToEnd => self.editor.move_to_end(),
+                EditCommand::MoveToLineStart => self.editor.move_to_line_start(),
+                EditCommand::MoveToLineEnd => self.editor.move_to_line_end(),
                 EditCommand::MoveLeft => self.editor.move_left(),
                 EditCommand::MoveRight => self.editor.move_right(),
                 EditCommand::MoveWordLeft => self.editor.move_word_left(),
@@ -829,11 +831,14 @@ impl Reedline {
                 EditCommand::BackspaceWord => self.editor.backspace_word(),
                 EditCommand::DeleteWord => self.editor.delete_word(),
                 EditCommand::Clear => self.editor.clear(),
+                EditCommand::ClearToLineEnd => self.editor.clear_to_line_end(),
+                EditCommand::CutCurrentLine => self.editor.cut_current_line(),
                 EditCommand::CutFromStart => self.editor.cut_from_start(),
                 EditCommand::CutToEnd => self.editor.cut_from_end(),
                 EditCommand::CutWordLeft => self.editor.cut_word_left(),
                 EditCommand::CutWordRight => self.editor.cut_word_right(),
-                EditCommand::PasteCutBuffer => self.editor.insert_cut_buffer(),
+                EditCommand::PasteCutBufferBefore => self.editor.insert_cut_buffer_before(),
+                EditCommand::PasteCutBufferAfter => self.editor.insert_cut_buffer_after(),
                 EditCommand::UppercaseWord => self.editor.uppercase_word(),
                 EditCommand::LowercaseWord => self.editor.lowercase_word(),
                 EditCommand::CapitalizeChar => self.editor.capitalize_char(),
@@ -849,6 +854,8 @@ impl Reedline {
                 EditCommand::CutLeftBefore(c) => self.editor.cut_left_until_char(*c, true),
                 EditCommand::MoveLeftUntil(c) => self.editor.move_left_until_char(*c, false),
                 EditCommand::MoveLeftBefore(c) => self.editor.move_left_until_char(*c, true),
+                EditCommand::CutFromLineStart => self.editor.cut_from_line_start(),
+                EditCommand::CutToLineEnd => self.editor.cut_to_line_end(),
             }
 
             match command.undo_behavior() {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -21,8 +21,14 @@ pub enum EditCommand {
     /// Move to the start of the buffer
     MoveToStart,
 
+    /// Move to the start of the current line
+    MoveToLineStart,
+
     /// Move to the end of the buffer
     MoveToEnd,
+
+    /// Move to the end of the current line
+    MoveToLineEnd,
 
     /// Move one character to the left
     MoveLeft,
@@ -57,11 +63,23 @@ pub enum EditCommand {
     /// Clear the current buffer
     Clear,
 
+    /// Clear the current buffer
+    ClearToLineEnd,
+
+    /// Cut the current line
+    CutCurrentLine,
+
     /// Cut from the start of the buffer to the insertion point
     CutFromStart,
 
+    /// Cut from the start of the current line to the insertion point
+    CutFromLineStart,
+
     /// Cut from the insertion point to the end of the buffer
     CutToEnd,
+
+    /// Cut from the insertion point to the end of the current line
+    CutToLineEnd,
 
     /// Cut the word left of the insertion point
     CutWordLeft,
@@ -69,8 +87,11 @@ pub enum EditCommand {
     /// Cut the word right of the insertion point
     CutWordRight,
 
-    /// Paste the cut buffer at the insertion point
-    PasteCutBuffer,
+    /// Paste the cut buffer in front of the insertion point (Emacs, vi `P`)
+    PasteCutBufferBefore,
+
+    /// Paste the cut buffer in front of the insertion point (vi `p`)
+    PasteCutBufferAfter,
 
     /// Upper case the current word
     UppercaseWord,
@@ -126,6 +147,8 @@ impl EditCommand {
             // Cursor moves
             EditCommand::MoveToStart
             | EditCommand::MoveToEnd
+            | EditCommand::MoveToLineStart
+            | EditCommand::MoveToLineEnd
             | EditCommand::MoveLeft
             | EditCommand::MoveRight
             | EditCommand::MoveWordLeft
@@ -137,19 +160,24 @@ impl EditCommand {
 
             // Coalesceable insert
             EditCommand::InsertChar(_) => UndoBehavior::Coalesce,
-            EditCommand::InsertString(_) => UndoBehavior::Full,
 
             // Full edits
             EditCommand::Backspace
             | EditCommand::Delete
+            | EditCommand::InsertString(_)
             | EditCommand::BackspaceWord
             | EditCommand::DeleteWord
             | EditCommand::Clear
+            | EditCommand::ClearToLineEnd
+            | EditCommand::CutCurrentLine
             | EditCommand::CutFromStart
+            | EditCommand::CutFromLineStart
+            | EditCommand::CutToLineEnd
             | EditCommand::CutToEnd
             | EditCommand::CutWordLeft
             | EditCommand::CutWordRight
-            | EditCommand::PasteCutBuffer
+            | EditCommand::PasteCutBufferBefore
+            | EditCommand::PasteCutBufferAfter
             | EditCommand::UppercaseWord
             | EditCommand::LowercaseWord
             | EditCommand::CapitalizeChar


### PR DESCRIPTION
- Moves to start and beginning of the line
- Make start and end of buffer available for move via `Ctrl-Home` and
`Ctrl-End`
- Support vi style cutting of whole lines in the cut buffer.
- add vi style `p` after paste in addition to before cursor paste with
`P` or in emacs mode
- Enables vi style `dd` and paste
- Make sure the line to end cut and clear operations work only on the
line
