### PR TITLE
chronological order search

### DIFF
--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{vec_deque::Iter, HashSet, VecDeque},
+    collections::{vec_deque::Iter, VecDeque},
     fs::{File, OpenOptions},
     io::{BufRead, BufReader, BufWriter, Write},
     path::PathBuf,
@@ -121,18 +121,11 @@ impl History for FileBackedHistory {
     }
 
     fn query_entries(&self, search: &str) -> Vec<String> {
-        let mut values = self
-            .entries
-            .iter()
+        self.iter_chronologic()
+            .rev()
             .filter(|entry| entry.contains(search))
             .cloned()
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect::<Vec<String>>();
-
-        values.sort();
-
-        values
+            .collect::<Vec<String>>()
     }
 
     fn max_values(&self) -> usize {

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,7 @@ fn print_events_helper() -> Result<()> {
 fn add_menu_keybindings(keybindings: &mut Keybindings) {
     keybindings.add_binding(
         KeyModifiers::CONTROL,
-        KeyCode::Char('i'),
+        KeyCode::Char('x'),
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::Menu("history_menu".to_string()),
             ReedlineEvent::MenuPageNext,
@@ -199,7 +199,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
 
     keybindings.add_binding(
         KeyModifiers::CONTROL | KeyModifiers::SHIFT,
-        KeyCode::Char('i'),
+        KeyCode::Char('x'),
         ReedlineEvent::MenuPagePrevious,
     );
 


### PR DESCRIPTION
Change how the history filters data. The filtered values now are sorter chronologically 

Also the keybinding for the history menu is changed to match engine q