### PR TITLE
can partially complete case insensitive

### DIFF
--- a/src/menu/completion_menu.rs
+++ b/src/menu/completion_menu.rs
@@ -367,8 +367,14 @@ impl Menu for CompletionMenu {
             if !matching.is_empty() {
                 line_buffer.replace(span.start..span.end, matching);
 
-                let mut offset = line_buffer.offset();
-                offset += matching.len() - (span.end - span.start);
+                let offset = if matching.len() < (span.end - span.start) {
+                    line_buffer
+                        .offset()
+                        .saturating_sub((span.end - span.start) - matching.len())
+                } else {
+                    line_buffer.offset() + matching.len() - (span.end - span.start)
+                };
+
                 line_buffer.set_insertion_point(offset);
 
                 // The values need to be updated because the spans need to be

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -188,7 +188,12 @@ fn find_common_string(values: &[(Span, String)]) -> (Option<&(Span, String)>, Op
                 first_string
                     .chars()
                     .zip(value.chars())
-                    .position(|(lhs, rhs)| lhs != rhs)
+                    .position(|(mut lhs, mut rhs)| {
+                        lhs.make_ascii_lowercase();
+                        rhs.make_ascii_lowercase();
+
+                        lhs != rhs
+                    })
                     .map(|new_index| match index {
                         Some(index) => {
                             if index <= new_index {


### PR DESCRIPTION
Corrects a bug when trying to adjust position for escaped `\`. This was calculating the wrong offset producing a panic.
It also adds a case insensitive comparison when partially completing