### PR TITLE
Make appending and truncating history file thread safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +125,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fd-lock"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcef756dea9cf3db5ce73759cf0467330427a786b47711b8d6c97620d718ceb9"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,10 +186,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ef6787e7f0faedc040f95716bdd0e62bcfcf4ba93da053b62dea2691c13864"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95f5690fef754d905294c56f7ac815836f2513af966aa47f2e07ac79be07827f"
 
 [[package]]
 name = "lock_api"
@@ -401,6 +454,7 @@ dependencies = [
  "chrono",
  "clipboard",
  "crossterm",
+ "fd-lock",
  "nu-ansi-term",
  "pretty_assertions",
  "rstest",
@@ -442,6 +496,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cee647393af53c750e15dcbf7781cdd2e550b246bde76e46c326e7ea3c73773"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -654,6 +722,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
 
 [[package]]
 name = "x11-clipboard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ unicode-width = "0.1.9"
 strip-ansi-escapes = "0.1.1"
 strum = "0.23"
 strum_macros = "0.23"
+fd-lock = "3.0.3"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -2,8 +2,9 @@ use super::{base::HistoryNavigationQuery, History};
 use crate::core_editor::LineBuffer;
 use std::{
     collections::{vec_deque::Iter, VecDeque},
-    fs::{File, OpenOptions},
-    io::{BufRead, BufReader, BufWriter, Write},
+    fs::OpenOptions,
+    io::{BufRead, BufReader, BufWriter, Seek, SeekFrom, Write},
+    ops::{Deref, DerefMut},
     path::PathBuf,
 };
 
@@ -23,8 +24,7 @@ pub struct FileBackedHistory {
     entries: VecDeque<String>,
     cursor: usize, // If cursor == entries.len() outside history browsing
     file: Option<PathBuf>,
-    len_on_disk: usize,  // Keep track what was previously written to disk
-    truncate_file: bool, // as long as the file would not exceed capacity we can use appending writes
+    len_on_disk: usize, // Keep track what was previously written to disk
     query: HistoryNavigationQuery,
 }
 
@@ -62,7 +62,6 @@ impl History for FileBackedHistory {
                 // before adding a new one.
                 self.entries.pop_front();
                 self.len_on_disk = self.len_on_disk.saturating_sub(1);
-                self.truncate_file = true;
             }
             self.entries.push_back(entry.to_string());
         }
@@ -147,7 +146,6 @@ impl FileBackedHistory {
             cursor: 0,
             file: None,
             len_on_disk: 0,
-            truncate_file: true,
             query: HistoryNavigationQuery::Normal(LineBuffer::default()),
         }
     }
@@ -166,51 +164,8 @@ impl FileBackedHistory {
             std::fs::create_dir_all(base_dir)?;
         }
         hist.file = Some(file);
-        hist.load_file()?;
+        hist.sync()?;
         Ok(hist)
-    }
-
-    /// Loads history from the associated newline separated file
-    ///
-    /// Expects the [`History`] to be empty.
-    ///
-    ///
-    /// **Side effect:** creates not yet existing file.
-    fn load_file(&mut self) -> std::io::Result<()> {
-        let f = File::open(
-            self.file
-                .as_ref()
-                .expect("History::load_file should only be called if a filename is set"),
-        );
-        assert!(
-            self.entries.is_empty(),
-            "History currently designed to load file once in the constructor"
-        );
-        match f {
-            Err(e) => match e.kind() {
-                std::io::ErrorKind::NotFound => {
-                    File::create(self.file.as_ref().unwrap())?;
-                    Ok(())
-                }
-                _ => Err(e),
-            },
-            Ok(file) => {
-                let reader = BufReader::new(file);
-                let mut from_file = reader
-                    .lines()
-                    .map(|o| o.map(|i| decode_entry(&i)))
-                    .collect::<Result<VecDeque<String>, _>>()?;
-                let from_file = if from_file.len() > self.capacity {
-                    from_file.split_off(from_file.len() - self.capacity)
-                } else {
-                    from_file
-                };
-                self.len_on_disk = from_file.len();
-                self.entries = from_file;
-                self.reset_cursor();
-                Ok(())
-            }
-        }
     }
 
     fn back_with_criteria(&mut self, criteria: &dyn Fn(&str) -> bool) {
@@ -249,32 +204,65 @@ impl FileBackedHistory {
     /// Writes unwritten history contents to disk.
     ///
     /// If file would exceed `capacity` truncates the oldest entries.
-    fn flush(&mut self) -> std::io::Result<()> {
-        if self.file.is_none() {
-            return Ok(());
+    pub fn sync(&mut self) -> std::io::Result<()> {
+        if let Some(fname) = &self.file {
+            // The unwritten entries
+            let own_entries = self.entries.range(self.len_on_disk..);
+
+            let mut f_lock = fd_lock::RwLock::new(
+                OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .read(true)
+                    .open(fname)?,
+            );
+            let mut writer_guard = f_lock.write()?;
+            let (mut foreign_entries, truncate) = {
+                let reader = BufReader::new(writer_guard.deref());
+                let mut from_file = reader
+                    .lines()
+                    .map(|o| o.map(|i| decode_entry(&i)))
+                    .collect::<Result<VecDeque<_>, _>>()?;
+                if from_file.len() + own_entries.len() > self.capacity {
+                    (
+                        from_file.split_off(from_file.len() - (self.capacity - own_entries.len())),
+                        true,
+                    )
+                } else {
+                    (from_file, false)
+                }
+            };
+
+            {
+                let mut writer = BufWriter::new(writer_guard.deref_mut());
+                if truncate {
+                    writer.seek(SeekFrom::Start(0))?;
+
+                    for line in &foreign_entries {
+                        writer.write_all(encode_entry(line).as_bytes())?;
+                        writer.write_all("\n".as_bytes())?;
+                    }
+                } else {
+                    writer.seek(SeekFrom::End(0))?;
+                }
+                for line in own_entries {
+                    writer.write_all(encode_entry(line).as_bytes())?;
+                    writer.write_all("\n".as_bytes())?;
+                }
+                writer.flush()?;
+            }
+            if truncate {
+                let file = writer_guard.deref_mut();
+                let file_len = file.stream_position()?;
+                file.set_len(file_len)?;
+            }
+
+            let own_entries = self.entries.drain(self.len_on_disk..);
+            foreign_entries.extend(own_entries);
+            self.entries = foreign_entries;
+
+            self.len_on_disk = self.entries.len();
         }
-        let file = if self.truncate_file {
-            // Rewrite the whole file if we truncated the old output
-            self.len_on_disk = 0;
-            // TODO: make this file race safe if multiple instances are used.
-            OpenOptions::new()
-                .write(true)
-                .truncate(true)
-                .open(self.file.as_ref().unwrap())?
-        } else {
-            // If the file is not beyond capacity just append new stuff
-            // (use the stored self.len_on_disk as offset)
-            OpenOptions::new()
-                .append(true)
-                .open(self.file.as_ref().unwrap())?
-        };
-        let mut writer = BufWriter::new(file);
-        for line in self.entries.range(self.len_on_disk..) {
-            writer.write_all(encode_entry(line).as_bytes())?;
-            writer.write_all("\n".as_bytes())?;
-        }
-        writer.flush()?;
-        self.len_on_disk = self.entries.len();
 
         Ok(())
     }
@@ -288,7 +276,7 @@ impl FileBackedHistory {
 impl Drop for FileBackedHistory {
     /// On drop the content of the [`History`] will be written to the file if specified via [`FileBackedHistory::with_file()`].
     fn drop(&mut self) {
-        let _res = self.flush();
+        let _res = self.sync();
     }
 }
 


### PR DESCRIPTION
Add safe `sync` method to `History`

This method both reads from the file and writes local additions. Is safe
when multiple `History` instances try to truncate the history file on
disk.

To avoid race conditions on the file uses the `fd_lock` crate for file
advisory locks. (Inspiration for that thanks to rustyline: https://github.com/kkawakam/rustyline/blob/master/src/history.rs)



Fixes #221

- Cover history file ops with tests
- Add test for conflicting writes that should truncate
- Add safe `sync` method to `History`
- Test `FileBackedHistory` for threadsafety
