### PR TITLE
Vim normal keybingings

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -102,14 +102,14 @@ impl EditMode for Emacs {
                     // Mixed modifiers are used by non american keyboards that have extra
                     // keys like 'alt gr'. Keep this in mind if in the future there are
                     // cases where an event is not being captured
-                    let c = c.to_ascii_lowercase();
+                    let c = match modifier {
+                        KeyModifiers::NONE => c,
+                        _ => c.to_ascii_lowercase(),
+                    };
 
-                    if modifier == KeyModifiers::NONE
-                        || modifier == KeyModifiers::SHIFT
-                        || modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
-                        || modifier
-                            == KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
-                    {
+                    if let Some(event) = self.keybindings.find_binding(modifier, KeyCode::Char(c)) {
+                        event
+                    } else {
                         ReedlineEvent::Edit(vec![EditCommand::InsertChar(
                             if modifier == KeyModifiers::SHIFT {
                                 c.to_ascii_uppercase()
@@ -117,10 +117,6 @@ impl EditMode for Emacs {
                                 c
                             },
                         )])
-                    } else {
-                        self.keybindings
-                            .find_binding(modifier, KeyCode::Char(c))
-                            .unwrap_or(ReedlineEvent::None)
                     }
                 }
                 (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -107,9 +107,12 @@ impl EditMode for Emacs {
                         _ => c.to_ascii_lowercase(),
                     };
 
-                    if let Some(event) = self.keybindings.find_binding(modifier, KeyCode::Char(c)) {
-                        event
-                    } else {
+                    if modifier == KeyModifiers::NONE
+                        || modifier == KeyModifiers::SHIFT
+                        || modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
+                        || modifier
+                            == KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
+                    {
                         ReedlineEvent::Edit(vec![EditCommand::InsertChar(
                             if modifier == KeyModifiers::SHIFT {
                                 c.to_ascii_uppercase()
@@ -117,6 +120,10 @@ impl EditMode for Emacs {
                                 c
                             },
                         )])
+                    } else {
+                        self.keybindings
+                            .find_binding(modifier, KeyCode::Char(c))
+                            .unwrap_or(ReedlineEvent::None)
                     }
                 }
                 (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -55,6 +55,10 @@ where
             let _ = input.next();
             Some(Command::MoveToLineStart)
         }
+        Some('^') => {
+            let _ = input.next();
+            Some(Command::MoveToLineStart)
+        }
         Some('$') => {
             let _ = input.next();
             Some(Command::MoveToLineEnd)

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -116,12 +116,12 @@ impl EditMode for Vi {
                         _ => c.to_ascii_lowercase(),
                     };
 
-                    if let Some(event) = self
-                        .insert_keybindings
-                        .find_binding(modifier, KeyCode::Char(c))
+                    if modifier == KeyModifiers::NONE
+                        || modifier == KeyModifiers::SHIFT
+                        || modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
+                        || modifier
+                            == KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
                     {
-                        event
-                    } else {
                         ReedlineEvent::Edit(vec![EditCommand::InsertChar(
                             if modifier == KeyModifiers::SHIFT {
                                 c.to_ascii_uppercase()
@@ -129,6 +129,10 @@ impl EditMode for Vi {
                                 c
                             },
                         )])
+                    } else {
+                        self.insert_keybindings
+                            .find_binding(modifier, KeyCode::Char(c))
+                            .unwrap_or(ReedlineEvent::None)
                     }
                 }
                 (_, KeyModifiers::NONE, KeyCode::Esc) => {


### PR DESCRIPTION
Corrects a bug where it wasnt possible to define keybindings for normal mode for NONE or SHIFT modifiers.
It also captures uppercase when using caps