### PR TITLE
Provide cursor position for highlighting

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1018,7 +1018,7 @@ impl Reedline {
             // Highlight matches
             let res_string = if self.use_ansi_coloring {
                 let match_highlighter = SimpleMatchHighlighter::new(substring);
-                let styled = match_highlighter.highlight(&res_string);
+                let styled = match_highlighter.highlight(&res_string, 0);
                 styled.render_simple()
             } else {
                 res_string
@@ -1049,7 +1049,7 @@ impl Reedline {
 
         let (before_cursor, after_cursor) = self
             .highlighter
-            .highlight(buffer_to_paint)
+            .highlight(buffer_to_paint, cursor_position_in_buffer)
             .render_around_insertion_point(
                 cursor_position_in_buffer,
                 prompt.render_prompt_multiline_indicator().borrow(),

--- a/src/highlighter/example.rs
+++ b/src/highlighter/example.rs
@@ -15,7 +15,7 @@ pub struct ExampleHighlighter {
 }
 
 impl Highlighter for ExampleHighlighter {
-    fn highlight(&self, line: &str) -> StyledText {
+    fn highlight(&self, line: &str, _cursor: usize) -> StyledText {
         let mut styled_text = StyledText::new();
 
         if self

--- a/src/highlighter/mod.rs
+++ b/src/highlighter/mod.rs
@@ -9,5 +9,7 @@ pub use simple_match::SimpleMatchHighlighter;
 /// return a `StyledText` object, which represents the contents of the original line as styled strings
 pub trait Highlighter: Send {
     /// The action that will handle the current buffer as a line and return the corresponding `StyledText` for the buffer
-    fn highlight(&self, line: &str) -> StyledText;
+    ///
+    /// Cursor position as byte offsets in the string
+    fn highlight(&self, line: &str, cursor: usize) -> StyledText;
 }

--- a/src/highlighter/simple_match.rs
+++ b/src/highlighter/simple_match.rs
@@ -25,7 +25,7 @@ impl Default for SimpleMatchHighlighter {
 }
 
 impl Highlighter for SimpleMatchHighlighter {
-    fn highlight(&self, line: &str) -> StyledText {
+    fn highlight(&self, line: &str, _cursor: usize) -> StyledText {
         let mut styled_text = StyledText::new();
         if self.query.is_empty() {
             styled_text.push((self.neutral_style, line.to_owned()));


### PR DESCRIPTION
Changes the `Highlighter` trait to include the position of the cursor in
the buffer. This allows it to make cursor aware highlighting such as
highlighting matching braces or code blocks

Prerequisite to address nushell/nushell#4325
