### PR TITLE
Add support for quick completions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,7 @@ fn main() -> Result<()> {
     let mut line_editor = Reedline::create()?
         .with_history(history)?
         .with_completer(completer)
+        .with_quick_completions(true)
         .with_highlighter(Box::new(ExampleHighlighter::new(commands)))
         .with_hinter(Box::new(
             DefaultHinter::default().with_style(Style::new().fg(Color::DarkGray)),


### PR DESCRIPTION
This adds a new configuration setting for completions that will auto-select a completion entry if the user narrows down to a single entry.

As this might surprise some users, I'm leaving it off for now. It can be configured with the builder.