### PR TITLE
[Draft] Try to have a safe simple history

### DIFF
--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -147,7 +147,7 @@ impl FileBackedHistory {
             cursor: 0,
             file: None,
             len_on_disk: 0,
-            truncate_file: true,
+            truncate_file: false,
             query: HistoryNavigationQuery::Normal(LineBuffer::default()),
         }
     }


### PR DESCRIPTION
- Cover history file ops with tests
- Use the appending mode when possible

End goal: Fix #221 and have a file based solution that should work for most users, if not wanting to use a sqlite solution

Draft pushed now to see if CI accepts filesystem tests
