### PR TITLE
History improved

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -37,12 +37,14 @@ impl Editor {
             EditCommand::MoveToLineStart => self.line_buffer.move_to_line_start(),
             EditCommand::MoveToEnd => self.line_buffer.move_to_end(),
             EditCommand::MoveToLineEnd => self.line_buffer.move_to_line_end(),
+            EditCommand::MoveToPosition(pos) => self.line_buffer.set_insertion_point(*pos),
             EditCommand::MoveLeft => self.line_buffer.move_left(),
             EditCommand::MoveRight => self.line_buffer.move_right(),
             EditCommand::MoveWordLeft => self.line_buffer.move_word_left(),
             EditCommand::MoveWordRight => self.line_buffer.move_word_right(),
             EditCommand::InsertChar(c) => self.insert_char(*c),
             EditCommand::InsertString(str) => self.line_buffer.insert_str(str),
+            EditCommand::ReplaceChars(n_chars, str) => self.replace_chars(*n_chars, str),
             EditCommand::Backspace => self.line_buffer.delete_left_grapheme(),
             EditCommand::Delete => self.line_buffer.delete_right_grapheme(),
             EditCommand::BackspaceWord => self.line_buffer.delete_word_left(),
@@ -392,6 +394,14 @@ impl Editor {
                 }
             }
         }
+    }
+
+    fn replace_chars(&mut self, n_chars: usize, string: &str) {
+        for _ in 0..n_chars {
+            self.line_buffer.delete_right_grapheme();
+        }
+
+        self.line_buffer.insert_str(string);
     }
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -114,7 +114,7 @@ pub struct Reedline {
     // Engine Menus
     menus: Vec<Box<dyn Menu>>,
 
-    // replaced history
+    // Keeps track if a history entry was introduced using the ! (bang) command
     replaced_history: bool,
 }
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -43,11 +43,17 @@ pub enum EditCommand {
     /// Move one word to the right
     MoveWordRight,
 
+    /// Move to position
+    MoveToPosition(usize),
+
     /// Insert a character at the current insertion point
     InsertChar(char),
 
     /// Insert a string at the current insertion point
     InsertString(String),
+
+    /// Repace characters with string
+    ReplaceChars(usize, String),
 
     /// Backspace delete from the current insertion point
     Backspace,
@@ -150,6 +156,7 @@ impl EditCommand {
             | EditCommand::MoveToEnd
             | EditCommand::MoveToLineStart
             | EditCommand::MoveToLineEnd
+            | EditCommand::MoveToPosition(_)
             | EditCommand::MoveLeft
             | EditCommand::MoveRight
             | EditCommand::MoveWordLeft
@@ -166,6 +173,7 @@ impl EditCommand {
             EditCommand::Backspace
             | EditCommand::Delete
             | EditCommand::InsertString(_)
+            | EditCommand::ReplaceChars(_, _)
             | EditCommand::BackspaceWord
             | EditCommand::DeleteWord
             | EditCommand::Clear


### PR DESCRIPTION
Improvements on the history commands:
- The `!!` can be undone
- The `!10` will select the entry number 10 chronologically (matches history command)
- Values from history menu can be inserted in the prompt 
![Animation3](https://user-images.githubusercontent.com/6942205/156903846-55406c5b-e8e6-46e6-a14f-6dd09cace5be.gif)
