### PR TITLE
Use chars in `str::replace` where applicable

### DIFF
--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -38,7 +38,7 @@ impl Default for FileBackedHistory {
 }
 
 fn encode_entry(s: &str) -> String {
-    s.replace("\n", NEWLINE_ESCAPE)
+    s.replace('\n', NEWLINE_ESCAPE)
 }
 
 fn decode_entry(s: &str) -> String {

--- a/src/menu/completion_menu.rs
+++ b/src/menu/completion_menu.rs
@@ -365,7 +365,7 @@ impl Menu for CompletionMenu {
         // editing a multiline buffer.
         // Also, by replacing the new line character with a space, the insert
         // position is maintain in the line buffer.
-        let trimmed_buffer = line_buffer.get_buffer().replace("\n", " ");
+        let trimmed_buffer = line_buffer.get_buffer().replace('\n', " ");
         self.values = completer.complete(trimmed_buffer.as_str(), line_buffer.offset());
         self.reset_position();
     }

--- a/src/menu/history_menu.rs
+++ b/src/menu/history_menu.rs
@@ -540,7 +540,7 @@ impl Menu for HistoryMenu {
 
                             lines + "..."
                         } else {
-                            line.replace("\n", &format!("\r\n{}", self.multiline_marker))
+                            line.replace('\n', &format!("\r\n{}", self.multiline_marker))
                         };
 
                         let row_number = format!("{}: ", index + values_before_page);


### PR DESCRIPTION
Fixes ci fail due to new clippy lint in rust 1.59
