### PR TITLE
Add event to keybind a command in the hosting app

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -499,6 +499,10 @@ impl Reedline {
                 self.input_mode = InputMode::Regular;
                 Ok(EventStatus::Handled)
             }
+            ReedlineEvent::ExecuteHostCommand(host_command) => {
+                // TODO: Decide if we need to do something special to have a nicer painter state on the next go
+                Ok(EventStatus::Exits(Signal::Success(host_command)))
+            }
             ReedlineEvent::Edit(commands) => {
                 self.run_history_commands(&commands);
                 Ok(EventStatus::Handled)
@@ -717,6 +721,10 @@ impl Reedline {
 
                     Ok(EventStatus::Handled)
                 }
+            }
+            ReedlineEvent::ExecuteHostCommand(host_command) => {
+                // TODO: Decide if we need to do something special to have a nicer painter state on the next go
+                Ok(EventStatus::Exits(Signal::Success(host_command)))
             }
             ReedlineEvent::Edit(commands) => {
                 self.run_edit_commands(&commands);

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -316,6 +316,9 @@ pub enum ReedlineEvent {
 
     /// Move to the previous history page
     MenuPagePrevious,
+
+    /// Way to bind the execution of a whole command (directly returning from [`crate::Reedline::read_line()`]) to a keybinding
+    ExecuteHostCommand(String),
 }
 
 pub(crate) enum EventStatus {


### PR DESCRIPTION
Instead of affecting the editor this lets `Reedline::read_line` return
with `Ok(Signal::Success)` containing a predefined command to be executed or
consumed by the app using `reedline` as a line editor.
The state of the editor is preserved. After the command execution in a
REPL the host would call `Reedline::read_line` again and the line editor
would be redrawn on the next free line.
Command will not be added to the history in this config.

Open for debate if this should not expect printed output from the
command and try to redraw on top or reset some state.

Addresses #312
