### PR TITLE
API break: remove unnecessary fallibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ use reedline::{DefaultPrompt, Reedline, Signal};
 use std::io;
 
 fn main() -> io::Result<()> {
-    let mut line_editor = Reedline::create()?;
+    let mut line_editor = Reedline::create();
     let prompt = DefaultPrompt::default();
 
     loop {
-        let sig = line_editor.read_line(&prompt).unwrap();
+        let sig = line_editor.read_line(&prompt)?;
         match sig {
             Signal::Success(buffer) => {
                 println!("We processed: {}", buffer);
@@ -81,7 +81,7 @@ keybindings.add_binding(
   vec![EditCommand::BackspaceWord],
 );
 
-let mut line_editor = Reedline::create()?.with_keybindings(keybindings);
+let mut line_editor = Reedline::create().with_keybindings(keybindings);
 ```
 
 ## Integrate with `History`
@@ -95,9 +95,8 @@ let history = Box::new(
   FileBackedHistory::with_file(5, "history.txt".into())
     .expect("Error configuring history with file"),
 );
-let mut line_editor = Reedline::create()?
-  .with_history(history)
-  .expect("Error configuring reedline with history");
+let mut line_editor = Reedline::create()
+  .with_history(history);
 ```
 
 ### Integrate with custom syntax `Highlighter`
@@ -114,7 +113,7 @@ let commands = vec![
   "this is the reedline crate".into(),
 ];
 let mut line_editor =
-Reedline::create()?.with_highlighter(Box::new(ExampleHighlighter::new(commands)));
+Reedline::create().with_highlighter(Box::new(ExampleHighlighter::new(commands)));
 ```
 
 ### Integrate with custom tab completion
@@ -134,7 +133,7 @@ let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2)
 // Use the interactive menu to select options from the completer
 let completion_menu = Box::new(CompletionMenu::default());
 
-let mut line_editor = Reedline::create()?.with_completer(completer).with_menu(completion_menu);
+let mut line_editor = Reedline::create().with_completer(completer).with_menu(completion_menu);
 ```
 
 ### Integrate with `Hinter` for fish-style history autosuggestions
@@ -151,7 +150,7 @@ use {
   reedline::{DefaultHinter, Reedline},
 };
 
-let mut line_editor = Reedline::create()?.with_hinter(Box::new(
+let mut line_editor = Reedline::create().with_hinter(Box::new(
   DefaultHinter::default()
   .with_style(Style::new().italic().fg(Color::LightGray)),
 ));
@@ -166,7 +165,7 @@ use reedline::{DefaultValidator, Reedline};
 
 let validator = Box::new(DefaultValidator);
 
-let mut line_editor = Reedline::create()?.with_validator(validator);
+let mut line_editor = Reedline::create().with_validator(validator);
 ```
 
 ### Integrate with custom Edit Mode
@@ -176,7 +175,7 @@ let mut line_editor = Reedline::create()?.with_validator(validator);
 
 use reedline::{EditMode, Reedline};
 
-let mut line_editor = Reedline::create()?.with_edit_mode(
+let mut line_editor = Reedline::create().with_edit_mode(
   EditMode::ViNormal, // or EditMode::Emacs or EditMode::ViInsert
 );
 ```

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -20,7 +20,7 @@ use std::{
 /// ];
 /// let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 ///
-/// let mut line_editor = Reedline::create().unwrap().with_completer(completer);
+/// let mut line_editor = Reedline::create().with_completer(completer);
 /// ```
 #[derive(Debug, Clone)]
 pub struct DefaultCompleter {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -59,9 +59,8 @@ enum InputMode {
 ///
 /// ## Example usage
 /// ```no_run
-/// use std::io;
 /// use reedline::{Reedline, Signal, DefaultPrompt};
-/// let mut line_editor = Reedline::create()?;
+/// let mut line_editor = Reedline::create();
 /// let prompt = DefaultPrompt::default();
 ///
 /// let out = line_editor.read_line(&prompt).unwrap();
@@ -74,7 +73,6 @@ enum InputMode {
 ///
 ///    }
 /// }
-/// # Ok::<(), io::Error>(())
 /// ```
 pub struct Reedline {
     editor: Editor,
@@ -163,17 +161,15 @@ impl Reedline {
     /// //Cargo.toml
     /// //[dependencies]
     /// //nu-ansi-term = "*"
-    /// use std::io;
     /// use {
     ///     nu_ansi_term::{Color, Style},
     ///     reedline::{DefaultHinter, Reedline},
     /// };
     ///
-    /// let mut line_editor = Reedline::create()?.with_hinter(Box::new(
+    /// let mut line_editor = Reedline::create().with_hinter(Box::new(
     ///     DefaultHinter::default()
     ///     .with_style(Style::new().italic().fg(Color::LightGray)),
     /// ));
-    /// # Ok::<(), io::Error>(())
     /// ```
     #[must_use]
     pub fn with_hinter(mut self, hinter: Box<dyn Hinter>) -> Self {
@@ -186,7 +182,6 @@ impl Reedline {
     /// ```rust,no_run
     /// // Create a reedline object with tab completions support
     ///
-    /// use std::io;
     /// use reedline::{DefaultCompleter, Reedline};
     ///
     /// let commands = vec![
@@ -197,8 +192,7 @@ impl Reedline {
     /// ];
     /// let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
     ///
-    /// let mut line_editor = Reedline::create()?.with_completer(completer);
-    /// # Ok::<(), io::Error>(())
+    /// let mut line_editor = Reedline::create().with_completer(completer);
     /// ```
     #[must_use]
     pub fn with_completer(mut self, completer: Box<dyn Completer>) -> Self {
@@ -243,7 +237,6 @@ impl Reedline {
     /// ```rust,no_run
     /// // Create a reedline object with highlighter support
     ///
-    /// use std::io;
     /// use reedline::{ExampleHighlighter, Reedline};
     ///
     /// let commands = vec![
@@ -253,8 +246,7 @@ impl Reedline {
     ///   "this is the reedline crate".into(),
     /// ];
     /// let mut line_editor =
-    /// Reedline::create()?.with_highlighter(Box::new(ExampleHighlighter::new(commands)));
-    /// # Ok::<(), io::Error>(())
+    /// Reedline::create().with_highlighter(Box::new(ExampleHighlighter::new(commands)));
     /// ```
     #[must_use]
     pub fn with_highlighter(mut self, highlighter: Box<dyn Highlighter>) -> Self {
@@ -267,17 +259,14 @@ impl Reedline {
     /// ```rust,no_run
     /// // Create a reedline object with history support, including history size limits
     ///
-    /// use std::io;
     /// use reedline::{FileBackedHistory, Reedline};
     ///
     /// let history = Box::new(
     /// FileBackedHistory::with_file(5, "history.txt".into())
     ///     .expect("Error configuring history with file"),
     /// );
-    /// let mut line_editor = Reedline::create()?
-    ///     .with_history(history)
-    ///     .expect("Error configuring reedline with history");
-    /// # Ok::<(), io::Error>(())
+    /// let mut line_editor = Reedline::create()
+    ///     .with_history(history);
     /// ```
     #[must_use]
     pub fn with_history(mut self, history: Box<dyn History>) -> Self {
@@ -290,12 +279,10 @@ impl Reedline {
     /// ```rust,no_run
     /// // Create a reedline object with validator support
     ///
-    /// use std::io;
     /// use reedline::{DefaultValidator, Reedline};
     ///
     /// let mut line_editor =
-    /// Reedline::create()?.with_validator(Box::new(DefaultValidator));
-    /// # Ok::<(), io::Error>(())
+    /// Reedline::create().with_validator(Box::new(DefaultValidator));
     /// ```
     #[must_use]
     pub fn with_validator(mut self, validator: Box<dyn Validator>) -> Self {
@@ -1204,5 +1191,5 @@ impl Reedline {
 #[test]
 fn thread_safe() {
     fn f<S: Send>(_: S) {}
-    f(Reedline::create().unwrap());
+    f(Reedline::create());
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -127,7 +127,8 @@ impl Drop for Reedline {
 
 impl Reedline {
     /// Create a new [`Reedline`] engine with a local [`History`] that is not synchronized to a file.
-    pub fn create() -> io::Result<Reedline> {
+    #[must_use]
+    pub fn create() -> Self {
         let history = Box::new(FileBackedHistory::default());
         let painter = Painter::new(std::io::BufWriter::new(std::io::stderr()));
         let buffer_highlighter = Box::new(ExampleHighlighter::default());
@@ -136,7 +137,7 @@ impl Reedline {
         let validator = Box::new(DefaultValidator);
         let edit_mode = Box::new(Emacs::default());
 
-        let reedline = Reedline {
+        Reedline {
             editor: Editor::default(),
             history,
             input_mode: InputMode::Regular,
@@ -153,9 +154,7 @@ impl Reedline {
             animate: false,
             use_ansi_coloring: true,
             menus: Vec::new(),
-        };
-
-        Ok(reedline)
+        }
     }
 
     /// A builder to include a [`Hinter`] in your instance of the Reedline engine
@@ -280,10 +279,10 @@ impl Reedline {
     ///     .expect("Error configuring reedline with history");
     /// # Ok::<(), io::Error>(())
     /// ```
-    pub fn with_history(mut self, history: Box<dyn History>) -> std::io::Result<Reedline> {
+    #[must_use]
+    pub fn with_history(mut self, history: Box<dyn History>) -> Self {
         self.history = history;
-
-        Ok(self)
+        self
     }
 
     /// A builder that configures the validator for your instance of the Reedline engine

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,9 @@
 //! ```rust,no_run
 //! // Create a default reedline object to handle user input
 //!
-//! # use std::io;
 //! use reedline::{DefaultPrompt, Reedline, Signal};
 //!
-//!  let mut line_editor = Reedline::create()?;
+//!  let mut line_editor = Reedline::create();
 //!  let prompt = DefaultPrompt::default();
 //!
 //!  loop {
@@ -37,7 +36,6 @@
 //!          }
 //!      }
 //!  }
-//! # Ok::<(), io::Error>(())
 //! ```
 //! ## Integrate with custom keybindings
 //!
@@ -48,7 +46,6 @@
 //! //    [dependencies]
 //! //    crossterm = "*"
 //!
-//! # use std::io;
 //! use {
 //!   crossterm::event::{KeyCode, KeyModifiers},
 //!   reedline::{default_emacs_keybindings, EditCommand, Reedline, Emacs, ReedlineEvent},
@@ -62,8 +59,7 @@
 //! );
 //! let edit_mode = Box::new(Emacs::new(keybindings));
 //!
-//! let mut line_editor = Reedline::create()?.with_edit_mode(edit_mode);
-//! # Ok::<(), io::Error>(())
+//! let mut line_editor = Reedline::create().with_edit_mode(edit_mode);
 //! ```
 //!
 //! ## Integrate with [`History`]
@@ -71,17 +67,14 @@
 //! ```rust,no_run
 //! // Create a reedline object with history support, including history size limits
 //!
-//! # use std::io;
 //! use reedline::{FileBackedHistory, Reedline};
 //!
 //! let history = Box::new(
 //!     FileBackedHistory::with_file(5, "history.txt".into())
 //!         .expect("Error configuring history with file"),
 //! );
-//! let mut line_editor = Reedline::create()?
-//!     .with_history(history)
-//!     .expect("Error configuring reedline with history");
-//! # Ok::<(), io::Error>(())
+//! let mut line_editor = Reedline::create()
+//!     .with_history(history);
 //! ```
 //!
 //! ## Integrate with custom syntax [`Highlighter`]
@@ -89,7 +82,6 @@
 //! ```rust,no_run
 //! // Create a reedline object with highlighter support
 //!
-//! # use std::io;
 //! use reedline::{ExampleHighlighter, Reedline};
 //!
 //! let commands = vec![
@@ -99,8 +91,7 @@
 //!   "this is the reedline crate".into(),
 //! ];
 //! let mut line_editor =
-//! Reedline::create()?.with_highlighter(Box::new(ExampleHighlighter::new(commands)));
-//! # Ok::<(), io::Error>(())
+//! Reedline::create().with_highlighter(Box::new(ExampleHighlighter::new(commands)));
 //! ```
 //!
 //! ## Integrate with custom tab completion
@@ -108,7 +99,6 @@
 //! ```rust,no_run
 //! // Create a reedline object with tab completions support
 //!
-//! # use std::io;
 //! use reedline::{DefaultCompleter, Reedline, CompletionMenu};
 //!
 //! let commands = vec![
@@ -121,8 +111,7 @@
 //! // Use the interactive menu to select options from the completer
 //! let completion_menu = Box::new(CompletionMenu::default());
 //!
-//! let mut line_editor = Reedline::create()?.with_completer(completer).with_menu(completion_menu, None);
-//! # Ok::<(), io::Error>(())
+//! let mut line_editor = Reedline::create().with_completer(completer).with_menu(completion_menu, None);
 //! ```
 //!
 //! ## Integrate with [`Hinter`] for fish-style history autosuggestions
@@ -134,18 +123,16 @@
 //! //    [dependencies]
 //! //    nu-ansi-term = "*"
 //!
-//! # use std::io;
 //! use {
 //!   nu_ansi_term::{Color, Style},
 //!   reedline::{DefaultHinter, Reedline},
 //! };
 //!
 //!
-//! let mut line_editor = Reedline::create()?.with_hinter(Box::new(
+//! let mut line_editor = Reedline::create().with_hinter(Box::new(
 //!   DefaultHinter::default()
 //!   .with_style(Style::new().italic().fg(Color::LightGray)),
 //! ));
-//! # Ok::<(), io::Error>(())
 //! ```
 //!
 //! ## Are we prompt yet? (Development status)

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,8 +67,8 @@ fn main() -> Result<()> {
 
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 
-    let mut line_editor = Reedline::create()?
-        .with_history(history)?
+    let mut line_editor = Reedline::create()
+        .with_history(history)
         .with_completer(completer)
         .with_quick_completions(true)
         .with_partial_completions(true)


### PR DESCRIPTION
The fallible std::io::Results were originally introduced for the history
file but the critical points are completely separated from the builder
pattern now.

Makes the public API nicer
