### PR TITLE
bump to 0.3.1 and nu-ansi-term to 0.45.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280affd8593c03f90633b7305cee7a3b55ddab9fbad95041a39bda689f7b64f7"
+checksum = "c7bca0d33a384280d1563b97f49cb95303df9fa22588739a04b7d8015c1ccd50"
 dependencies = [
  "overload",
  "winapi",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reedline"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["JT <jonathan.d.turner@gmail.com>"]
 edition = "2021"
 description = "A readline-like crate for CLI text input"
@@ -19,7 +19,7 @@ path = "src/main.rs"
 chrono = "0.4.19"
 clipboard = { version = "0.5.0", optional = true }
 crossterm = { version = "0.23.0", features = ["serde"] }
-nu-ansi-term = "0.45.0"
+nu-ansi-term = "0.45.1"
 serde = { version = "1.0", features = ["derive"] }
 unicode-segmentation = "1.9.0"
 unicode-width = "0.1.9"


### PR DESCRIPTION
This updates reedline to 0.3.1 so we can use nu-ansi-term 0.45.1 in nushell