### PR TITLE
Support "token by token" hint completion

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -96,7 +96,7 @@ mod test {
         keybindings.add_binding(
             KeyModifiers::CONTROL,
             KeyCode::Char('l'),
-            ReedlineEvent::Complete,
+            ReedlineEvent::HistoryHintComplete,
         );
 
         let mut emacs = Emacs::new(keybindings);
@@ -106,7 +106,7 @@ mod test {
         });
         let result = emacs.parse_event(ctrl_l);
 
-        assert_eq!(result, ReedlineEvent::Complete);
+        assert_eq!(result, ReedlineEvent::HistoryHintComplete);
     }
 
     #[test]

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -79,7 +79,14 @@ pub fn default_emacs_keybindings() -> Keybindings {
 
     // CTRL
     kb.add_binding(KM::CONTROL, KC::Left, edit_bind(EC::MoveWordLeft));
-    kb.add_binding(KM::CONTROL, KC::Right, edit_bind(EC::MoveWordRight));
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Right,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::HistoryHintWordComplete,
+            edit_bind(EC::MoveWordRight),
+        ]),
+    );
     kb.add_binding(KM::CONTROL, KC::Delete, edit_bind(EC::DeleteWord));
     kb.add_binding(KM::CONTROL, KC::Backspace, edit_bind(EC::BackspaceWord));
     kb.add_binding(KM::CONTROL, KC::End, edit_bind(EC::MoveToEnd));
@@ -127,13 +134,27 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::CONTROL, KC::Char('t'), edit_bind(EC::SwapGraphemes));
     kb.add_binding(KM::CONTROL, KC::Char('l'), ReedlineEvent::ClearScreen);
     kb.add_binding(KM::ALT, KC::Char('b'), edit_bind(EC::MoveWordLeft));
-    kb.add_binding(KM::ALT, KC::Char('f'), edit_bind(EC::MoveWordRight));
+    kb.add_binding(
+        KM::ALT,
+        KC::Char('f'),
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::HistoryHintWordComplete,
+            edit_bind(EC::MoveWordRight),
+        ]),
+    );
     kb.add_binding(KM::ALT, KC::Char('d'), edit_bind(EC::CutWordRight));
     kb.add_binding(KM::ALT, KC::Char('u'), edit_bind(EC::UppercaseWord));
     kb.add_binding(KM::ALT, KC::Char('l'), edit_bind(EC::LowercaseWord));
     kb.add_binding(KM::ALT, KC::Char('c'), edit_bind(EC::CapitalizeChar));
     kb.add_binding(KM::ALT, KC::Left, edit_bind(EC::MoveWordLeft));
-    kb.add_binding(KM::ALT, KC::Right, edit_bind(EC::MoveWordRight));
+    kb.add_binding(
+        KM::ALT,
+        KC::Right,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::HistoryHintWordComplete,
+            edit_bind(EC::MoveWordRight),
+        ]),
+    );
     kb.add_binding(KM::ALT, KC::Delete, edit_bind(EC::DeleteWord));
     kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));
 

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -108,7 +108,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
         KM::CONTROL,
         KC::Char('f'),
         ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::Complete,
+            ReedlineEvent::HistoryHintComplete,
             ReedlineEvent::MenuRight,
             ReedlineEvent::Right,
         ]),
@@ -159,7 +159,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
         KM::NONE,
         KC::Right,
         ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::Complete,
+            ReedlineEvent::HistoryHintComplete,
             ReedlineEvent::MenuRight,
             ReedlineEvent::Right,
         ]),

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -40,7 +40,7 @@ pub fn default_vi_insert_keybindings() -> Keybindings {
         KM::NONE,
         KC::Right,
         ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::Complete,
+            ReedlineEvent::HistoryHintComplete,
             ReedlineEvent::MenuRight,
             ReedlineEvent::Right,
         ]),

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -53,6 +53,15 @@ pub fn default_vi_insert_keybindings() -> Keybindings {
 
     kb.add_binding(KM::CONTROL, KC::Char('c'), ReedlineEvent::CtrlC);
     kb.add_binding(KM::CONTROL, KC::Char('r'), ReedlineEvent::SearchHistory);
+    kb.add_binding(KM::CONTROL, KC::Left, edit_bind(EC::MoveWordLeft));
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Right,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::HistoryHintWordComplete,
+            edit_bind(EC::MoveWordRight),
+        ]),
+    );
 
     kb.add_binding(
         KM::NONE,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -517,6 +517,7 @@ impl Reedline {
             | ReedlineEvent::UntilFound(_)
             | ReedlineEvent::None
             | ReedlineEvent::Esc
+            | ReedlineEvent::HistoryHintWordComplete
             | ReedlineEvent::MenuNext
             | ReedlineEvent::MenuPrevious
             | ReedlineEvent::MenuUp
@@ -610,6 +611,20 @@ impl Reedline {
                     && !current_hint.is_empty()
                 {
                     self.run_edit_commands(&[EditCommand::InsertString(current_hint)]);
+                    self.buffer_paint(prompt)?;
+                    Ok(EventStatus::Handled)
+                } else {
+                    Ok(EventStatus::Inapplicable)
+                }
+            }
+            ReedlineEvent::HistoryHintWordComplete => {
+                let current_hint_part = self.hinter.next_hint_token();
+                if self.hints_active()
+                    && !self.context_menu.is_active()
+                    && self.editor.offset() == self.editor.get_buffer().len()
+                    && !current_hint_part.is_empty()
+                {
+                    self.run_edit_commands(&[EditCommand::InsertString(current_hint_part)]);
                     self.buffer_paint(prompt)?;
                     Ok(EventStatus::Handled)
                 } else {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -468,7 +468,7 @@ impl Reedline {
                 Ok(EventStatus::Exits(Signal::CtrlC))
             }
             ReedlineEvent::ClearScreen => Ok(EventStatus::Exits(Signal::CtrlL)),
-            ReedlineEvent::Enter | ReedlineEvent::Complete => {
+            ReedlineEvent::Enter | ReedlineEvent::HistoryHintComplete => {
                 if let Some(string) = self.history.string_at_cursor() {
                     self.editor.set_buffer(string);
                     self.editor.remember_undo_state(true);
@@ -602,8 +602,8 @@ impl Reedline {
                     Ok(EventStatus::Inapplicable)
                 }
             }
-            ReedlineEvent::Complete => {
-                let current_hint = self.hinter.current_hint();
+            ReedlineEvent::HistoryHintComplete => {
+                let current_hint = self.hinter.complete_hint();
                 if self.hints_active()
                     && !self.context_menu.is_active()
                     && self.editor.offset() == self.editor.get_buffer().len()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -609,7 +609,6 @@ impl Reedline {
                     && self.editor.offset() == self.editor.get_buffer().len()
                     && !current_hint.is_empty()
                 {
-                    self.editor.clear_to_end();
                     self.run_edit_commands(&[EditCommand::InsertString(current_hint)]);
                     self.buffer_paint(prompt)?;
                     Ok(EventStatus::Handled)

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -219,6 +219,9 @@ pub enum ReedlineEvent {
     /// Complete history hint (default in full)
     HistoryHintComplete,
 
+    /// Complete a single token/word of the history hint
+    HistoryHintWordComplete,
+
     /// Action event
     ActionHandler,
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -216,8 +216,8 @@ pub enum ReedlineEvent {
     /// Trigger context menu
     ContextMenu,
 
-    /// Completes hint
-    Complete,
+    /// Complete history hint (default in full)
+    HistoryHintComplete,
 
     /// Action event
     ActionHandler,

--- a/src/hinter.rs
+++ b/src/hinter.rs
@@ -19,6 +19,10 @@ pub trait Hinter: Send {
 
     /// Return the current hint unformatted to perform the completion of the full hint
     fn complete_hint(&self) -> String;
+
+    /// Return the first semantic token of the hint
+    /// for incremental completion
+    fn next_hint_token(&self) -> String;
 }
 
 /// A default example hinter that use the completions or the history to show a hint to the user
@@ -55,6 +59,24 @@ impl Hinter for DefaultHinter {
 
     fn complete_hint(&self) -> String {
         self.current_hint.clone()
+    }
+
+    fn next_hint_token(&self) -> String {
+        let mut reached_content = false;
+        let result: String = self
+            .current_hint
+            .chars()
+            .take_while(|c| match (c.is_whitespace(), reached_content) {
+                (true, true) => false,
+                (true, false) => true,
+                (false, true) => true,
+                (false, false) => {
+                    reached_content = true;
+                    true
+                }
+            })
+            .collect();
+        result
     }
 }
 

--- a/src/hinter.rs
+++ b/src/hinter.rs
@@ -7,6 +7,8 @@ use {
 /// Hints are often shown in-line as part of the buffer, showing the user text they can accept or ignore
 pub trait Hinter: Send {
     /// Handle the hinting duty by using the line, position, and current history
+    ///
+    /// Returns the formatted output to show the user
     fn handle(
         &mut self,
         line: &str,
@@ -15,8 +17,8 @@ pub trait Hinter: Send {
         use_ansi_coloring: bool,
     ) -> String;
 
-    /// Return the current hint being shown to the user
-    fn current_hint(&self) -> String;
+    /// Return the current hint unformatted to perform the completion of the full hint
+    fn complete_hint(&self) -> String;
 }
 
 /// A default example hinter that use the completions or the history to show a hint to the user
@@ -51,7 +53,7 @@ impl Hinter for DefaultHinter {
         }
     }
 
-    fn current_hint(&self) -> String {
+    fn complete_hint(&self) -> String {
         self.current_hint.clone()
     }
 }


### PR DESCRIPTION
Hints can now be completed partially

Keybindings: `Alt-right` `Alt-f` `Ctrl-right`

Uses whitespace as token/word boundary for now
