### PR TITLE
Menu events

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ mod validator;
 pub use validator::{DefaultValidator, ValidationResult, Validator};
 
 mod menu;
-pub use menu::{CompletionMenu, HistoryMenu, Menu};
+pub use menu::{CompletionMenu, HistoryMenu, Menu, MenuEvent};
 
 mod internal;
 pub use internal::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> Result<()> {
     let mut line_editor = Reedline::create()?
         .with_history(history)?
         .with_completer(completer)
-        .with_quick_completions(true)
+        .with_quick_completions(false)
         .with_highlighter(Box::new(ExampleHighlighter::new(commands)))
         .with_hinter(Box::new(
             DefaultHinter::default().with_style(Style::new().fg(Color::DarkGray)),

--- a/src/menu/completion_menu.rs
+++ b/src/menu/completion_menu.rs
@@ -1,4 +1,4 @@
-use super::{Menu, MenuTextStyle};
+use super::{Menu, MenuEvent, MenuTextStyle};
 use crate::{painter::Painter, Completer, History, LineBuffer, Span};
 use nu_ansi_term::{ansi::RESET, Style};
 
@@ -57,8 +57,8 @@ pub struct CompletionMenu {
     row_pos: u16,
     /// Menu marker when active
     marker: String,
-    /// When edit true the values need to be updated
-    edit: bool,
+    /// Event sent to the menu
+    event: Option<MenuEvent>,
 }
 
 impl Default for CompletionMenu {
@@ -73,7 +73,7 @@ impl Default for CompletionMenu {
             col_pos: 0,
             row_pos: 0,
             marker: "| ".to_string(),
-            edit: false,
+            event: None,
         }
     }
 }
@@ -113,172 +113,6 @@ impl CompletionMenu {
     pub fn with_marker(mut self, marker: String) -> Self {
         self.marker = marker;
         self
-    }
-
-    /// Calculates how many rows the Menu will use
-    fn get_rows(&self) -> u16 {
-        let rows = self.get_values().len() as u16 / self.get_cols();
-        rows + 1
-    }
-
-    /// Reset menu position
-    fn reset_position(&mut self) {
-        self.col_pos = 0;
-        self.row_pos = 0;
-        self.edit = false;
-    }
-
-    fn no_records_msg(&self, use_ansi_coloring: bool) -> String {
-        let msg = "NO RECORDS FOUND";
-        if use_ansi_coloring {
-            format!(
-                "{}{}{}",
-                self.color.selected_text_style.prefix(),
-                msg,
-                RESET
-            )
-        } else {
-            msg.to_string()
-        }
-    }
-
-    /// Creates default string that represents one line from a menu
-    fn create_string(
-        &self,
-        line: &str,
-        index: usize,
-        column: u16,
-        empty_space: usize,
-        use_ansi_coloring: bool,
-    ) -> String {
-        if use_ansi_coloring {
-            format!(
-                "{}{}{}{:empty$}{}",
-                self.text_style(index),
-                &line,
-                RESET,
-                "",
-                self.end_of_line(column),
-                empty = empty_space
-            )
-        } else {
-            // If no ansi coloring is found, then the selection word is
-            // the line in uppercase
-            let line_str = if index == self.position() {
-                format!(">{}", line.to_uppercase())
-            } else {
-                line.to_string()
-            };
-
-            // Final string with formatting
-            format!(
-                "{:width$}{}",
-                line_str,
-                self.end_of_line(column),
-                width = self.get_width()
-            )
-        }
-    }
-}
-
-impl Menu for CompletionMenu {
-    /// Menu name
-    fn name(&self) -> &str {
-        "completion_menu"
-    }
-
-    /// Menu indicator
-    fn indicator(&self) -> &str {
-        self.marker.as_str()
-    }
-
-    /// Deactivates context menu
-    fn is_active(&self) -> bool {
-        self.active
-    }
-
-    /// Activates context menu
-    fn activate(&mut self) {
-        self.active = true;
-        self.reset_position();
-    }
-
-    /// Deactivates context menu
-    fn deactivate(&mut self) {
-        self.active = false
-    }
-
-    /// Updates menu values
-    fn update_values(
-        &mut self,
-        line_buffer: &mut LineBuffer,
-        _history: &dyn History,
-        completer: &dyn Completer,
-    ) {
-        // If there is a new line character in the line buffer, the completer
-        // doesn't calculate the suggested values correctly. This happens when
-        // editing a multiline buffer.
-        // Also, by replacing the new line character with a space, the insert
-        // position is maintain in the line buffer.
-        let trimmed_buffer = line_buffer.get_buffer().replace("\n", " ");
-        self.values = completer.complete(trimmed_buffer.as_str(), line_buffer.offset());
-        self.reset_position();
-    }
-
-    /// The working details for the menu changes based on the size of the lines
-    /// collected from the completer
-    fn update_working_details(
-        &mut self,
-        line_buffer: &mut LineBuffer,
-        history: &dyn History,
-        completer: &dyn Completer,
-        painter: &Painter,
-    ) {
-        if self.edit {
-            self.reset_position();
-            self.update_values(line_buffer, history, completer);
-            self.edit = false;
-        }
-
-        let max_width = self.get_values().iter().fold(0, |acc, (_, string)| {
-            let str_len = string.len() + self.working_details.col_padding;
-            if str_len > acc {
-                str_len
-            } else {
-                acc
-            }
-        });
-
-        // If no default width if found, then the total screen width is used to estimate
-        // the column width based on the default number of columns
-        let default_width = match self.default_details.col_width {
-            Some(col_width) => col_width,
-            None => {
-                let col_width = painter.screen_width() / self.default_details.columns;
-                col_width as usize
-            }
-        };
-
-        // Adjusting the working width of the column based the max line width found
-        // in the menu values
-        if max_width > default_width {
-            self.working_details.col_width = max_width;
-        } else {
-            self.working_details.col_width = default_width;
-        };
-
-        // The working columns is adjusted based on possible number of columns
-        // that could be fitted in the screen with the calculated column width
-        let possible_cols = painter.screen_width() / self.working_details.col_width as u16;
-        if possible_cols > self.default_details.columns {
-            self.working_details.columns = self.default_details.columns.max(1);
-        } else {
-            self.working_details.columns = possible_cols;
-        }
-    }
-
-    fn edit_line_buffer(&mut self) {
-        self.edit = true
     }
 
     /// Move menu cursor to the next element
@@ -330,6 +164,284 @@ impl Menu for CompletionMenu {
         }
     }
 
+    /// Move menu cursor up
+    fn move_up(&mut self) {
+        self.row_pos = if let Some(new_row) = self.row_pos.checked_sub(1) {
+            new_row
+        } else {
+            let new_row = self.get_rows().saturating_sub(1);
+            let index = new_row * self.get_cols() + self.col_pos;
+            if index >= self.values.len() as u16 {
+                0
+            } else {
+                new_row
+            }
+        }
+    }
+
+    /// Move menu cursor left
+    fn move_down(&mut self) {
+        let new_row = self.row_pos + 1;
+        self.row_pos = if new_row >= self.get_rows() {
+            0
+        } else {
+            let index = new_row * self.get_cols() + self.col_pos;
+            if index >= self.values.len() as u16 {
+                0
+            } else {
+                new_row
+            }
+        }
+    }
+
+    /// Move menu cursor left
+    fn move_left(&mut self) {
+        self.col_pos = if let Some(row) = self.col_pos.checked_sub(1) {
+            row
+        } else if self.index() == self.values.len() - 1 {
+            0
+        } else {
+            self.get_cols().saturating_sub(1)
+        }
+    }
+
+    /// Move menu cursor element
+    fn move_right(&mut self) {
+        let new_col = self.col_pos + 1;
+        self.col_pos = if new_col >= self.get_cols() || self.index() + 1 > self.values.len() - 1 {
+            0
+        } else {
+            new_col
+        }
+    }
+
+    /// Menu index based on column and row position
+    fn index(&self) -> usize {
+        let index = self.row_pos * self.get_cols() + self.col_pos;
+        index as usize
+    }
+
+    /// Get selected value from the menu
+    fn get_value(&self) -> Option<(Span, String)> {
+        self.get_values().get(self.index()).cloned()
+    }
+
+    /// Calculates how many rows the Menu will use
+    fn get_rows(&self) -> u16 {
+        let rows = self.get_values().len() as u16 / self.get_cols();
+
+        if self.get_values().len() as u16 % self.get_cols() != 0 {
+            rows + 1
+        } else {
+            rows
+        }
+    }
+
+    /// Returns working details col width
+    fn get_width(&self) -> usize {
+        self.working_details.col_width
+    }
+
+    /// Reset menu position
+    fn reset_position(&mut self) {
+        self.col_pos = 0;
+        self.row_pos = 0;
+    }
+
+    fn no_records_msg(&self, use_ansi_coloring: bool) -> String {
+        let msg = "NO RECORDS FOUND";
+        if use_ansi_coloring {
+            format!(
+                "{}{}{}",
+                self.color.selected_text_style.prefix(),
+                msg,
+                RESET
+            )
+        } else {
+            msg.to_string()
+        }
+    }
+
+    /// Returns working details columns
+    fn get_cols(&self) -> u16 {
+        self.working_details.columns.max(1)
+    }
+
+    /// End of line for menu
+    fn end_of_line(&self, column: u16) -> &str {
+        if column == self.get_cols().saturating_sub(1) {
+            "\r\n"
+        } else {
+            ""
+        }
+    }
+
+    /// Text style for menu
+    fn text_style(&self, index: usize) -> String {
+        if index == self.index() {
+            self.color.selected_text_style.prefix().to_string()
+        } else {
+            self.color.text_style.prefix().to_string()
+        }
+    }
+
+    /// Creates default string that represents one line from a menu
+    fn create_string(
+        &self,
+        line: &str,
+        index: usize,
+        column: u16,
+        empty_space: usize,
+        use_ansi_coloring: bool,
+    ) -> String {
+        if use_ansi_coloring {
+            format!(
+                "{}{}{}{:empty$}{}",
+                self.text_style(index),
+                &line,
+                RESET,
+                "",
+                self.end_of_line(column),
+                empty = empty_space
+            )
+        } else {
+            // If no ansi coloring is found, then the selection word is
+            // the line in uppercase
+            let line_str = if index == self.index() {
+                format!(">{}", line.to_uppercase())
+            } else {
+                line.to_string()
+            };
+
+            // Final string with formatting
+            format!(
+                "{:width$}{}",
+                line_str,
+                self.end_of_line(column),
+                width = self.get_width()
+            )
+        }
+    }
+}
+
+impl Menu for CompletionMenu {
+    /// Menu name
+    fn name(&self) -> &str {
+        "completion_menu"
+    }
+
+    /// Menu indicator
+    fn indicator(&self) -> &str {
+        self.marker.as_str()
+    }
+
+    /// Deactivates context menu
+    fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// Selects what type of event happened with the menu
+    fn menu_event(&mut self, event: MenuEvent) {
+        if let MenuEvent::Activate(_) = event {
+            self.active = true;
+        }
+
+        self.event = Some(event)
+    }
+
+    /// Updates menu values
+    fn update_values(
+        &mut self,
+        line_buffer: &mut LineBuffer,
+        _history: &dyn History,
+        completer: &dyn Completer,
+    ) {
+        // If there is a new line character in the line buffer, the completer
+        // doesn't calculate the suggested values correctly. This happens when
+        // editing a multiline buffer.
+        // Also, by replacing the new line character with a space, the insert
+        // position is maintain in the line buffer.
+        let trimmed_buffer = line_buffer.get_buffer().replace("\n", " ");
+        self.values = completer.complete(trimmed_buffer.as_str(), line_buffer.offset());
+        self.reset_position();
+    }
+
+    /// The working details for the menu changes based on the size of the lines
+    /// collected from the completer
+    fn update_working_details(
+        &mut self,
+        line_buffer: &mut LineBuffer,
+        history: &dyn History,
+        completer: &dyn Completer,
+        painter: &Painter,
+    ) {
+        if let Some(event) = self.event.take() {
+            match event {
+                MenuEvent::Activate(updated) => {
+                    self.active = true;
+                    self.reset_position();
+
+                    if !updated {
+                        self.update_values(line_buffer, history, completer);
+                    }
+                }
+                MenuEvent::Deactivate => self.active = false,
+                MenuEvent::Edit(updated) => {
+                    self.reset_position();
+
+                    if !updated {
+                        self.update_values(line_buffer, history, completer);
+                    }
+                }
+                MenuEvent::NextElement => self.move_next(),
+                MenuEvent::PreviousElement => self.move_previous(),
+                MenuEvent::MoveUp => self.move_up(),
+                MenuEvent::MoveDown => self.move_down(),
+                MenuEvent::MoveLeft => self.move_left(),
+                MenuEvent::MoveRight => self.move_right(),
+                MenuEvent::PreviousPage | MenuEvent::NextPage => {
+                    // The completion menu doest have the concept of pages, yet
+                }
+            }
+
+            let max_width = self.get_values().iter().fold(0, |acc, (_, string)| {
+                let str_len = string.len() + self.working_details.col_padding;
+                if str_len > acc {
+                    str_len
+                } else {
+                    acc
+                }
+            });
+
+            // If no default width is found, then the total screen width is used to estimate
+            // the column width based on the default number of columns
+            let default_width = match self.default_details.col_width {
+                Some(col_width) => col_width,
+                None => {
+                    let col_width = painter.screen_width() / self.default_details.columns;
+                    col_width as usize
+                }
+            };
+
+            // Adjusting the working width of the column based the max line width found
+            // in the menu values
+            if max_width > default_width {
+                self.working_details.col_width = max_width;
+            } else {
+                self.working_details.col_width = default_width;
+            };
+
+            // The working columns is adjusted based on possible number of columns
+            // that could be fitted in the screen with the calculated column width
+            let possible_cols = painter.screen_width() / self.working_details.col_width as u16;
+            if possible_cols > self.default_details.columns {
+                self.working_details.columns = self.default_details.columns.max(1);
+            } else {
+                self.working_details.columns = possible_cols;
+            }
+        }
+    }
+
     /// The buffer gets replaced in the Span location
     fn replace_in_buffer(&self, line_buffer: &mut LineBuffer) {
         if let Some((span, value)) = self.get_value() {
@@ -341,81 +453,14 @@ impl Menu for CompletionMenu {
         }
     }
 
-    /// Move menu cursor up
-    fn move_up(&mut self) {
-        self.row_pos = if let Some(row) = self.row_pos.checked_sub(1) {
-            row
-        } else {
-            self.get_rows().saturating_sub(1)
-        }
-    }
-
-    /// Move menu cursor left
-    fn move_down(&mut self) {
-        let new_row = self.row_pos + 1;
-        self.row_pos = if new_row >= self.get_rows().saturating_sub(1) {
-            0
-        } else {
-            new_row
-        }
-    }
-
-    /// Move menu cursor left
-    fn move_left(&mut self) {
-        self.col_pos = if let Some(row) = self.col_pos.checked_sub(1) {
-            row
-        } else {
-            self.get_cols().saturating_sub(1)
-        }
-    }
-
-    /// Move menu cursor element
-    fn move_right(&mut self) {
-        let new_col = self.col_pos + 1;
-        self.col_pos = if new_col >= self.get_cols() {
-            0
-        } else {
-            new_col
-        }
-    }
-
-    /// Text style for menu
-    fn text_style(&self, index: usize) -> String {
-        if index == self.position() {
-            self.color.selected_text_style.prefix().to_string()
-        } else {
-            self.color.text_style.prefix().to_string()
-        }
-    }
-
     /// Minimum rows that should be displayed by the menu
     fn min_rows(&self) -> u16 {
         self.get_rows().min(self.min_rows)
     }
 
-    /// Row position
-    fn row_pos(&self) -> u16 {
-        self.row_pos
-    }
-
-    /// Column position
-    fn col_pos(&self) -> u16 {
-        self.col_pos
-    }
-
     /// Gets values from filler that will be displayed in the menu
     fn get_values(&self) -> &[(Span, String)] {
         &self.values
-    }
-
-    /// Returns working details columns
-    fn get_cols(&self) -> u16 {
-        self.working_details.columns.max(1)
-    }
-
-    /// Returns working details col width
-    fn get_width(&self) -> usize {
-        self.working_details.col_width
     }
 
     fn menu_required_lines(&self, _terminal_columns: u16) -> u16 {
@@ -428,8 +473,8 @@ impl Menu for CompletionMenu {
         } else {
             // The skip values represent the number of lines that should be skipped
             // while printing the menu
-            let skip_values = if self.row_pos() >= available_lines {
-                let skip_lines = self.row_pos().saturating_sub(available_lines) + 1;
+            let skip_values = if self.row_pos >= available_lines {
+                let skip_lines = self.row_pos.saturating_sub(available_lines) + 1;
                 (skip_lines * self.get_cols()) as usize
             } else {
                 0

--- a/src/menu/history_menu.rs
+++ b/src/menu/history_menu.rs
@@ -78,7 +78,7 @@ impl Default for HistoryMenu {
     fn default() -> Self {
         Self {
             color: MenuTextStyle::default(),
-            page_size: 2,
+            page_size: 10,
             row_char: ':',
             active: false,
             values: Vec::new(),

--- a/src/menu/history_menu.rs
+++ b/src/menu/history_menu.rs
@@ -308,7 +308,7 @@ impl HistoryMenu {
             };
 
             // Final string with formatting
-            format!("{:width$}{}", line_str, self.end_of_line(), width = 50)
+            format!("{}{}", line_str, self.end_of_line())
         }
     }
 }

--- a/src/menu/history_menu.rs
+++ b/src/menu/history_menu.rs
@@ -286,19 +286,17 @@ impl HistoryMenu {
         line: &str,
         index: usize,
         row_number: &str,
-        empty_space: usize,
         use_ansi_coloring: bool,
     ) -> String {
         if use_ansi_coloring {
             format!(
-                "{}{}{}{}{:empty$}{}",
+                "{}{}{}{}{}{}",
                 row_number,
                 self.text_style(index),
                 &line,
                 RESET,
                 "",
                 self.end_of_line(),
-                empty = empty_space
             )
         } else {
             // If no ansi coloring is found, then the selection word is
@@ -532,8 +530,6 @@ impl Menu for HistoryMenu {
                     .take(page.size)
                     .enumerate()
                     .map(|(index, (_, line))| {
-                        let empty_space = 50;
-
                         // Final string with colors
                         let line = if line.lines().count() > self.max_lines as usize {
                             let lines = line
@@ -549,13 +545,7 @@ impl Menu for HistoryMenu {
 
                         let row_number = format!("{}: ", index + values_before_page);
 
-                        self.create_string(
-                            &line,
-                            index,
-                            &row_number,
-                            empty_space,
-                            use_ansi_coloring,
-                        )
+                        self.create_string(&line, index, &row_number, use_ansi_coloring)
                     })
                     .collect::<String>();
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -252,7 +252,7 @@ impl Painter {
         self.terminal_size.0
     }
 
-    fn remaining_lines(&self) -> u16 {
+    pub fn remaining_lines(&self) -> u16 {
         self.screen_height() - self.prompt_start_row
     }
 


### PR DESCRIPTION
The menu trait has being simplified to work with an event enum. These events remove the need to update twice when the `quick_completions` is true.

closes #301 and fixes some navigation issues with completion_menu