### PR TITLE
Improve correctness of move operations

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -348,24 +348,24 @@ impl Editor {
         }
     }
 
-    pub fn move_right_until_char(&mut self, c: char, before_char: bool) {
+    pub fn move_right_until_char(&mut self, c: char, before_char: bool, current_line: bool) {
         if before_char {
-            self.line_buffer.move_right_before(c);
+            self.line_buffer.move_right_before(c, current_line);
         } else {
-            self.line_buffer.move_right_until(c);
+            self.line_buffer.move_right_until(c, current_line);
         }
     }
 
-    pub fn move_left_until_char(&mut self, c: char, before_char: bool) {
+    pub fn move_left_until_char(&mut self, c: char, before_char: bool, current_line: bool) {
         if before_char {
-            self.line_buffer.move_left_before(c);
+            self.line_buffer.move_left_before(c, current_line);
         } else {
-            self.line_buffer.move_left_until(c);
+            self.line_buffer.move_left_until(c, current_line);
         }
     }
 
-    pub fn cut_right_until_char(&mut self, c: char, before_char: bool) {
-        if let Some(index) = self.line_buffer.find_char_right(c) {
+    pub fn cut_right_until_char(&mut self, c: char, before_char: bool, current_line: bool) {
+        if let Some(index) = self.line_buffer.find_char_right(c, current_line) {
             // Saving the section of the string that will be deleted to be
             // stored into the buffer
             let extra = if before_char { 0 } else { c.len_utf8() };
@@ -376,16 +376,16 @@ impl Editor {
                 self.cut_buffer.set(cut_slice, ClipboardMode::Normal);
 
                 if before_char {
-                    self.line_buffer.delete_right_before_char(c);
+                    self.line_buffer.delete_right_before_char(c, current_line);
                 } else {
-                    self.line_buffer.delete_right_until_char(c);
+                    self.line_buffer.delete_right_until_char(c, current_line);
                 }
             }
         }
     }
 
-    pub fn cut_left_until_char(&mut self, c: char, before_char: bool) {
-        if let Some(index) = self.line_buffer.find_char_left(c) {
+    pub fn cut_left_until_char(&mut self, c: char, before_char: bool, current_line: bool) {
+        if let Some(index) = self.line_buffer.find_char_left(c, current_line) {
             // Saving the section of the string that will be deleted to be
             // stored into the buffer
             let extra = if before_char { c.len_utf8() } else { 0 };
@@ -396,9 +396,9 @@ impl Editor {
                 self.cut_buffer.set(cut_slice, ClipboardMode::Normal);
 
                 if before_char {
-                    self.line_buffer.delete_left_before_char(c);
+                    self.line_buffer.delete_left_before_char(c, current_line);
                 } else {
-                    self.line_buffer.delete_left_until_char(c);
+                    self.line_buffer.delete_left_until_char(c, current_line);
                 }
             }
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -829,14 +829,18 @@ impl Reedline {
                 EditCommand::SwapGraphemes => self.editor.swap_graphemes(),
                 EditCommand::Undo => self.editor.undo(),
                 EditCommand::Redo => self.editor.redo(),
-                EditCommand::CutRightUntil(c) => self.editor.cut_right_until_char(*c, false),
-                EditCommand::CutRightBefore(c) => self.editor.cut_right_until_char(*c, true),
-                EditCommand::MoveRightUntil(c) => self.editor.move_right_until_char(*c, false),
-                EditCommand::MoveRightBefore(c) => self.editor.move_right_until_char(*c, true),
-                EditCommand::CutLeftUntil(c) => self.editor.cut_left_until_char(*c, false),
-                EditCommand::CutLeftBefore(c) => self.editor.cut_left_until_char(*c, true),
-                EditCommand::MoveLeftUntil(c) => self.editor.move_left_until_char(*c, false),
-                EditCommand::MoveLeftBefore(c) => self.editor.move_left_until_char(*c, true),
+                EditCommand::CutRightUntil(c) => self.editor.cut_right_until_char(*c, false, true),
+                EditCommand::CutRightBefore(c) => self.editor.cut_right_until_char(*c, true, true),
+                EditCommand::MoveRightUntil(c) => {
+                    self.editor.move_right_until_char(*c, false, true)
+                }
+                EditCommand::MoveRightBefore(c) => {
+                    self.editor.move_right_until_char(*c, true, true)
+                }
+                EditCommand::CutLeftUntil(c) => self.editor.cut_left_until_char(*c, false, true),
+                EditCommand::CutLeftBefore(c) => self.editor.cut_left_until_char(*c, true, true),
+                EditCommand::MoveLeftUntil(c) => self.editor.move_left_until_char(*c, false, true),
+                EditCommand::MoveLeftBefore(c) => self.editor.move_left_until_char(*c, true, true),
                 EditCommand::CutFromLineStart => self.editor.cut_from_line_start(),
                 EditCommand::CutToLineEnd => self.editor.cut_to_line_end(),
             }


### PR DESCRIPTION
- Made move up and move down unicode safe
- Added the option to constrict the char search (vi `f` `F` `t` `T`) to
the current line as usual in vi
- Improved test coverage
