### PR TITLE
Better crossterm fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,8 @@ dependencies = [
 [[package]]
 name = "crossterm"
 version = "0.23.0"
-source = "git+https://github.com/crossterm-rs/crossterm.git?rev=e920d0cfd7819752b050ace40471af6f6529904c#e920d0cfd7819752b050ace40471af6f6529904c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b75a27dc8d220f1f8521ea69cd55a34d720a200ebb3a624d9aa19193d3b432"
 dependencies = [
  "bitflags",
  "crossterm_winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,8 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
+version = "0.23.0"
+source = "git+https://github.com/crossterm-rs/crossterm.git?rev=e920d0cfd7819752b050ace40471af6f6529904c#e920d0cfd7819752b050ace40471af6f6529904c"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -162,7 +161,7 @@ checksum = "fcef756dea9cf3db5ce73759cf0467330427a786b47711b8d6c97620d718ceb9"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys",
+ "windows-sys 0.30.0",
 ]
 
 [[package]]
@@ -337,27 +336,25 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-sys 0.32.0",
 ]
 
 [[package]]
@@ -681,11 +678,24 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.30.0",
+ "windows_i686_gnu 0.30.0",
+ "windows_i686_msvc 0.30.0",
+ "windows_x86_64_gnu 0.30.0",
+ "windows_x86_64_msvc 0.30.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
 ]
 
 [[package]]
@@ -695,10 +705,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -707,16 +729,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "x11-clipboard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 chrono = "0.4.19"
 clipboard = { version = "0.5.0", optional = true }
-crossterm = { git = "https://github.com/crossterm-rs/crossterm.git", rev = "e920d0cfd7819752b050ace40471af6f6529904c", features = ["serde"] }
+crossterm = { version = "0.23.0", features = ["serde"] }
 nu-ansi-term = "0.42.0"
 serde = { version = "1.0", features = ["derive"] }
 unicode-segmentation = "1.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 chrono = "0.4.19"
 clipboard = { version = "0.5.0", optional = true }
-crossterm = { version = "0.22.1", features = ["serde"] }
+crossterm = { git = "https://github.com/crossterm-rs/crossterm.git", rev = "e920d0cfd7819752b050ace40471af6f6529904c", features = ["serde"] }
 nu-ansi-term = "0.42.0"
 serde = { version = "1.0", features = ["derive"] }
 unicode-segmentation = "1.9.0"

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -87,18 +87,24 @@ impl EditMode for Emacs {
                     // Mixed modifiers are used by non american keyboards that have extra
                     // keys like 'alt gr'. Keep this in mind if in the future there are
                     // cases where an event is not being captured
-                    if modifier == KeyModifiers::SHIFT {
-                        let char = c.to_ascii_uppercase();
-                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(char)])
-                    } else if modifier == KeyModifiers::NONE
+                    let c = c.to_ascii_lowercase();
+
+                    if modifier == KeyModifiers::NONE
+                        || modifier == KeyModifiers::SHIFT
                         || modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
                         || modifier
                             == KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
                     {
-                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
+                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(
+                            if modifier == KeyModifiers::SHIFT {
+                                c.to_ascii_uppercase()
+                            } else {
+                                c
+                            },
+                        )])
                     } else {
                         self.keybindings
-                            .find_binding(modifier, code)
+                            .find_binding(modifier, KeyCode::Char(c))
                             .unwrap_or(ReedlineEvent::None)
                     }
                 }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -66,13 +66,14 @@ impl EditMode for Vi {
                         }
                     }
 
+                    let c = c.to_ascii_lowercase();
+
                     if modifier == KeyModifiers::NONE || modifier == KeyModifiers::SHIFT {
-                        let char = if let KeyModifiers::SHIFT = modifier {
+                        self.cache.push(if modifier == KeyModifiers::SHIFT {
                             c.to_ascii_uppercase()
                         } else {
                             c
-                        };
-                        self.cache.push(char);
+                        });
 
                         let res = parse(&mut self.cache.iter().peekable());
 
@@ -97,7 +98,7 @@ impl EditMode for Vi {
                         event
                     } else {
                         self.normal_keybindings
-                            .find_binding(modifiers, code)
+                            .find_binding(modifiers, KeyCode::Char(c))
                             .unwrap_or(ReedlineEvent::None)
                     }
                 }
@@ -110,18 +111,25 @@ impl EditMode for Vi {
                     // Mixed modifiers are used by non american keyboards that have extra
                     // keys like 'alt gr'. Keep this in mind if in the future there are
                     // cases where an event is not being captured
-                    if modifier == KeyModifiers::SHIFT {
-                        let char = c.to_ascii_uppercase();
-                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(char)])
-                    } else if modifier == KeyModifiers::NONE
+
+                    let c = c.to_ascii_lowercase();
+
+                    if modifier == KeyModifiers::NONE
+                        || modifier == KeyModifiers::SHIFT
                         || modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
                         || modifier
                             == KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
                     {
-                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(c)])
+                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(
+                            if modifier == KeyModifiers::SHIFT {
+                                c.to_ascii_uppercase()
+                            } else {
+                                c
+                            },
+                        )])
                     } else {
                         self.insert_keybindings
-                            .find_binding(modifier, code)
+                            .find_binding(modifier, KeyCode::Char(c))
                             .unwrap_or(ReedlineEvent::None)
                     }
                 }


### PR DESCRIPTION
Instead of moving to crossterm git, use the latest crossterm but normalise the key events to be lowercase.

For times when we need the uppercase character, detect the SHIFT modifier, and then uppercase based on that.