### PR TITLE
Remove superfluous insertion of carriage return

### DIFF
--- a/src/hinter.rs
+++ b/src/hinter.rs
@@ -54,8 +54,6 @@ impl Hinter for DefaultHinter {
                 let span = completions[0].0;
                 hint.replace_range(0..(span.end - span.start), "");
 
-                let hint = hint.replace("\n", "\r\n");
-
                 self.current_hint = hint.clone();
 
                 output = self.style.paint(hint).to_string();


### PR DESCRIPTION
In the hinter logic `LF` was always replaced by `CRLF` thus inserting unnecessary `CR`'s into the linebuffer that accumulate if a multiline entry is recalled via hint autosuggestion from history multiple times.

![image](https://user-images.githubusercontent.com/15833959/150232746-dbfc50d9-f5cf-4a48-b284-4c3022093918.png)
- Hexdump of history file shows contamination with `CR` (`0x0D`)

Carriage returns, that are not introduced at the end of the line as part of the painter or the OS convention, break the painting of multilines, as the cursor position might jump to the start of the multiline continuation prompt and start painting from there!
