### PR TITLE
Insert strings directly

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -76,6 +76,10 @@ impl Editor {
         self.line_buffer.insert_char(c);
     }
 
+    pub fn insert_str(&mut self, string: &str) {
+        self.line_buffer.insert_str(string);
+    }
+
     pub fn backspace(&mut self) {
         self.line_buffer.delete_left_grapheme();
     }
@@ -116,7 +120,11 @@ impl Editor {
         self.line_buffer.swap_graphemes();
     }
 
-    pub fn set_insertion_point(&mut self, pos: usize) {
+    /// Directly change the cursor position measured in bytes in the buffer
+    ///
+    /// ## Unicode safety:
+    /// Not checked, inproper use may cause panics in following operations
+    pub(crate) fn set_insertion_point(&mut self, pos: usize) {
         self.line_buffer.set_insertion_point(pos);
     }
 

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -247,13 +247,15 @@ impl LineBuffer {
         self.move_right();
     }
 
-    /// Insert `&str` at the `idx` position in the current line.
+    /// Insert `&str` at the cursor position in the current line.
     ///
-    /// Cursor is placed after the inserted string.
+    /// Sets cursor to end of inserted string
+    ///
+    /// ## Unicode safety:
+    /// Does not validate the incoming string or the current cursor position
     pub fn insert_str(&mut self, string: &str) {
-        let pos = self.insertion_point();
-        self.lines.insert_str(pos.offset, string);
-        self.insertion_point.offset = pos.offset + string.len();
+        self.lines.insert_str(self.offset(), string);
+        self.insertion_point.offset = self.offset() + string.len();
     }
 
     /// Empty buffer and reset cursor

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -792,16 +792,10 @@ impl Reedline {
                 EditCommand::MoveRight => self.editor.move_right(),
                 EditCommand::MoveWordLeft => self.editor.move_word_left(),
                 EditCommand::MoveWordRight => self.editor.move_word_right(),
-                // Performing mutation here might incur a perf hit down this line when
-                // we would like to do multiple inserts.
-                // A simple solution that we can do is to queue up these and perform the wrapping
-                // check after the loop finishes. Will need to sort out the details.
+
                 EditCommand::InsertChar(c) => self.editor.insert_char(*c),
-                EditCommand::InsertString(s) => {
-                    for c in s.chars() {
-                        self.editor.insert_char(c);
-                    }
-                }
+                EditCommand::InsertString(s) => self.editor.insert_str(s),
+
                 EditCommand::Backspace => self.editor.backspace(),
                 EditCommand::Delete => self.editor.delete(),
                 EditCommand::BackspaceWord => self.editor.backspace_word(),


### PR DESCRIPTION
There are latent concerns about unicode correctness, but as long as
crossterm/hints are providing correct chars/strs this is neither a security risk
(no unchecked/unsafe string ops on our side) nor
a DoS risk.
