### PR TITLE
Remove `Reedline::print_line` from the API

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -343,7 +343,7 @@ impl Reedline {
     }
 
     /// Writes `msg` to the terminal with a following carriage return and newline
-    pub fn print_line(&mut self, msg: &str) -> Result<()> {
+    fn print_line(&mut self, msg: &str) -> Result<()> {
         self.painter.paint_line(msg)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> Result<()> {
                     line_editor.print_history()?;
                     continue;
                 }
-                line_editor.print_line(&format!("Our buffer: {}", buffer))?;
+                println!("Our buffer: {}", buffer);
             }
             Ok(Signal::CtrlC) => {
                 // Prompt has been cleared and should start on the next line


### PR DESCRIPTION
As this function can only be called outside running
`Reedline::read_line` it is not relevant for raw mode reasons and can be
replaced by standard `println!()`
