### PR TITLE
Coerce to CRLF lazily

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1050,11 +1050,7 @@ impl Reedline {
 
             let prompt_history_search = PromptHistorySearch::new(status, substring.clone());
 
-            let res_string = self
-                .history
-                .string_at_cursor()
-                .unwrap_or_default()
-                .replace("\n", "\r\n");
+            let res_string = self.history.string_at_cursor().unwrap_or_default();
 
             // Highlight matches
             let res_string = if self.use_ansi_coloring {
@@ -1110,9 +1106,6 @@ impl Reedline {
 
         // Needs to add return carriage to newlines because when not in raw mode
         // some OS don't fully return the carriage
-        let before_cursor = before_cursor.replace("\n", "\r\n");
-        let after_cursor = after_cursor.replace("\n", "\r\n");
-        let hint = hint.replace("\n", "\r\n");
 
         // Updating the working details of the active menu
         for menu in self.menus.iter_mut() {

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -402,7 +402,7 @@ impl Painter {
                     start_position,
                     self.prompt_coords.prompt_start.1,
                 ))?
-                .queue(Print(&lines.prompt_str_right))?
+                .queue(Print(&coerce_crlf(&lines.prompt_str_right)))?
                 .queue(RestorePosition)?;
         }
 
@@ -450,13 +450,14 @@ impl Painter {
                 .queue(SetForegroundColor(prompt.get_prompt_color()))?;
         }
 
-        self.stdout.queue(Print(&lines.prompt_str_left))?;
+        self.stdout
+            .queue(Print(&coerce_crlf(&lines.prompt_str_left)))?;
 
         let prompt_indicator = match menu {
             Some(menu) => menu.indicator(),
             None => &lines.prompt_indicator,
         };
-        self.stdout.queue(Print(prompt_indicator))?;
+        self.stdout.queue(Print(&coerce_crlf(prompt_indicator)))?;
 
         self.print_right_prompt(lines)?;
 
@@ -515,7 +516,7 @@ impl Painter {
         // In case the prompt is made out of multiple lines, the prompt is split by
         // lines and only the required ones are printed
         let prompt_skipped = skip_buffer_lines(&lines.prompt_str_left, extra_rows, None);
-        self.stdout.queue(Print(prompt_skipped))?;
+        self.stdout.queue(Print(&coerce_crlf(prompt_skipped)))?;
 
         if extra_rows == 0 {
             self.print_right_prompt(lines)?;
@@ -525,7 +526,7 @@ impl Painter {
         let extra_rows = extra_rows.saturating_sub(prompt_lines);
 
         let indicator_skipped = skip_buffer_lines(prompt_indicator, extra_rows, None);
-        self.stdout.queue(Print(indicator_skipped))?;
+        self.stdout.queue(Print(&coerce_crlf(indicator_skipped)))?;
 
         if use_ansi_coloring {
             self.stdout.queue(ResetColor)?;


### PR DESCRIPTION
Will only introduce a CR if LF is not part of CRLF.

Only allocates if necessary
