### PR TITLE
Improve and highlight history search

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ let mut line_editor = Reedline::create()?
 ```rust,no_run
 // Create a reedline object with highlighter support
 
-use reedline::{DefaultHighlighter, Reedline};
+use reedline::{ExampleHighlighter, Reedline};
 
 let commands = vec![
   "test".into(),
@@ -96,7 +96,7 @@ let commands = vec![
   "this is the reedline crate".into(),
 ];
 let mut line_editor =
-Reedline::create()?.with_highlighter(Box::new(DefaultHighlighter::new(commands)));
+Reedline::create()?.with_highlighter(Box::new(ExampleHighlighter::new(commands)));
 ```
 
 ### Integrate with custom Tab-Handler

--- a/src/highlighter/example.rs
+++ b/src/highlighter/example.rs
@@ -1,27 +1,20 @@
-use nu_ansi_term::Style;
-
-use {crate::styled_text::StyledText, nu_ansi_term::Color};
+use crate::highlighter::Highlighter;
+use crate::StyledText;
+use nu_ansi_term::{Color, Style};
 
 pub static DEFAULT_BUFFER_MATCH_COLOR: Color = Color::Green;
 pub static DEFAULT_BUFFER_NEUTRAL_COLOR: Color = Color::White;
 pub static DEFAULT_BUFFER_NOTMATCH_COLOR: Color = Color::Red;
 
-/// The syntax highlighting trait. Implementers of this trait will take in the current string and then
-/// return a `StyledText` object, which represents the contents of the original line as styled strings
-pub trait Highlighter: Send {
-    /// The action that will handle the current buffer as a line and return the corresponding `StyledText` for the buffer
-    fn highlight(&self, line: &str) -> StyledText;
-}
-
 /// A simple, example highlighter that shows how to highlight keywords
-pub struct DefaultHighlighter {
+pub struct ExampleHighlighter {
     external_commands: Vec<String>,
     match_color: Color,
     notmatch_color: Color,
     neutral_color: Color,
 }
 
-impl Highlighter for DefaultHighlighter {
+impl Highlighter for ExampleHighlighter {
     fn highlight(&self, line: &str) -> StyledText {
         let mut styled_text = StyledText::new();
 
@@ -64,10 +57,10 @@ impl Highlighter for DefaultHighlighter {
         styled_text
     }
 }
-impl DefaultHighlighter {
+impl ExampleHighlighter {
     /// Construct the default highlighter with a given set of extern commands/keywords to detect and highlight
-    pub fn new(external_commands: Vec<String>) -> DefaultHighlighter {
-        DefaultHighlighter {
+    pub fn new(external_commands: Vec<String>) -> ExampleHighlighter {
+        ExampleHighlighter {
             external_commands,
             match_color: DEFAULT_BUFFER_MATCH_COLOR,
             notmatch_color: DEFAULT_BUFFER_NOTMATCH_COLOR,
@@ -87,8 +80,8 @@ impl DefaultHighlighter {
         self.neutral_color = neutral_color;
     }
 }
-impl Default for DefaultHighlighter {
+impl Default for ExampleHighlighter {
     fn default() -> Self {
-        DefaultHighlighter::new(vec![])
+        ExampleHighlighter::new(vec![])
     }
 }

--- a/src/highlighter/mod.rs
+++ b/src/highlighter/mod.rs
@@ -1,0 +1,13 @@
+mod example;
+mod simple_match;
+
+use crate::styled_text::StyledText;
+
+pub use example::ExampleHighlighter;
+pub use simple_match::SimpleMatchHighlighter;
+/// The syntax highlighting trait. Implementers of this trait will take in the current string and then
+/// return a `StyledText` object, which represents the contents of the original line as styled strings
+pub trait Highlighter: Send {
+    /// The action that will handle the current buffer as a line and return the corresponding `StyledText` for the buffer
+    fn highlight(&self, line: &str) -> StyledText;
+}

--- a/src/highlighter/simple_match.rs
+++ b/src/highlighter/simple_match.rs
@@ -1,0 +1,76 @@
+use crate::highlighter::Highlighter;
+use crate::StyledText;
+use nu_ansi_term::{Color, Style};
+
+/// Highlight all matches for a given search string in a line
+///
+/// Default style:
+///
+/// - non-matching text: Default style
+/// - matching text: Green foreground color
+pub struct SimpleMatchHighlighter {
+    neutral_style: Style,
+    match_style: Style,
+    query: String,
+}
+
+impl Default for SimpleMatchHighlighter {
+    fn default() -> Self {
+        Self {
+            neutral_style: Default::default(),
+            match_style: Style::new().fg(Color::Green),
+            query: Default::default(),
+        }
+    }
+}
+
+impl Highlighter for SimpleMatchHighlighter {
+    fn highlight(&self, line: &str) -> StyledText {
+        let mut styled_text = StyledText::new();
+        if self.query.is_empty() {
+            styled_text.push((self.neutral_style, line.to_owned()));
+        } else {
+            let mut next_idx: usize = 0;
+
+            for (idx, mat) in line.match_indices(&self.query) {
+                if idx != next_idx {
+                    styled_text.push((self.neutral_style, line[next_idx..idx].to_owned()));
+                }
+                styled_text.push((self.match_style, mat.to_owned()));
+                next_idx = idx + mat.len();
+            }
+            if next_idx != line.len() {
+                styled_text.push((self.neutral_style, line[next_idx..].to_owned()));
+            }
+        }
+        styled_text
+    }
+}
+
+impl SimpleMatchHighlighter {
+    /// Create a simple highlighter that styles every exact match of `query`.
+    pub fn new(query: String) -> Self {
+        Self {
+            query,
+            ..Self::default()
+        }
+    }
+
+    /// Update query string to match
+    pub fn with_query(mut self, query: String) -> Self {
+        self.query = query;
+        self
+    }
+
+    /// Set style for the matches found
+    pub fn with_match_style(mut self, match_style: Style) -> Self {
+        self.match_style = match_style;
+        self
+    }
+
+    /// Set style for the text that does not match the query
+    pub fn with_neutral_style(mut self, neutral_style: Style) -> Self {
+        self.neutral_style = neutral_style;
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@
 //! // Create a reedline object with highlighter support
 //!
 //! use std::io;
-//! use reedline::{DefaultHighlighter, Reedline};
+//! use reedline::{ExampleHighlighter, Reedline};
 //!
 //! let commands = vec![
 //!   "test".into(),
@@ -97,7 +97,7 @@
 //!   "this is the reedline crate".into(),
 //! ];
 //! let mut line_editor =
-//! Reedline::create()?.with_highlighter(Box::new(DefaultHighlighter::new(commands)));
+//! Reedline::create()?.with_highlighter(Box::new(ExampleHighlighter::new(commands)));
 //! # Ok::<(), io::Error>(())
 //! ```
 //!
@@ -212,7 +212,7 @@ mod edit_mode;
 pub use edit_mode::{default_emacs_keybindings, EditMode, Emacs, Vi};
 
 mod highlighter;
-pub use highlighter::{DefaultHighlighter, Highlighter};
+pub use highlighter::{ExampleHighlighter, Highlighter, SimpleMatchHighlighter};
 
 mod styled_text;
 pub use styled_text::StyledText;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use {
     },
     nu_ansi_term::{Color, Style},
     reedline::{
-        default_emacs_keybindings, DefaultCompleter, DefaultHighlighter, DefaultHinter,
-        DefaultPrompt, EditCommand, FileBackedHistory, Reedline, ReedlineEvent, Signal,
+        default_emacs_keybindings, DefaultCompleter, DefaultHinter, DefaultPrompt, EditCommand,
+        ExampleHighlighter, FileBackedHistory, Reedline, ReedlineEvent, Signal,
     },
     std::{
         io::{stdout, Write},
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
     let mut line_editor = Reedline::create()?
         .with_history(history)?
         .with_edit_mode(edit_mode)
-        .with_highlighter(Box::new(DefaultHighlighter::new(commands)))
+        .with_highlighter(Box::new(ExampleHighlighter::new(commands)))
         .with_completion_action_handler(Box::new(
             ListCompletionHandler::default().with_completer(completer),
         ))

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -1,5 +1,5 @@
 use crate::PromptHistorySearch;
-use crossterm::{cursor::MoveToRow, terminal::ScrollUp};
+use crossterm::{cursor::MoveToRow, style::ResetColor, terminal::ScrollUp};
 
 use {
     crate::{prompt::PromptEditMode, Prompt},
@@ -245,7 +245,11 @@ impl Painter {
             .queue(MoveToColumn(0))?
             .queue(Clear(ClearType::FromCursorDown))?
             .queue(Print(&prompt_str))?
-            .queue(Print(&prompt_indicator))?
+            .queue(Print(&prompt_indicator))?;
+        if use_ansi_coloring {
+            self.stdout.queue(ResetColor)?;
+        }
+        self.stdout
             .queue(Print(&lines.before_cursor))?
             .queue(SavePosition)?
             .queue(Print(&lines.hint))?
@@ -317,12 +321,6 @@ impl Painter {
             self.stdout.queue(Print("\n"))?;
         }
         self.stdout.queue(MoveTo(0, 0))?;
-
-        self.stdout.flush()
-    }
-
-    pub(crate) fn clear_until_newline(&mut self) -> Result<()> {
-        self.stdout.queue(Clear(ClearType::UntilNewLine))?;
 
         self.stdout.flush()
     }

--- a/src/styled_text.rs
+++ b/src/styled_text.rs
@@ -28,6 +28,8 @@ impl StyledText {
     /// place to put the cursor. This assumes a logic that prints the first part of the
     /// string, saves the cursor position, prints the second half, and then restores
     /// the cursor position
+    ///
+    /// Also inserts the multiline continuation prompt
     pub fn render_around_insertion_point(
         &self,
         insertion_point: usize,
@@ -68,6 +70,19 @@ impl StyledText {
         } else {
             (strip_ansi(&left_string), strip_ansi(&right_string))
         }
+    }
+
+    /// Apply the ANSI style formatting to the full string.
+    pub fn render_simple(&self) -> String {
+        self.buffer
+            .iter()
+            .map(|(style, text)| style.paint(text).to_string())
+            .collect()
+    }
+
+    /// Get the unformatted text as a single continuous string.
+    pub fn raw_string(&self) -> String {
+        self.buffer.iter().map(|(_, str)| str.as_str()).collect()
     }
 }
 


### PR DESCRIPTION
Fixes `history_search_paint`:
- Fix unnecessary clear of single line
- Ensure LF to CRLF in search results

Fixes `Painter`:
- Make sure that Color is cleared after prompt (Currently depends on
Highlighter to provide a new color)
- Remove unnecessary fn

Introduce simple highlighting of the search term in the search result
![image](https://user-images.githubusercontent.com/15833959/147862279-be61eea5-28e0-41c4-8960-61e68cc52b67.png)
