### PR TITLE
Fix one item completions

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -561,7 +561,8 @@ impl Reedline {
                             );
 
                             if menu.get_values().len() == 1 {
-                                return self.handle_editor_event(prompt, ReedlineEvent::Enter);
+                                menu.replace_in_buffer(self.editor.line_buffer());
+                                return Ok(EventStatus::Handled);
                             }
                         }
 


### PR DESCRIPTION
Fixes the case where you have a single item in your completion list.

Previously, it would hit enter immediately without finishing the completion.

Now, it will fill out the completion and allow you to continue typing.