### PR TITLE
Fix `menu::menu_functions::find_common_string`

### DIFF
--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -348,3 +348,40 @@ impl CompletionNode {
         completions
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn default_completer_with_non_ansi() {
+        use super::*;
+
+        let mut completions = DefaultCompleter::default();
+        completions.insert(
+            vec!["ｎｕｓｈｅｌｌ", "ｎｕｌｌ", "ｎｕｍｂｅｒ"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        );
+
+        assert_eq!(
+            completions.complete("ｎ", 3),
+            vec![
+                Suggestion {
+                    value: "ｎｕｌｌ".into(),
+                    description: None,
+                    span: Span { start: 0, end: 3 },
+                },
+                Suggestion {
+                    value: "ｎｕｍｂｅｒ".into(),
+                    description: None,
+                    span: Span { start: 0, end: 3 },
+                },
+                Suggestion {
+                    value: "ｎｕｓｈｅｌｌ".into(),
+                    description: None,
+                    span: Span { start: 0, end: 3 },
+                },
+            ]
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,8 @@ fn main() -> Result<()> {
         "abaaac".into(),
         "abaaaxyc".into(),
         "abaaarabc".into(),
+        "こんにちは世界".into(),
+        "こんばんは世界".into(),
     ];
 
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));


### PR DESCRIPTION
Fix `menu::menu_functions::find_common_string` returning wrong index when given non-ASCII strings. This should fix https://github.com/nushell/nushell/issues/4971