### PR TITLE
Distill `DefaultHinter` down to history suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,21 +130,11 @@ let mut line_editor = Reedline::create()?.with_completion_action_handler(Box::ne
 
 use {
   nu_ansi_term::{Color, Style},
-  reedline::{DefaultCompleter, DefaultHinter, Reedline},
+  reedline::{DefaultHinter, Reedline},
 };
-
-let commands = vec![
-  "test".into(),
-  "hello world".into(),
-  "hello world reedline".into(),
-  "this is the reedline crate".into(),
-];
-let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 
 let mut line_editor = Reedline::create()?.with_hinter(Box::new(
   DefaultHinter::default()
-  .with_completer(completer) // or .with_history()
-  // .with_inside_line()
   .with_style(Style::new().italic().fg(Color::LightGray)),
 ));
 ```

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -6,45 +6,6 @@ use std::{
 
 use crate::{Completer, Span};
 
-/// A history-specific completer with a focus on completing whole lines of history
-pub struct HistoryCompleter {
-    history: Vec<String>,
-}
-
-impl HistoryCompleter {
-    pub fn new(history: Vec<String>) -> Self {
-        Self { history }
-    }
-}
-
-impl Completer for HistoryCompleter {
-    fn complete(&self, line: &str, pos: usize) -> Vec<(Span, String)> {
-        let mut completions = vec![];
-
-        if line.is_empty() {
-            return vec![];
-        }
-
-        for hist in &self.history {
-            if hist.starts_with(&line[0..pos]) {
-                completions.push((
-                    Span {
-                        start: pos,
-                        end: line.len(),
-                    },
-                    hist[pos..].to_string(),
-                ));
-            }
-        }
-
-        if let Some(last) = completions.last() {
-            vec![last.clone()]
-        } else {
-            completions
-        }
-    }
-}
-
 /// A default completer that can detect keywords
 ///
 /// # Example

--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -5,5 +5,5 @@ mod list;
 
 pub use base::{Completer, CompletionActionHandler, Span};
 pub use circular::CircularCompletionHandler;
-pub use default::{DefaultCompleter, HistoryCompleter};
+pub use default::DefaultCompleter;
 pub use list::ListCompletionHandler;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -152,21 +152,11 @@ impl Reedline {
     /// use std::io;
     /// use {
     ///     nu_ansi_term::{Color, Style},
-    ///     reedline::{DefaultCompleter, DefaultHinter, Reedline},
+    ///     reedline::{DefaultHinter, Reedline},
     /// };
-    ///
-    /// let commands = vec![
-    ///     "test".into(),
-    ///     "hello world".into(),
-    ///     "hello world reedline".into(),
-    ///     "this is the reedline crate".into(),
-    /// ];
-    /// let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
     ///
     /// let mut line_editor = Reedline::create()?.with_hinter(Box::new(
     ///     DefaultHinter::default()
-    ///     .with_completer(completer) // or .with_history()
-    ///     // .with_inside_line()
     ///     .with_style(Style::new().italic().fg(Color::LightGray)),
     /// ));
     /// # Ok::<(), io::Error>(())

--- a/src/hinter.rs
+++ b/src/hinter.rs
@@ -1,7 +1,5 @@
-use crate::completion::HistoryCompleter;
-
 use {
-    crate::{Completer, History},
+    crate::History,
     nu_ansi_term::{Color, Style},
 };
 
@@ -23,10 +21,7 @@ pub trait Hinter: Send {
 
 /// A default example hinter that use the completions or the history to show a hint to the user
 pub struct DefaultHinter {
-    completer: Option<Box<dyn Completer>>,
-    history: bool,
     style: Style,
-    inside_line: bool,
     current_hint: String,
 }
 
@@ -34,42 +29,20 @@ impl Hinter for DefaultHinter {
     fn handle(
         &mut self,
         line: &str,
-        pos: usize,
+        #[allow(unused_variables)] pos: usize,
         history: &dyn History,
         use_ansi_coloring: bool,
     ) -> String {
-        let mut completions = vec![];
-        let mut output = String::new();
-
-        if pos == line.len() || self.inside_line {
-            if let Some(c) = &self.completer {
-                completions = c.complete(line, pos);
-            } else if self.history {
-                let history: Vec<String> = history.iter_chronologic().cloned().collect();
-                completions = HistoryCompleter::new(history).complete(line, pos);
-            }
-
-            if !completions.is_empty() {
-                let mut hint = completions[0].1.clone();
-                let span = completions[0].0;
-                hint.replace_range(0..(span.end - span.start), "");
-
-                self.current_hint = hint.clone();
-
-                output = self.style.paint(hint).to_string();
-            } else {
-                self.current_hint = String::new();
-            }
-        } else {
-            self.current_hint = String::new();
-        }
+        self.current_hint = history
+            .iter_chronologic()
+            .rev()
+            .find(|entry| entry.starts_with(line))
+            .map_or_else(String::new, |entry| entry[line.len()..].to_string());
 
         if use_ansi_coloring {
-            output
-        } else if let Ok(bytes) = strip_ansi_escapes::strip(&output) {
-            String::from_utf8_lossy(&bytes).to_string()
+            self.style.paint(&self.current_hint).to_string()
         } else {
-            output
+            self.current_hint.clone()
         }
     }
 
@@ -81,34 +54,13 @@ impl Hinter for DefaultHinter {
 impl Default for DefaultHinter {
     fn default() -> Self {
         DefaultHinter {
-            completer: None,
-            history: false,
             style: Style::new().fg(Color::LightGray),
-            inside_line: false,
             current_hint: String::new(),
         }
     }
 }
 
 impl DefaultHinter {
-    /// A builder for the default hinter that configures if the hint is shown inside the current line
-    pub fn with_inside_line(mut self) -> DefaultHinter {
-        self.inside_line = true;
-        self
-    }
-
-    /// A builder that will configure the completer used by this hinter
-    pub fn with_completer(mut self, completer: Box<dyn Completer>) -> DefaultHinter {
-        self.completer = Some(completer);
-        self
-    }
-
-    /// A builder that configures the history the hinter will use to hint, if in history mode
-    pub fn with_history(mut self) -> DefaultHinter {
-        self.history = true;
-        self
-    }
-
     /// A builder that sets the style applied to the hint as part of the buffer
     pub fn with_style(mut self, style: Style) -> DefaultHinter {
         self.style = style;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,21 +135,12 @@
 //! use std::io;
 //! use {
 //!   nu_ansi_term::{Color, Style},
-//!   reedline::{DefaultCompleter, DefaultHinter, Reedline},
+//!   reedline::{DefaultHinter, Reedline},
 //! };
 //!
-//! let commands = vec![
-//!   "test".into(),
-//!   "hello world".into(),
-//!   "hello world reedline".into(),
-//!   "this is the reedline crate".into(),
-//! ];
-//! let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 //!
 //! let mut line_editor = Reedline::create()?.with_hinter(Box::new(
 //!   DefaultHinter::default()
-//!   .with_completer(completer) // or .with_history()
-//!   // .with_inside_line()
 //!   .with_style(Style::new().italic().fg(Color::LightGray)),
 //! ));
 //! # Ok::<(), io::Error>(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,11 +73,7 @@ fn main() -> Result<()> {
             ListCompletionHandler::default().with_completer(completer.clone()),
         ))
         .with_hinter(Box::new(
-            DefaultHinter::default()
-                .with_history()
-                // .with_completer(completer) // or .with_history()
-                // .with_inside_line()
-                .with_style(Style::new().fg(Color::DarkGray)),
+            DefaultHinter::default().with_style(Style::new().fg(Color::DarkGray)),
         ))
         .with_ansi_colors(true)
         .with_menu_completer(completer, ContextMenuInput::default());

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -77,7 +77,10 @@ impl<'prompt> PromptLines<'prompt> {
                 + self.hint
                 + self.after_cursor
         } else {
-            self.prompt_str_left.to_string() + &self.prompt_indicator + self.before_cursor
+            self.prompt_str_left.to_string()
+                + &self.prompt_indicator
+                + self.before_cursor
+                + self.after_cursor
         };
 
         let lines = input.lines().fold(0, |acc, line| {
@@ -442,13 +445,13 @@ impl Painter {
 
         self.stdout
             .queue(Print(&lines.before_cursor))?
-            .queue(SavePosition)?;
+            .queue(SavePosition)?
+            .queue(Print(&lines.after_cursor))?;
 
         if let Some(context_menu) = context_menu {
             self.print_context_menu(context_menu, lines, use_ansi_coloring)?;
         } else {
-            self.stdout
-                .queue(Print(format!("{}{}", &lines.hint, &lines.after_cursor)))?;
+            self.stdout.queue(Print(&lines.hint))?;
         }
 
         Ok(())
@@ -525,6 +528,8 @@ impl Painter {
         self.stdout.queue(SavePosition)?;
 
         if let Some(context_menu) = context_menu {
+            // TODO: Also solve the dificult problem of displaying (parts of)
+            // the content after the cursor with the completion menu
             self.print_context_menu(context_menu, lines, use_ansi_coloring)?;
         } else {
             // Selecting lines for the hint

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -74,8 +74,8 @@ impl<'prompt> PromptLines<'prompt> {
             self.prompt_str_left.to_string()
                 + &self.prompt_indicator
                 + self.before_cursor
-                + self.hint
                 + self.after_cursor
+                + self.hint
         } else {
             self.prompt_str_left.to_string()
                 + &self.prompt_indicator
@@ -535,14 +535,14 @@ impl Painter {
             // Selecting lines for the hint
             // The -1 subtraction is done because the remaining lines consider the line where the
             // cursor is located as a remaining line. That has to be removed to get the correct offset
-            // for the hint and after cursor lines
+            // for the after-cursor and hint lines
             let offset = remaining_lines.saturating_sub(1) as usize;
-            let hint_skipped = skip_buffer_lines(lines.hint, 0, Some(offset));
-            self.stdout.queue(Print(hint_skipped))?;
-
             // Selecting lines after the cursor
             let after_cursor_skipped = skip_buffer_lines(lines.after_cursor, 0, Some(offset));
             self.stdout.queue(Print(after_cursor_skipped))?;
+            // Hint lines
+            let hint_skipped = skip_buffer_lines(lines.hint, 0, Some(offset));
+            self.stdout.queue(Print(hint_skipped))?;
         }
 
         Ok(())


### PR DESCRIPTION
Focus the functionality of the `DefaultHinter` on providing fish/zsh-style history autosuggestions

Simplifies hinter and drastically reduces the number of allocations per `Hinter::handle` call

- (Show content after cursor when completing)
- Place the hint obligatory behind the line content
- Simplify hinter internals/capabilities
- Remove `HistoryCompleter` (was never pub)
- Fix doctest `Reedline::with_hinter`
- Add configurable character threshold for Hinter
