### PR TITLE
Context menu

### DIFF
--- a/src/context_menu.rs
+++ b/src/context_menu.rs
@@ -1,0 +1,19 @@
+pub trait ContextMenu {
+    fn get_values(&self) -> Vec<&str>;
+}
+
+/// Example implementation of Context Menu
+pub struct ExampleMenu {}
+
+impl ContextMenu for ExampleMenu {
+    fn get_values(&self) -> Vec<&str> {
+        vec!["one", "two", "three", "four", "five", "six"]
+    }
+}
+
+impl ExampleMenu {
+    /// Creates new instance of Example Menu
+    pub fn new() -> Self {
+        ExampleMenu {}
+    }
+}

--- a/src/context_menu.rs
+++ b/src/context_menu.rs
@@ -112,7 +112,7 @@ impl ContextMenu {
 
 /// The MenuFiller is a trait that defines how the data for the context menu
 /// will be collected.
-pub trait MenuFiller {
+pub trait MenuFiller: Send {
     /// Collects menu values
     fn context_values(&self) -> Vec<&str>;
 }

--- a/src/context_menu.rs
+++ b/src/context_menu.rs
@@ -1,19 +1,142 @@
-pub trait ContextMenu {
-    fn get_values(&self) -> Vec<&str>;
+/// Context menu definition
+pub struct ContextMenu {
+    filler: Box<dyn MenuFiller>,
+    active: bool,
+    /// Number of minimum rows that are displayed when
+    /// the required lines is larger than the available lines
+    min_rows: u16,
+    /// Marker for selected value
+    pub marker: &'static str,
+    /// column position of the cursor. Starts from 0
+    pub col_pos: u16,
+    /// row position in the menu. Starts from 0
+    pub row_pos: u16,
+    /// Number of columns that the menu will have
+    pub cols: u16,
+    /// Column width
+    pub col_width: usize,
 }
 
-/// Example implementation of Context Menu
-pub struct ExampleMenu {}
-
-impl ContextMenu for ExampleMenu {
-    fn get_values(&self) -> Vec<&str> {
-        vec!["one", "two", "three", "four", "five", "six"]
+impl Default for ContextMenu {
+    fn default() -> Self {
+        let filler = Box::new(ExampleData::new());
+        Self::new_with(filler)
     }
 }
 
-impl ExampleMenu {
+impl ContextMenu {
+    /// Creates a context menu with a filler
+    pub fn new_with(filler: Box<dyn MenuFiller>) -> Self {
+        Self {
+            filler,
+            active: false,
+            min_rows: 3,
+            marker: "*",
+            col_pos: 0,
+            row_pos: 0,
+            cols: 4,
+            col_width: 10,
+        }
+    }
+
+    /// Activates context menu
+    pub fn activate(&mut self) {
+        self.active = true
+    }
+
+    /// Deactivates context menu
+    pub fn deactivate(&mut self) {
+        self.active = false
+    }
+
+    /// Deactivates context menu
+    pub fn is_active(&mut self) -> bool {
+        self.active
+    }
+
+    /// Gets values from filler that will be displayed in the menu
+    pub fn get_values(&self) -> Vec<&str> {
+        self.filler.context_values()
+    }
+
+    /// Calculates how many rows the Menu will use
+    pub fn get_rows(&self) -> u16 {
+        let rows = self.get_values().len() as f64 / self.cols as f64;
+        rows.ceil() as u16
+    }
+
+    /// Minimum rows that should be displayed by the menu
+    pub fn min_rows(&self) -> u16 {
+        self.get_rows().min(self.min_rows)
+    }
+
+    /// Reset menu position
+    pub fn reset_position(&mut self) {
+        self.col_pos = 0;
+        self.row_pos = 0;
+    }
+
+    /// Menu index based on column and row position
+    pub fn position(&self) -> usize {
+        let position = self.row_pos * self.cols + self.col_pos;
+        position as usize
+    }
+
+    /// Move menu cursor up
+    pub fn move_up(&mut self) {
+        self.row_pos = self.row_pos.saturating_sub(1);
+    }
+
+    /// Move menu cursor left
+    pub fn move_down(&mut self) {
+        let new_row = self.row_pos + 1;
+        self.row_pos = new_row.min(self.get_rows().saturating_sub(1))
+    }
+
+    /// Move menu cursor left
+    pub fn move_left(&mut self) {
+        self.col_pos = self.col_pos.saturating_sub(1);
+    }
+
+    /// Move menu cursor right
+    pub fn move_right(&mut self) {
+        let new_col = self.col_pos + 1;
+        self.col_pos = new_col.min(self.cols.saturating_sub(1))
+    }
+
+    /// Get selected value from filler
+    pub fn get_value(&self) -> Option<&str> {
+        self.get_values().get(self.position()).copied()
+    }
+}
+
+/// The MenuFiller is a trait that defines how the data for the context menu
+/// will be collected.
+pub trait MenuFiller {
+    /// Collects menu values
+    fn context_values(&self) -> Vec<&str>;
+}
+
+/// Data example for Reedline ContextMenu
+struct ExampleData {}
+
+impl MenuFiller for ExampleData {
+    fn context_values(&self) -> Vec<&str> {
+        vec![
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+        ]
+    }
+}
+
+impl ExampleData {
     /// Creates new instance of Example Menu
     pub fn new() -> Self {
-        ExampleMenu {}
+        ExampleData {}
     }
 }

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -96,7 +96,7 @@ mod test {
         keybindings.add_binding(
             KeyModifiers::CONTROL,
             KeyCode::Char('l'),
-            ReedlineEvent::HandleTab,
+            ReedlineEvent::Complete,
         );
 
         let mut emacs = Emacs::new(keybindings);
@@ -106,7 +106,7 @@ mod test {
         });
         let result = emacs.parse_event(ctrl_l);
 
-        assert_eq!(result, ReedlineEvent::HandleTab);
+        assert_eq!(result, ReedlineEvent::Complete);
     }
 
     #[test]

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -25,26 +25,30 @@ impl EditMode for Emacs {
     fn parse_event(&mut self, event: Event) -> ReedlineEvent {
         match event {
             Event::Key(KeyEvent { code, modifiers }) => match (modifiers, code) {
-                (KeyModifiers::NONE, KeyCode::Char(c)) => {
-                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
+                (modifier, KeyCode::Char(c)) => {
+                    // Note. The modifier can also be a combination of modifiers, for
+                    // example:
+                    //     KeyModifiers::CONTROL | KeyModifiers::ALT
+                    //     KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
+                    //
+                    // Mixed modifiers are used by non american keyboards that have extra
+                    // keys like 'alt gr'. Keep this in mind if in the future there are
+                    // cases where an event is not being captured
+                    if modifier == KeyModifiers::SHIFT {
+                        let char = c.to_ascii_uppercase();
+                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(char)])
+                    } else if modifier == KeyModifiers::NONE
+                        || modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
+                        || modifier
+                            == KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
+                    {
+                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
+                    } else {
+                        self.keybindings
+                            .find_binding(modifier, code)
+                            .unwrap_or(ReedlineEvent::None)
+                    }
                 }
-                // This combination of modifiers (CONTROL | ALT) is needed for non american keyboards.
-                // There is a special key called 'alt gr' that is captured with the combination
-                // of those two modifiers
-                (m, KeyCode::Char(c)) if m == KeyModifiers::CONTROL | KeyModifiers::ALT => {
-                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
-                }
-
-                (m, KeyCode::Char(c))
-                    if m == KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT =>
-                {
-                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
-                }
-
-                (KeyModifiers::SHIFT, KeyCode::Char(c)) => {
-                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(c.to_ascii_uppercase())])
-                }
-
                 (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,
                 _ => self
                     .keybindings

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -52,7 +52,7 @@ impl Keybindings {
     }
 }
 
-fn edit_bind(command: EditCommand) -> ReedlineEvent {
+pub fn edit_bind(command: EditCommand) -> ReedlineEvent {
     ReedlineEvent::Edit(vec![command])
 }
 
@@ -105,7 +105,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));
     kb.add_binding(KM::NONE, KC::End, edit_bind(EC::MoveToLineEnd));
     kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToLineStart));
-    kb.add_binding(KM::NONE, KC::Tab, ReedlineEvent::HandleTab);
+    kb.add_binding(KM::CONTROL | KM::ALT, KC::Right, ReedlineEvent::Complete);
     kb.add_binding(KM::NONE, KC::Up, ReedlineEvent::Up);
     kb.add_binding(KM::NONE, KC::Down, ReedlineEvent::Down);
     kb.add_binding(KM::NONE, KC::Left, edit_bind(EC::MoveLeft));
@@ -114,27 +114,4 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::Backspace));
 
     kb
-}
-
-pub fn default_vi_normal_keybindings() -> Keybindings {
-    Keybindings::new()
-}
-
-pub fn default_vi_insert_keybindings() -> Keybindings {
-    use EditCommand as EC;
-    use KeyCode as KC;
-    use KeyModifiers as KM;
-
-    let mut keybindings = Keybindings::new();
-
-    keybindings.add_binding(KM::NONE, KC::Up, ReedlineEvent::Up);
-    keybindings.add_binding(KM::NONE, KC::Down, ReedlineEvent::Down);
-    keybindings.add_binding(KM::NONE, KC::Left, edit_bind(EC::MoveLeft));
-    keybindings.add_binding(KM::NONE, KC::Right, edit_bind(EC::MoveRight));
-    keybindings.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::Backspace));
-    keybindings.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
-    keybindings.add_binding(KM::NONE, KC::End, edit_bind(EC::MoveToLineEnd));
-    keybindings.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToLineStart));
-
-    keybindings
 }

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -105,13 +105,16 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));
     kb.add_binding(KM::NONE, KC::End, edit_bind(EC::MoveToLineEnd));
     kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToLineStart));
-    kb.add_binding(KM::CONTROL | KM::ALT, KC::Right, ReedlineEvent::Complete);
+    kb.add_binding(KM::NONE, KC::Tab, ReedlineEvent::Complete);
     kb.add_binding(KM::NONE, KC::Up, ReedlineEvent::Up);
     kb.add_binding(KM::NONE, KC::Down, ReedlineEvent::Down);
     kb.add_binding(KM::NONE, KC::Left, edit_bind(EC::MoveLeft));
     kb.add_binding(KM::NONE, KC::Right, edit_bind(EC::MoveRight));
     kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
     kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::Backspace));
+
+    kb.add_binding(KM::ALT, KC::Char('1'), ReedlineEvent::ContextMenu);
+    kb.add_binding(KM::NONE, KC::Esc, ReedlineEvent::Esc);
 
     kb
 }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -53,7 +53,7 @@ impl EditMode for Vi {
                         }
                     }
 
-                    if modifier == KeyModifiers::NONE || modifier == KeyModifiers::NONE {
+                    if modifier == KeyModifiers::NONE || modifier == KeyModifiers::SHIFT {
                         let char = if let KeyModifiers::SHIFT = modifier {
                             c.to_ascii_uppercase()
                         } else {
@@ -115,7 +115,7 @@ impl EditMode for Vi {
                 (_, KeyModifiers::NONE, KeyCode::Esc) => {
                     self.cache.clear();
                     self.mode = Mode::Normal;
-                    ReedlineEvent::Repaint
+                    ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint])
                 }
                 (_, KeyModifiers::NONE, KeyCode::Enter) => {
                     self.mode = Mode::Insert;

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -1,15 +1,14 @@
 mod command;
 mod motion;
 mod parser;
+mod vi_keybindings;
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use vi_keybindings::{default_vi_insert_keybindings, default_vi_normal_keybindings};
 
 use super::EditMode;
 use crate::{
-    edit_mode::{
-        keybindings::{default_vi_insert_keybindings, default_vi_normal_keybindings, Keybindings},
-        vi::parser::parse,
-    },
+    edit_mode::{keybindings::Keybindings, vi::parser::parse},
     enums::{EditCommand, ReedlineEvent},
     PromptEditMode, PromptViMode,
 };
@@ -54,34 +53,40 @@ impl EditMode for Vi {
                         }
                     }
 
-                    let char = if let KeyModifiers::SHIFT = modifier {
-                        c.to_ascii_uppercase()
-                    } else {
-                        c
-                    };
-                    self.cache.push(char);
+                    if modifier == KeyModifiers::NONE || modifier == KeyModifiers::NONE {
+                        let char = if let KeyModifiers::SHIFT = modifier {
+                            c.to_ascii_uppercase()
+                        } else {
+                            c
+                        };
+                        self.cache.push(char);
 
-                    let res = parse(&mut self.cache.iter().peekable());
+                        let res = parse(&mut self.cache.iter().peekable());
 
-                    if res.enter_insert_mode() {
-                        self.mode = Mode::Insert;
-                    }
+                        if res.enter_insert_mode() {
+                            self.mode = Mode::Insert;
+                        }
 
-                    let event = res.to_reedline_event();
-                    match event {
-                        ReedlineEvent::None => {
-                            if !res.is_valid() {
+                        let event = res.to_reedline_event();
+                        match event {
+                            ReedlineEvent::None => {
+                                if !res.is_valid() {
+                                    self.cache.clear();
+                                }
+                            }
+                            _ => {
                                 self.cache.clear();
                             }
-                        }
-                        _ => {
-                            self.cache.clear();
-                        }
-                    };
+                        };
 
-                    self.previous = Some(event.clone());
+                        self.previous = Some(event.clone());
 
-                    event
+                        event
+                    } else {
+                        self.normal_keybindings
+                            .find_binding(modifiers, code)
+                            .unwrap_or(ReedlineEvent::None)
+                    }
                 }
                 (Mode::Insert, modifier, KeyCode::Char(c)) => {
                     // Note. The modifier can also be a combination of modifiers, for
@@ -92,15 +97,21 @@ impl EditMode for Vi {
                     // Mixed modifiers are used by non american keyboards that have extra
                     // keys like 'alt gr'. Keep this in mind if in the future there are
                     // cases where an event is not being captured
-                    let char = if let KeyModifiers::SHIFT = modifier {
-                        c.to_ascii_uppercase()
+                    if modifier == KeyModifiers::SHIFT {
+                        let char = c.to_ascii_uppercase();
+                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(char)])
+                    } else if modifier == KeyModifiers::NONE
+                        || modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
+                        || modifier
+                            == KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
+                    {
+                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
                     } else {
-                        c
-                    };
-
-                    ReedlineEvent::Edit(vec![EditCommand::InsertChar(char)])
+                        self.insert_keybindings
+                            .find_binding(modifier, code)
+                            .unwrap_or(ReedlineEvent::None)
+                    }
                 }
-                (_, KeyModifiers::NONE, KeyCode::Tab) => ReedlineEvent::HandleTab,
                 (_, KeyModifiers::NONE, KeyCode::Esc) => {
                     self.cache.clear();
                     self.mode = Mode::Normal;

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -28,7 +28,8 @@ pub fn default_vi_insert_keybindings() -> Keybindings {
     kb.add_binding(KM::NONE, KC::End, edit_bind(EC::MoveToLineEnd));
     kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToLineStart));
     kb.add_binding(KM::CONTROL, KC::Char('c'), ReedlineEvent::CtrlC);
-    kb.add_binding(KM::CONTROL | KM::ALT, KC::Right, ReedlineEvent::Complete);
+    kb.add_binding(KM::NONE, KC::Tab, ReedlineEvent::Complete);
+    kb.add_binding(KM::ALT, KC::Char('1'), ReedlineEvent::ContextMenu);
 
     kb
 }

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -1,0 +1,34 @@
+use crate::{
+    edit_mode::{keybindings::edit_bind, Keybindings},
+    ReedlineEvent,
+};
+
+use {
+    crate::EditCommand as EC,
+    crossterm::event::{KeyCode as KC, KeyModifiers as KM},
+};
+
+pub fn default_vi_normal_keybindings() -> Keybindings {
+    let mut kb = Keybindings::new();
+
+    kb.add_binding(KM::CONTROL, KC::Char('c'), ReedlineEvent::CtrlC);
+
+    kb
+}
+
+pub fn default_vi_insert_keybindings() -> Keybindings {
+    let mut kb = Keybindings::new();
+
+    kb.add_binding(KM::NONE, KC::Up, ReedlineEvent::Up);
+    kb.add_binding(KM::NONE, KC::Down, ReedlineEvent::Down);
+    kb.add_binding(KM::NONE, KC::Left, edit_bind(EC::MoveLeft));
+    kb.add_binding(KM::NONE, KC::Right, edit_bind(EC::MoveRight));
+    kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::Backspace));
+    kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
+    kb.add_binding(KM::NONE, KC::End, edit_bind(EC::MoveToLineEnd));
+    kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToLineStart));
+    kb.add_binding(KM::CONTROL, KC::Char('c'), ReedlineEvent::CtrlC);
+    kb.add_binding(KM::CONTROL | KM::ALT, KC::Right, ReedlineEvent::Complete);
+
+    kb
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -530,7 +530,6 @@ impl Reedline {
         match event {
             ReedlineEvent::ContextMenu => {
                 self.context_menu.activate();
-                self.context_menu.reset_position();
 
                 self.buffer_paint(prompt)?;
                 Ok(None)

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -216,6 +216,9 @@ pub enum ReedlineEvent {
     /// Trigger Tab
     HandleTab,
 
+    /// Completes hint
+    Complete,
+
     /// Handle EndOfLine event
     ///
     /// Expected Behavior:

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -213,8 +213,8 @@ pub enum ReedlineEvent {
     /// No op event
     None,
 
-    /// Trigger Tab
-    HandleTab,
+    /// Trigger context menu
+    ContextMenu,
 
     /// Completes hint
     Complete,
@@ -242,6 +242,9 @@ pub enum ReedlineEvent {
 
     /// Handle enter event
     Enter,
+
+    /// Esc event
+    Esc,
 
     /// Mouse
     Mouse, // Fill in details later

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,3 +228,6 @@ pub use hinter::{DefaultHinter, Hinter};
 
 mod validator;
 pub use validator::{DefaultValidator, ValidationResult, Validator};
+
+mod context_menu;
+pub use context_menu::ExampleMenu;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,4 +230,4 @@ mod validator;
 pub use validator::{DefaultValidator, ValidationResult, Validator};
 
 mod context_menu;
-pub use context_menu::ExampleMenu;
+pub use context_menu::{ContextMenu, MenuFiller};

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -169,6 +169,7 @@ pub struct Painter {
     last_required_lines: u16,
     pub large_buffer: bool,
     debug_mode: bool,
+    context_menu_mode: bool,
 }
 
 impl Painter {
@@ -180,6 +181,7 @@ impl Painter {
             last_required_lines: 0,
             large_buffer: false,
             debug_mode: false,
+            context_menu_mode: false,
         }
     }
 
@@ -191,6 +193,7 @@ impl Painter {
             last_required_lines: 0,
             large_buffer: false,
             debug_mode: true,
+            context_menu_mode: false,
         }
     }
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -1,4 +1,6 @@
-use crate::PromptHistorySearch;
+use std::borrow::Cow;
+
+use crate::{context_menu::ContextMenu, PromptHistorySearch};
 use crossterm::{cursor::MoveToRow, style::ResetColor, terminal::ScrollUp};
 
 use {
@@ -25,6 +27,9 @@ impl PromptCoordinates {
 }
 
 pub struct PromptLines<'prompt> {
+    prompt_str_left: Cow<'prompt, str>,
+    prompt_str_right: Cow<'prompt, str>,
+    prompt_indicator: Cow<'prompt, str>,
     before_cursor: &'prompt str,
     after_cursor: &'prompt str,
     hint: &'prompt str,
@@ -35,11 +40,25 @@ impl<'prompt> PromptLines<'prompt> {
     /// This vector with the str are used to calculate how many lines are
     /// required to print after the prompt
     pub fn new(
+        prompt: &'prompt dyn Prompt,
+        prompt_mode: PromptEditMode,
+        history_indicator: Option<PromptHistorySearch>,
         before_cursor: &'prompt str,
         after_cursor: &'prompt str,
         hint: &'prompt str,
     ) -> Self {
+        let prompt_str_left = prompt.render_prompt_left();
+        let prompt_str_right = prompt.render_prompt_right();
+
+        let prompt_indicator = match history_indicator {
+            Some(prompt_search) => prompt.render_prompt_history_search_indicator(prompt_search),
+            None => prompt.render_prompt_indicator(prompt_mode),
+        };
+
         Self {
+            prompt_str_left,
+            prompt_str_right,
+            prompt_indicator,
             before_cursor,
             after_cursor,
             hint,
@@ -49,17 +68,16 @@ impl<'prompt> PromptLines<'prompt> {
     /// The required lines to paint the buffer are calculated by counting the
     /// number of newlines in all the strings that form the prompt and buffer.
     /// The plus 1 is to indicate that there should be at least one line.
-    fn required_lines(
-        &self,
-        prompt_str: &str,
-        prompt_indicator: &str,
-        terminal_columns: u16,
-    ) -> u16 {
-        let input = prompt_str.to_string()
-            + prompt_indicator
-            + self.before_cursor
-            + self.hint
-            + self.after_cursor;
+    fn required_lines(&self, terminal_columns: u16, context_menu: Option<&ContextMenu>) -> u16 {
+        let input = if context_menu.is_none() {
+            self.prompt_str_left.to_string()
+                + &self.prompt_indicator
+                + self.before_cursor
+                + self.hint
+                + self.after_cursor
+        } else {
+            self.prompt_str_left.to_string() + &self.prompt_indicator + self.before_cursor
+        };
 
         let lines = input.lines().fold(0, |acc, line| {
             let wrap = if let Ok(line) = strip_ansi_escapes::strip(line) {
@@ -71,16 +89,17 @@ impl<'prompt> PromptLines<'prompt> {
             acc + 1 + wrap
         });
 
-        lines as u16
+        if let Some(context_menu) = context_menu {
+            lines as u16 + context_menu.get_rows()
+        } else {
+            lines as u16
+        }
     }
 
-    fn distance_from_prompt(
-        &self,
-        prompt_str: &str,
-        prompt_indicator: &str,
-        terminal_columns: u16,
-    ) -> u16 {
-        let input = prompt_str.to_string() + prompt_indicator + self.before_cursor;
+    /// Estimated distance of the cursor to the prompt.
+    /// This considers line wrapping
+    fn distance_from_prompt(&self, terminal_columns: u16) -> u16 {
+        let input = self.prompt_str_left.to_string() + &self.prompt_indicator + self.before_cursor;
 
         let lines = input.lines().fold(0, |acc, line| {
             let wrap = if let Ok(line) = strip_ansi_escapes::strip(line) {
@@ -97,6 +116,40 @@ impl<'prompt> PromptLines<'prompt> {
 
     fn concatenate_lines(&self) -> String {
         self.before_cursor.to_string() + self.after_cursor + self.hint
+    }
+
+    /// Total lines that the prompt uses considering that it may wrap the screen
+    fn prompt_lines_with_wrap(&self, screen_width: u16) -> u16 {
+        let complete_prompt = self.prompt_str_left.to_string() + &self.prompt_indicator;
+        let prompt_wrap = estimated_wrapped_line_count(&complete_prompt, screen_width);
+
+        (self.prompt_str_left.matches('\n').count() + prompt_wrap) as u16
+    }
+
+    /// Estimated width of the actual input
+    fn estimate_first_input_line_width(&self) -> u16 {
+        let last_line_left_prompt = self.prompt_str_left.lines().last();
+
+        let prompt_lines_total = self.concatenate_lines();
+        let prompt_lines_first = prompt_lines_total.lines().next();
+
+        let mut estimate = 0; // space in front of the input
+
+        if let Some(last_line_left_prompt) = last_line_left_prompt {
+            estimate += line_width(last_line_left_prompt);
+        }
+
+        estimate += line_width(&self.prompt_indicator);
+
+        if let Some(prompt_lines_first) = prompt_lines_first {
+            estimate += line_width(prompt_lines_first);
+        }
+
+        if estimate > u16::MAX as usize {
+            u16::MAX
+        } else {
+            estimate as u16
+        }
     }
 }
 
@@ -148,17 +201,7 @@ fn skip_buffer_lines(string: &str, skip: usize, offset: Option<usize>) -> &str {
         None => string.len(),
     };
 
-    let line = &string[index..limit];
-
-    line.trim_end_matches('\n')
-}
-
-/// Total lines that the prompt uses considering that it may wrap the screen
-fn prompt_lines_with_wrap(prompt_str: &str, prompt_indicator: &str, screen_width: u16) -> u16 {
-    let complete_prompt = prompt_str.to_string() + prompt_indicator;
-    let prompt_wrap = estimated_wrapped_line_count(&complete_prompt, screen_width);
-
-    (prompt_str.matches('\n').count() + prompt_wrap) as u16
+    string[index..limit].trim_end_matches('\n')
 }
 
 pub struct Painter {
@@ -169,7 +212,6 @@ pub struct Painter {
     last_required_lines: u16,
     pub large_buffer: bool,
     debug_mode: bool,
-    context_menu_mode: bool,
 }
 
 impl Painter {
@@ -181,7 +223,6 @@ impl Painter {
             last_required_lines: 0,
             large_buffer: false,
             debug_mode: false,
-            context_menu_mode: false,
         }
     }
 
@@ -193,7 +234,6 @@ impl Painter {
             last_required_lines: 0,
             large_buffer: false,
             debug_mode: true,
-            context_menu_mode: false,
         }
     }
 
@@ -251,27 +291,17 @@ impl Painter {
     pub fn repaint_buffer(
         &mut self,
         prompt: &dyn Prompt,
-        prompt_mode: PromptEditMode,
         lines: PromptLines,
-        history_indicator: Option<PromptHistorySearch>,
+        context_menu: Option<&ContextMenu>,
         use_ansi_coloring: bool,
     ) -> Result<()> {
         self.stdout.queue(cursor::Hide)?;
 
         // String representation of the prompt
         let (screen_width, screen_height) = self.terminal_size;
-        let prompt_str_left = prompt.render_prompt_left();
-        let prompt_str_right = prompt.render_prompt_right();
-
-        // The prompt indicator could be normal one or the history indicator
-        let prompt_indicator = match history_indicator {
-            Some(prompt_search) => prompt.render_prompt_history_search_indicator(prompt_search),
-            None => prompt.render_prompt_indicator(prompt_mode),
-        };
 
         // Lines and distance parameters
-        let required_lines =
-            lines.required_lines(&prompt_str_left, &prompt_indicator, screen_width);
+        let required_lines = lines.required_lines(screen_width, context_menu);
         let remaining_lines = self.remaining_lines();
 
         // Marking the painter state as larger buffer to avoid animations
@@ -294,19 +324,9 @@ impl Painter {
             .queue(Clear(ClearType::FromCursorDown))?;
 
         if self.large_buffer {
-            self.print_large_buffer(
-                prompt,
-                (&prompt_str_left, &prompt_str_right, &prompt_indicator),
-                &lines,
-                use_ansi_coloring,
-            )?
+            self.print_large_buffer(prompt, &lines, context_menu, use_ansi_coloring)?
         } else {
-            self.print_small_buffer(
-                prompt,
-                (&prompt_str_left, &prompt_str_right, &prompt_indicator),
-                &lines,
-                use_ansi_coloring,
-            )?
+            self.print_small_buffer(prompt, &lines, context_menu, use_ansi_coloring)?
         }
 
         // The last_required_lines is used to move the cursor at the end where stdout
@@ -315,12 +335,11 @@ impl Painter {
 
         // In debug mode a string with position information is printed at the end of the buffer
         if self.debug_mode {
-            let cursor_distance =
-                lines.distance_from_prompt(&prompt_str_left, &prompt_indicator, screen_width);
-            let prompt_lines =
-                prompt_lines_with_wrap(&prompt_str_left, &prompt_indicator, screen_width);
-            let prompt_length = prompt_str_left.len() + prompt_indicator.len();
-            let estimated_prompt = estimated_wrapped_line_count(&prompt_str_left, screen_width);
+            let cursor_distance = lines.distance_from_prompt(screen_width);
+            let prompt_lines = lines.prompt_lines_with_wrap(screen_width);
+            let prompt_length = lines.prompt_str_left.len() + lines.prompt_indicator.len();
+            let estimated_prompt =
+                estimated_wrapped_line_count(&lines.prompt_str_left, screen_width);
 
             self.stdout
                 .queue(Print(format!(" [h{}:", screen_height)))?
@@ -341,10 +360,11 @@ impl Painter {
         self.flush()
     }
 
-    fn print_right_prompt(&mut self, prompt_str_right: &str, input_width: u16) -> Result<()> {
+    fn print_right_prompt(&mut self, lines: &PromptLines) -> Result<()> {
         let (screen_width, _) = self.terminal_size;
-        let prompt_length_right = line_width(prompt_str_right);
+        let prompt_length_right = line_width(&lines.prompt_str_right);
         let start_position = screen_width.saturating_sub(prompt_length_right as u16);
+        let input_width = lines.estimate_first_input_line_width();
 
         if input_width <= start_position {
             self.stdout
@@ -353,9 +373,82 @@ impl Painter {
                     start_position,
                     self.prompt_coords.prompt_start.1,
                 ))?
-                .queue(Print(&prompt_str_right))?
+                .queue(Print(&lines.prompt_str_right))?
                 .queue(RestorePosition)?;
         }
+
+        Ok(())
+    }
+
+    fn print_context_menu(
+        &mut self,
+        context_menu: &ContextMenu,
+        lines: &PromptLines,
+    ) -> Result<()> {
+        let (screen_width, screen_height) = self.terminal_size;
+        let cursor_distance = lines.distance_from_prompt(screen_width);
+
+        // If there is not enough space to print the menu, then the starting
+        // drawing point for the menu will overwrite the last rows in the buffer
+        let starting_row = if cursor_distance >= screen_height.saturating_sub(1) {
+            screen_height.saturating_sub(context_menu.min_rows())
+        } else {
+            self.prompt_coords.prompt_start.1 + cursor_distance + 1
+        };
+
+        // The skip values represent the number of lines that should be skipped
+        // while printing the menu
+        let remaining_lines = screen_height.saturating_sub(starting_row);
+        let skip_values = if context_menu.row_pos >= remaining_lines {
+            let skip_lines = context_menu.row_pos.saturating_sub(remaining_lines) + 1;
+            (skip_lines * context_menu.cols) as usize
+        } else {
+            0
+        };
+
+        // It seems that crossterm prefers to have a complete string ready to be printed
+        // rather than looping through the values and printing multiple things
+        // This reduces the flickering when printing the menu
+        let available_values = (remaining_lines * context_menu.cols) as usize;
+        let values = context_menu
+            .get_values()
+            .iter()
+            .skip(skip_values)
+            .take(available_values)
+            .enumerate()
+            .map(|(index, line)| {
+                // Correcting the enumerate index based on the number of skipped values
+                let index = index + skip_values;
+                let marker = if index == context_menu.position() {
+                    context_menu.marker
+                } else {
+                    ""
+                };
+
+                let column = index as u16 % context_menu.cols;
+                let end_of_line = if column == context_menu.cols.saturating_sub(1) {
+                    "\r\n"
+                } else {
+                    ""
+                };
+
+                let text_width = context_menu.col_width - marker.len();
+                let printable_width = (text_width - 2) as usize;
+                let printable_width = printable_width.min(line.len());
+                format!(
+                    "{}{:width$}{}",
+                    marker,
+                    &line[..printable_width],
+                    end_of_line,
+                    width = text_width
+                )
+            })
+            .collect::<String>();
+
+        self.stdout
+            .queue(cursor::MoveTo(0, starting_row))?
+            .queue(Clear(ClearType::FromCursorDown))?
+            .queue(Print(values.trim_end_matches('\n')))?;
 
         Ok(())
     }
@@ -363,12 +456,10 @@ impl Painter {
     fn print_small_buffer(
         &mut self,
         prompt: &dyn Prompt,
-        prompt_str: (&str, &str, &str),
         lines: &PromptLines,
+        context_menu: Option<&ContextMenu>,
         use_ansi_coloring: bool,
     ) -> Result<()> {
-        let (prompt_str_left, prompt_str_right, prompt_indicator) = prompt_str;
-
         // print our prompt with color
         if use_ansi_coloring {
             self.stdout
@@ -376,13 +467,10 @@ impl Painter {
         }
 
         self.stdout
-            .queue(Print(&prompt_str_left))?
-            .queue(Print(&prompt_indicator))?;
+            .queue(Print(&lines.prompt_str_left))?
+            .queue(Print(&lines.prompt_indicator))?;
 
-        let estimate_input_total_width =
-            estimate_first_input_line_width(prompt_str_left, prompt_indicator, lines);
-
-        self.print_right_prompt(prompt_str_right, estimate_input_total_width)?;
+        self.print_right_prompt(lines)?;
 
         if use_ansi_coloring {
             self.stdout.queue(ResetColor)?;
@@ -390,9 +478,14 @@ impl Painter {
 
         self.stdout
             .queue(Print(&lines.before_cursor))?
-            .queue(SavePosition)?
-            .queue(Print(&lines.hint))?
-            .queue(Print(&lines.after_cursor))?;
+            .queue(SavePosition)?;
+
+        if let Some(context_menu) = context_menu {
+            self.print_context_menu(context_menu, lines)?;
+        } else {
+            self.stdout
+                .queue(Print(format!("{}{}", &lines.hint, &lines.after_cursor)))?;
+        }
 
         Ok(())
     }
@@ -400,23 +493,20 @@ impl Painter {
     fn print_large_buffer(
         &mut self,
         prompt: &dyn Prompt,
-        prompt_str: (&str, &str, &str),
         lines: &PromptLines,
+        context_menu: Option<&ContextMenu>,
         use_ansi_coloring: bool,
     ) -> Result<()> {
-        let (prompt_str_left, prompt_str_right, prompt_indicator) = prompt_str;
         let (screen_width, screen_height) = self.terminal_size;
-        let cursor_distance =
-            lines.distance_from_prompt(prompt_str_left, prompt_indicator, screen_width);
+        let cursor_distance = lines.distance_from_prompt(screen_width);
         let remaining_lines = screen_height.saturating_sub(cursor_distance);
 
         // Calculating the total lines before the cursor
         // The -1 in the total_lines_before is there because the at least one line of the prompt
         // indicator is printed in the same line as the first line of the buffer
-        let prompt_lines =
-            prompt_lines_with_wrap(prompt_str_left, prompt_indicator, screen_width) as usize;
+        let prompt_lines = lines.prompt_lines_with_wrap(screen_width) as usize;
 
-        let prompt_indicator_lines = prompt_indicator.lines().count();
+        let prompt_indicator_lines = lines.prompt_indicator.lines().count();
         let before_cursor_lines = lines.before_cursor.lines().count();
         let total_lines_before = prompt_lines + prompt_indicator_lines + before_cursor_lines - 1;
 
@@ -431,42 +521,60 @@ impl Painter {
 
         // In case the prompt is made out of multiple lines, the prompt is split by
         // lines and only the required ones are printed
-        let prompt_skipped = skip_buffer_lines(prompt_str_left, extra_rows, None);
+        let prompt_skipped = skip_buffer_lines(&lines.prompt_str_left, extra_rows, None);
         self.stdout.queue(Print(prompt_skipped))?;
 
-        let estimate_input_total_width =
-            estimate_first_input_line_width(prompt_str_left, prompt_indicator, lines);
-
         if extra_rows == 0 {
-            self.print_right_prompt(prompt_str_right, estimate_input_total_width)?;
+            self.print_right_prompt(lines)?;
         }
 
         // Adjusting extra_rows base on the calculated prompt line size
         let extra_rows = extra_rows.saturating_sub(prompt_lines);
 
-        let indicator_skipped = skip_buffer_lines(prompt_indicator, extra_rows, None);
+        let indicator_skipped = skip_buffer_lines(&lines.prompt_indicator, extra_rows, None);
         self.stdout.queue(Print(indicator_skipped))?;
 
         if use_ansi_coloring {
             self.stdout.queue(ResetColor)?;
         }
 
+        // The minimum number of lines from the menu are removed from the buffer if there is no more
+        // space to print the menu. This will only happen if the cursor is at the last line and
+        // it is a large buffer
+        let offset = context_menu.and_then(|context_menu| {
+            if cursor_distance >= screen_height.saturating_sub(1) {
+                let rows = lines
+                    .before_cursor
+                    .lines()
+                    .count()
+                    .saturating_sub(extra_rows)
+                    .saturating_sub(context_menu.min_rows() as usize);
+                Some(rows)
+            } else {
+                None
+            }
+        });
+
         // Selecting the lines before the cursor that will be printed
-        let before_cursor_skipped = skip_buffer_lines(lines.before_cursor, extra_rows, None);
+        let before_cursor_skipped = skip_buffer_lines(lines.before_cursor, extra_rows, offset);
         self.stdout.queue(Print(before_cursor_skipped))?;
         self.stdout.queue(SavePosition)?;
 
-        // Selecting lines for the hint
-        // The -1 subtraction is done because the remaining lines consider the line where the
-        // cursor is located as a remaining line. That has to be removed to get the correct offset
-        // for the hint and after cursor lines
-        let offset = remaining_lines.saturating_sub(1) as usize;
-        let hint_skipped = skip_buffer_lines(lines.hint, 0, Some(offset));
-        self.stdout.queue(Print(hint_skipped))?;
+        if let Some(context_menu) = context_menu {
+            self.print_context_menu(context_menu, lines)?;
+        } else {
+            // Selecting lines for the hint
+            // The -1 subtraction is done because the remaining lines consider the line where the
+            // cursor is located as a remaining line. That has to be removed to get the correct offset
+            // for the hint and after cursor lines
+            let offset = remaining_lines.saturating_sub(1) as usize;
+            let hint_skipped = skip_buffer_lines(lines.hint, 0, Some(offset));
+            self.stdout.queue(Print(hint_skipped))?;
 
-        // Selecting lines after the cursor
-        let after_cursor_skipped = skip_buffer_lines(lines.after_cursor, 0, Some(offset));
-        self.stdout.queue(Print(after_cursor_skipped))?;
+            // Selecting lines after the cursor
+            let after_cursor_skipped = skip_buffer_lines(lines.after_cursor, 0, Some(offset));
+            self.stdout.queue(Print(after_cursor_skipped))?;
+        }
 
         Ok(())
     }
@@ -545,35 +653,6 @@ impl Painter {
 
     pub fn flush(&mut self) -> Result<()> {
         self.stdout.flush()
-    }
-}
-
-fn estimate_first_input_line_width(
-    left_prompt: &str,
-    indicator: &str,
-    prompt_lines: &PromptLines,
-) -> u16 {
-    let last_line_left_prompt = left_prompt.lines().last();
-
-    let prompt_lines_total = prompt_lines.concatenate_lines();
-    let prompt_lines_first = prompt_lines_total.lines().next();
-
-    let mut estimate = 0; // space in front of the input
-
-    if let Some(last_line_left_prompt) = last_line_left_prompt {
-        estimate += line_width(last_line_left_prompt);
-    }
-
-    estimate += line_width(indicator);
-
-    if let Some(prompt_lines_first) = prompt_lines_first {
-        estimate += line_width(prompt_lines_first);
-    }
-
-    if estimate > u16::MAX as usize {
-        u16::MAX
-    } else {
-        estimate as u16
     }
 }
 


### PR DESCRIPTION
Introduces context menu for reedline. 

To activate the menu use ALT+1. This is temporal while we decide how to call the menu
![Animation1](https://user-images.githubusercontent.com/6942205/148695895-e5016094-7e8f-4309-9f70-161e8eb24ef9.gif)
