### PR TITLE
Add event to synchronize history explicitly

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -549,6 +549,13 @@ impl Reedline {
                 }
                 Ok(EventStatus::Handled)
             }
+            ReedlineEvent::SynchronizeHistory => {
+                // this will internally also reset the cursor
+                self.history.sync()?;
+                // continue with the search
+                self.history.back();
+                Ok(EventStatus::Handled)
+            }
             // TODO: Check if events should be handled
             ReedlineEvent::Right
             | ReedlineEvent::Left
@@ -762,6 +769,10 @@ impl Reedline {
             ReedlineEvent::ExecuteHostCommand(host_command) => {
                 // TODO: Decide if we need to do something special to have a nicer painter state on the next go
                 Ok(EventStatus::Exits(Signal::Success(host_command)))
+            }
+            ReedlineEvent::SynchronizeHistory => {
+                self.history.sync()?;
+                Ok(EventStatus::Handled)
             }
             ReedlineEvent::Edit(commands) => {
                 self.run_edit_commands(&commands);

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -327,6 +327,9 @@ pub enum ReedlineEvent {
 
     /// Way to bind the execution of a whole command (directly returning from [`crate::Reedline::read_line()`]) to a keybinding
     ExecuteHostCommand(String),
+
+    /// Explicitly sync the history for concurrent reedline sessions
+    SynchronizeHistory,
 }
 
 pub(crate) enum EventStatus {

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -46,4 +46,10 @@ pub trait History: Send {
 
     /// Max number of values that can be queried from the history
     fn max_values(&self) -> usize;
+
+    /// Synchronize the state of the history with the backing filesystem or database if available
+    fn sync(&mut self) -> std::io::Result<()>;
+
+    /// Reset the browsing cursor back outside the history, does not affect the [`HistoryNavigationQuery`]
+    fn reset_cursor(&mut self);
 }

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -128,6 +128,79 @@ impl History for FileBackedHistory {
     fn max_values(&self) -> usize {
         self.entries.len()
     }
+
+    /// Writes unwritten history contents to disk.
+    ///
+    /// If file would exceed `capacity` truncates the oldest entries.
+    fn sync(&mut self) -> std::io::Result<()> {
+        if let Some(fname) = &self.file {
+            // The unwritten entries
+            let own_entries = self.entries.range(self.len_on_disk..);
+
+            let mut f_lock = fd_lock::RwLock::new(
+                OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .read(true)
+                    .open(fname)?,
+            );
+            let mut writer_guard = f_lock.write()?;
+            let (mut foreign_entries, truncate) = {
+                let reader = BufReader::new(writer_guard.deref());
+                let mut from_file = reader
+                    .lines()
+                    .map(|o| o.map(|i| decode_entry(&i)))
+                    .collect::<Result<VecDeque<_>, _>>()?;
+                if from_file.len() + own_entries.len() > self.capacity {
+                    (
+                        from_file.split_off(from_file.len() - (self.capacity - own_entries.len())),
+                        true,
+                    )
+                } else {
+                    (from_file, false)
+                }
+            };
+
+            {
+                let mut writer = BufWriter::new(writer_guard.deref_mut());
+                if truncate {
+                    writer.seek(SeekFrom::Start(0))?;
+
+                    for line in &foreign_entries {
+                        writer.write_all(encode_entry(line).as_bytes())?;
+                        writer.write_all("\n".as_bytes())?;
+                    }
+                } else {
+                    writer.seek(SeekFrom::End(0))?;
+                }
+                for line in own_entries {
+                    writer.write_all(encode_entry(line).as_bytes())?;
+                    writer.write_all("\n".as_bytes())?;
+                }
+                writer.flush()?;
+            }
+            if truncate {
+                let file = writer_guard.deref_mut();
+                let file_len = file.stream_position()?;
+                file.set_len(file_len)?;
+            }
+
+            let own_entries = self.entries.drain(self.len_on_disk..);
+            foreign_entries.extend(own_entries);
+            self.entries = foreign_entries;
+
+            self.len_on_disk = self.entries.len();
+        }
+
+        self.reset_cursor();
+
+        Ok(())
+    }
+
+    /// Reset the internal browsing cursor
+    fn reset_cursor(&mut self) {
+        self.cursor = self.entries.len();
+    }
 }
 
 impl FileBackedHistory {
@@ -199,77 +272,6 @@ impl FileBackedHistory {
         } else {
             self.reset_cursor();
         }
-    }
-
-    /// Writes unwritten history contents to disk.
-    ///
-    /// If file would exceed `capacity` truncates the oldest entries.
-    pub fn sync(&mut self) -> std::io::Result<()> {
-        if let Some(fname) = &self.file {
-            // The unwritten entries
-            let own_entries = self.entries.range(self.len_on_disk..);
-
-            let mut f_lock = fd_lock::RwLock::new(
-                OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .read(true)
-                    .open(fname)?,
-            );
-            let mut writer_guard = f_lock.write()?;
-            let (mut foreign_entries, truncate) = {
-                let reader = BufReader::new(writer_guard.deref());
-                let mut from_file = reader
-                    .lines()
-                    .map(|o| o.map(|i| decode_entry(&i)))
-                    .collect::<Result<VecDeque<_>, _>>()?;
-                if from_file.len() + own_entries.len() > self.capacity {
-                    (
-                        from_file.split_off(from_file.len() - (self.capacity - own_entries.len())),
-                        true,
-                    )
-                } else {
-                    (from_file, false)
-                }
-            };
-
-            {
-                let mut writer = BufWriter::new(writer_guard.deref_mut());
-                if truncate {
-                    writer.seek(SeekFrom::Start(0))?;
-
-                    for line in &foreign_entries {
-                        writer.write_all(encode_entry(line).as_bytes())?;
-                        writer.write_all("\n".as_bytes())?;
-                    }
-                } else {
-                    writer.seek(SeekFrom::End(0))?;
-                }
-                for line in own_entries {
-                    writer.write_all(encode_entry(line).as_bytes())?;
-                    writer.write_all("\n".as_bytes())?;
-                }
-                writer.flush()?;
-            }
-            if truncate {
-                let file = writer_guard.deref_mut();
-                let file_len = file.stream_position()?;
-                file.set_len(file_len)?;
-            }
-
-            let own_entries = self.entries.drain(self.len_on_disk..);
-            foreign_entries.extend(own_entries);
-            self.entries = foreign_entries;
-
-            self.len_on_disk = self.entries.len();
-        }
-
-        Ok(())
-    }
-
-    /// Reset the internal browsing cursor
-    fn reset_cursor(&mut self) {
-        self.cursor = self.entries.len();
     }
 }
 


### PR DESCRIPTION
This can be used to only synchronize the history with a keybinding

Resets the traditional Ctrl-R search. leaves the basic up/down
navigation in the previous state. TODO: Check effects on menu
