### PR TITLE
Move running of EditCommands to the editor

### DIFF
--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -239,15 +239,13 @@ impl LineBuffer {
     }
 
     /// Move cursor position *in front of* the next word to the left
-    pub fn move_word_left(&mut self) -> usize {
+    pub fn move_word_left(&mut self) {
         self.insertion_point.offset = self.word_left_index();
-        self.insertion_point.offset
     }
 
     /// Move cursor position *behind* the next word to the right
-    pub fn move_word_right(&mut self) -> usize {
+    pub fn move_word_right(&mut self) {
         self.insertion_point.offset = self.word_right_index();
-        self.insertion_point.offset
     }
 
     ///Insert a single character at the insertion point and move right

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -84,8 +84,8 @@ pub fn default_emacs_keybindings() -> Keybindings {
         KC::Char('y'),
         edit_bind(EC::PasteCutBufferBefore),
     );
-    kb.add_binding(KM::CONTROL, KC::Char('b'), edit_bind(EC::MoveLeft));
-    kb.add_binding(KM::CONTROL, KC::Char('f'), edit_bind(EC::MoveRight));
+    kb.add_binding(KM::CONTROL, KC::Char('b'), ReedlineEvent::Left);
+    kb.add_binding(KM::CONTROL, KC::Char('f'), ReedlineEvent::Right);
     kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
     kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
     kb.add_binding(KM::CONTROL, KC::Char('p'), ReedlineEvent::PreviousHistory);
@@ -108,7 +108,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::NONE, KC::Tab, ReedlineEvent::Complete);
     kb.add_binding(KM::NONE, KC::Up, ReedlineEvent::Up);
     kb.add_binding(KM::NONE, KC::Down, ReedlineEvent::Down);
-    kb.add_binding(KM::NONE, KC::Left, edit_bind(EC::MoveLeft));
+    kb.add_binding(KM::NONE, KC::Left, ReedlineEvent::Left);
     kb.add_binding(KM::NONE, KC::Right, ReedlineEvent::Right);
     kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
     kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::Backspace));

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -149,8 +149,8 @@ impl Command {
         match self {
             Self::MoveUp => vec![ReedlineOption::Event(ReedlineEvent::Up)],
             Self::MoveDown => vec![ReedlineOption::Event(ReedlineEvent::Down)],
-            Self::MoveLeft => vec![ReedlineOption::Edit(EditCommand::MoveLeft)],
-            Self::MoveRight => vec![ReedlineOption::Edit(EditCommand::MoveRight)],
+            Self::MoveLeft => vec![ReedlineOption::Event(ReedlineEvent::Left)],
+            Self::MoveRight => vec![ReedlineOption::Event(ReedlineEvent::Right)],
             Self::MoveToLineStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],
             Self::MoveToLineEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
             Self::MoveWordLeft => vec![ReedlineOption::Edit(EditCommand::MoveWordLeft)],

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -272,15 +272,15 @@ mod tests {
     #[case(&['2', 'j'], ReedlineEvent::Multiple(vec![ReedlineEvent::Down, ReedlineEvent::Down]))]
     #[case(&['j'], ReedlineEvent::Multiple(vec![ReedlineEvent::Down]))]
     #[case(&['2', 'l'], ReedlineEvent::Multiple(vec![
-        ReedlineEvent::Edit(vec![EditCommand::MoveRight]),
-        ReedlineEvent::Edit(vec![EditCommand::MoveRight])
+        ReedlineEvent::Right,
+        ReedlineEvent::Right
         ]))]
-    #[case(&['l'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveRight])]))]
+    #[case(&['l'], ReedlineEvent::Multiple(vec![ReedlineEvent::Right]))]
     #[case(&['2', 'h'], ReedlineEvent::Multiple(vec![
-        ReedlineEvent::Edit(vec![EditCommand::MoveLeft]),
-        ReedlineEvent::Edit(vec![EditCommand::MoveLeft]),
+        ReedlineEvent::Left,
+        ReedlineEvent::Left,
         ]))]
-    #[case(&['h'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveLeft])]))]
+    #[case(&['h'], ReedlineEvent::Multiple(vec![ReedlineEvent::Left]))]
     #[case(&['0'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineStart])]))]
     #[case(&['$'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineEnd])]))]
     #[case(&['i'], ReedlineEvent::Multiple(vec![ReedlineEvent::Repaint]))]

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -21,7 +21,7 @@ pub fn default_vi_insert_keybindings() -> Keybindings {
 
     kb.add_binding(KM::NONE, KC::Up, ReedlineEvent::Up);
     kb.add_binding(KM::NONE, KC::Down, ReedlineEvent::Down);
-    kb.add_binding(KM::NONE, KC::Left, edit_bind(EC::MoveLeft));
+    kb.add_binding(KM::NONE, KC::Left, ReedlineEvent::Left);
     kb.add_binding(KM::NONE, KC::Right, ReedlineEvent::Right);
     kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::Backspace));
     kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -267,8 +267,11 @@ pub enum ReedlineEvent {
     /// Move down to the next line, if multiline, or down through the historic buffers
     Down,
 
-    /// Move down to the next column, or complete hint
+    /// Move right to the next column, completion entry, or complete hint
     Right,
+
+    /// Move left to the next column, or completion entry
+    Left,
 
     /// Navigate to the next historic buffer
     NextHistory,


### PR DESCRIPTION
- Moves the big match statement for `EditCommand`s into `Editor`
- Removes the need for many `pub` wrappers around the `LineBuffer`
- Make `Left` a `ReedlineEvent` as well
- Fix left, right, up, down for vi mode
