### PR TITLE
Polishing in the painter

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -403,7 +403,7 @@ impl Reedline {
                 if let Some(ec) = last_edit_commands {
                     reedline_events.push(ReedlineEvent::Edit(ec));
                 }
-            } else if self.animate && !self.painter.large_buffer {
+            } else if self.animate && !self.painter.exceeds_screen_size() {
                 reedline_events.push(ReedlineEvent::Repaint);
             };
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -340,7 +340,6 @@ impl Reedline {
     /// Helper implementing the logic for [`Reedline::read_line()`] to be wrapped
     /// in a `raw_mode` context.
     fn read_line_helper(&mut self, prompt: &dyn Prompt) -> Result<Signal> {
-        self.painter.init_terminal_size()?;
         self.painter.initialize_prompt_position()?;
         self.hide_hints = false;
 

--- a/src/menu/completion_menu.rs
+++ b/src/menu/completion_menu.rs
@@ -255,7 +255,7 @@ impl Menu for CompletionMenu {
         let default_width = match self.default_details.col_width {
             Some(col_width) => col_width,
             None => {
-                let col_width = painter.terminal_cols() / self.default_details.columns;
+                let col_width = painter.screen_width() / self.default_details.columns;
                 col_width as usize
             }
         };
@@ -270,7 +270,7 @@ impl Menu for CompletionMenu {
 
         // The working columns is adjusted based on possible number of columns
         // that could be fitted in the screen with the calculated column width
-        let possible_cols = painter.terminal_cols() / self.working_details.col_width as u16;
+        let possible_cols = painter.screen_width() / self.working_details.col_width as u16;
         if possible_cols > self.default_details.columns {
             self.working_details.columns = self.default_details.columns.max(1);
         } else {

--- a/src/menu/history_menu.rs
+++ b/src/menu/history_menu.rs
@@ -1,6 +1,6 @@
 use super::{Menu, MenuTextStyle};
 use crate::{
-    painter::{estimated_wrapped_line_count, Painter},
+    painter::{estimate_single_line_wraps, Painter},
     Completer, History, LineBuffer, Span,
 };
 use nu_ansi_term::{ansi::RESET, Style};
@@ -664,12 +664,12 @@ fn number_of_lines(entry: &str, max_lines: usize, terminal_columns: u16) -> u16 
         };
 
         let wrap_lines = entry.lines().take(max_lines).fold(0, |acc, line| {
-            acc + estimated_wrapped_line_count(line, terminal_columns)
+            acc + estimate_single_line_wraps(line, terminal_columns)
         });
 
         (printable_lines + wrap_lines) as u16
     } else {
-        1 + estimated_wrapped_line_count(entry, terminal_columns) as u16
+        1 + estimate_single_line_wraps(entry, terminal_columns) as u16
     };
 
     lines

--- a/src/menu/history_menu.rs
+++ b/src/menu/history_menu.rs
@@ -188,7 +188,7 @@ impl HistoryMenu {
     }
 
     fn printable_entries(&self, painter: &Painter) -> usize {
-        let available_lines = painter.terminal_rows().saturating_sub(1);
+        let available_lines = painter.screen_height().saturating_sub(1);
         let (printable_entries, _) =
             self.get_values()
                 .iter()
@@ -198,7 +198,7 @@ impl HistoryMenu {
                         None => (lines, None),
                         Some(total_lines) => {
                             let new_total_lines =
-                                total_lines + self.number_of_lines(entry, painter.terminal_cols());
+                                total_lines + self.number_of_lines(entry, painter.screen_width());
 
                             if new_total_lines < available_lines {
                                 (lines + 1, Some(new_total_lines))

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -353,7 +353,7 @@ impl Painter {
             self.stdout
                 .queue(Print(format!(" [h{}:", screen_height)))?
                 .queue(Print(format!("w{}] ", screen_width)))?
-                .queue(Print(format!("y{}] ", self.prompt_start_row)))?
+                .queue(Print(format!("y:{} ", self.prompt_start_row)))?
                 .queue(Print(format!("rm:{} ", remaining_lines)))?
                 .queue(Print(format!("re:{} ", required_lines)))?
                 .queue(Print(format!("di:{} ", cursor_distance)))?

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -224,7 +224,7 @@ pub struct Painter {
     prompt_start_row: u16,
     terminal_size: (u16, u16),
     last_required_lines: u16,
-    pub large_buffer: bool,
+    large_buffer: bool,
     debug_mode: bool,
 }
 
@@ -265,8 +265,15 @@ impl Painter {
         self.terminal_size.0
     }
 
-    pub fn remaining_lines(&self) -> u16 {
+    fn remaining_lines(&self) -> u16 {
         self.screen_height() - self.prompt_start_row
+    }
+
+    /// Check if the currently painted content exceeds the size of the screen
+    /// and thus should not be repainted without reason (disable animation
+    /// repaint)
+    pub(crate) fn exceeds_screen_size(&self) -> bool {
+        self.large_buffer
     }
 
     /// Sets the prompt origin position.

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -244,12 +244,6 @@ impl Painter {
         }
     }
 
-    /// Update the terminal size information by polling the system
-    pub(crate) fn init_terminal_size(&mut self) -> Result<()> {
-        self.terminal_size = terminal::size()?;
-        Ok(())
-    }
-
     pub(crate) fn screen_height(&self) -> u16 {
         self.terminal_size.1
     }
@@ -269,8 +263,14 @@ impl Painter {
         self.large_buffer
     }
 
-    /// Sets the prompt origin position.
+    /// Sets the prompt origin position and screen size for a new line editor
+    /// invocation
+    ///
+    /// Not to be used for resizes during a running line editor, use
+    /// [`Painter::handle_resize()`] instead
     pub(crate) fn initialize_prompt_position(&mut self) -> Result<()> {
+        // Update the terminal size
+        self.terminal_size = terminal::size()?;
         // Cursor positions are 0 based here.
         let (column, row) = cursor::position()?;
         // Assumption: if the cursor is not on the zeroth column,


### PR DESCRIPTION
- Correct allocation behavior of `coerce_crlf`
- Consolidate names to `screen_width/height`
- Simplify the `PromptCoordinate` down to the row
- Encapsulate the large buffer state readonly
- Consolidate line requirement calculion
