### PR TITLE
Edit stack

### DIFF
--- a/src/core_editor/edit_stack.rs
+++ b/src/core_editor/edit_stack.rs
@@ -1,0 +1,144 @@
+/// This outlines the operations (interface) that any data strcuture will need to obey to be useful
+/// to the core_editor as undo/redo stack
+pub trait EditStack<T>: Send
+where
+    T: Default,
+    T: Clone,
+    T: Send,
+{
+    /// Go back one point in the undo stack.
+    /// If present on first edit do nothing
+    fn undo(&mut self) -> &T;
+
+    /// Go forward one point in the undo stack.
+    /// If present on the last edit do nothing
+    fn redo(&mut self) -> &T;
+
+    /// Insert a new entry to the undo stack.
+    /// NOTE: (IMP): If we have hit undo a few times then discard all the other values that come
+    /// after the current point
+    fn insert(&mut self, value: T);
+
+    /// Reset the stack to the initial state
+    fn reset(&mut self);
+
+    /// Return the entry currently being pointed to
+    fn current(&mut self) -> &T;
+
+    /// List out all the entries on the undo stack
+    /// Mostly used for debugging. Might remove this one
+    fn edits<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a>;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct BasicEditStack<T> {
+    internal_list: Vec<T>,
+    index: usize,
+}
+
+impl<T> BasicEditStack<T> {
+    pub fn new() -> Self
+    where
+        T: Default,
+    {
+        BasicEditStack {
+            internal_list: vec![T::default()],
+            index: 0,
+        }
+    }
+}
+
+impl<T> EditStack<T> for BasicEditStack<T>
+where
+    T: Default,
+    T: Clone,
+    T: Send,
+{
+    fn undo(&mut self) -> &T {
+        self.index = if self.index == 0 { 0 } else { self.index - 1 };
+        &self.internal_list[self.index]
+    }
+
+    fn redo(&mut self) -> &T {
+        self.index = if self.index == self.internal_list.len() - 1 {
+            self.index
+        } else {
+            self.index + 1
+        };
+        &self.internal_list[self.index]
+    }
+
+    fn insert(&mut self, value: T) {
+        if self.index < self.internal_list.len() - 1 {
+            self.internal_list.resize_with(self.index + 1, || {
+                panic!("Impossible state reached: Bug in UndoStack logic")
+            });
+        }
+        self.internal_list.push(value);
+        self.index += 1;
+    }
+
+    fn reset(&mut self) {
+        self.index = 0;
+        self.internal_list = vec![T::default()];
+    }
+
+    fn edits<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a> {
+        Box::new(self.internal_list.iter().take(self.index + 1))
+    }
+
+    fn current(&mut self) -> &T {
+        &self.internal_list[self.index]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    fn edit_stack<T>(values: &[T], index: usize) -> BasicEditStack<T>
+    where
+        T: Clone,
+    {
+        BasicEditStack {
+            internal_list: values.to_vec(),
+            index,
+        }
+    }
+
+    #[rstest]
+    #[case(edit_stack(&[1, 2, 3][..], 2), 2)]
+    #[case(edit_stack(&[1][..], 0), 1)]
+    fn undo_works(#[case] stack: BasicEditStack<isize>, #[case] value_after_undo: isize) {
+        let mut stack = stack;
+
+        let value = stack.undo();
+        assert_eq!(*value, value_after_undo);
+    }
+
+    #[rstest]
+    #[case(edit_stack(&[1, 2, 3][..], 1), 3)]
+    #[case(edit_stack(&[1][..], 0), 1)]
+    fn redo_works(#[case] stack: BasicEditStack<isize>, #[case] value_after_undo: isize) {
+        let mut stack = stack;
+
+        let value = stack.redo();
+        assert_eq!(*value, value_after_undo);
+    }
+
+    #[rstest]
+    #[case(edit_stack(&[1, 2, 3][..], 1), 4, edit_stack(&[1, 2, 4], 2))]
+    #[case(edit_stack(&[1, 2, 3][..], 2), 3, edit_stack(&[1, 2, 3, 3], 3))]
+    fn insert_works(
+        #[case] old_stack: BasicEditStack<isize>,
+        #[case] value_to_insert: isize,
+        #[case] expected_stack: BasicEditStack<isize>,
+    ) {
+        let mut stack = old_stack;
+
+        stack.insert(value_to_insert);
+        assert_eq!(stack, expected_stack);
+    }
+}

--- a/src/core_editor/edit_stack.rs
+++ b/src/core_editor/edit_stack.rs
@@ -57,11 +57,6 @@ where
         self.internal_list = vec![T::default()];
     }
 
-    /// List out all the entries on the undo stack Mostly used for debugging. Might remove this one
-    pub(super) fn edits<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a> {
-        Box::new(self.internal_list.iter().take(self.index + 1))
-    }
-
     /// Return the entry currently being pointed to
     pub(super) fn current(&mut self) -> &T {
         &self.internal_list[self.index]

--- a/src/core_editor/edit_stack.rs
+++ b/src/core_editor/edit_stack.rs
@@ -1,65 +1,35 @@
-/// This outlines the operations (interface) that any data strcuture will need to obey to be useful
-/// to the core_editor as undo/redo stack
-pub trait EditStack<T>: Send
-where
-    T: Default,
-    T: Clone,
-    T: Send,
-{
-    /// Go back one point in the undo stack.
-    /// If present on first edit do nothing
-    fn undo(&mut self) -> &T;
-
-    /// Go forward one point in the undo stack.
-    /// If present on the last edit do nothing
-    fn redo(&mut self) -> &T;
-
-    /// Insert a new entry to the undo stack.
-    /// NOTE: (IMP): If we have hit undo a few times then discard all the other values that come
-    /// after the current point
-    fn insert(&mut self, value: T);
-
-    /// Reset the stack to the initial state
-    fn reset(&mut self);
-
-    /// Return the entry currently being pointed to
-    fn current(&mut self) -> &T;
-
-    /// List out all the entries on the undo stack
-    /// Mostly used for debugging. Might remove this one
-    fn edits<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a>;
-}
-
 #[derive(Debug, PartialEq, Eq)]
-pub struct BasicEditStack<T> {
+pub struct EditStack<T> {
     internal_list: Vec<T>,
     index: usize,
 }
 
-impl<T> BasicEditStack<T> {
+impl<T> EditStack<T> {
     pub fn new() -> Self
     where
         T: Default,
     {
-        BasicEditStack {
+        EditStack {
             internal_list: vec![T::default()],
             index: 0,
         }
     }
 }
 
-impl<T> EditStack<T> for BasicEditStack<T>
+impl<T> EditStack<T>
 where
     T: Default,
     T: Clone,
     T: Send,
 {
-    fn undo(&mut self) -> &T {
+    /// Go back one point in the undo stack. If present on first edit do nothing
+    pub(super) fn undo(&mut self) -> &T {
         self.index = if self.index == 0 { 0 } else { self.index - 1 };
         &self.internal_list[self.index]
     }
 
-    fn redo(&mut self) -> &T {
+    /// Go forward one point in the undo stack. If present on the last edit do nothing
+    pub(super) fn redo(&mut self) -> &T {
         self.index = if self.index == self.internal_list.len() - 1 {
             self.index
         } else {
@@ -68,7 +38,10 @@ where
         &self.internal_list[self.index]
     }
 
-    fn insert(&mut self, value: T) {
+    /// Insert a new entry to the undo stack.
+    /// NOTE: (IMP): If we have hit undo a few times then discard all the other values that come
+    /// after the current point
+    pub(super) fn insert(&mut self, value: T) {
         if self.index < self.internal_list.len() - 1 {
             self.internal_list.resize_with(self.index + 1, || {
                 panic!("Impossible state reached: Bug in UndoStack logic")
@@ -78,16 +51,19 @@ where
         self.index += 1;
     }
 
-    fn reset(&mut self) {
+    /// Reset the stack to the initial state
+    pub(super) fn reset(&mut self) {
         self.index = 0;
         self.internal_list = vec![T::default()];
     }
 
-    fn edits<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a> {
+    /// List out all the entries on the undo stack Mostly used for debugging. Might remove this one
+    pub(super) fn edits<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a> {
         Box::new(self.internal_list.iter().take(self.index + 1))
     }
 
-    fn current(&mut self) -> &T {
+    /// Return the entry currently being pointed to
+    pub(super) fn current(&mut self) -> &T {
         &self.internal_list[self.index]
     }
 }
@@ -98,11 +74,11 @@ mod test {
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 
-    fn edit_stack<T>(values: &[T], index: usize) -> BasicEditStack<T>
+    fn edit_stack<T>(values: &[T], index: usize) -> EditStack<T>
     where
         T: Clone,
     {
-        BasicEditStack {
+        EditStack {
             internal_list: values.to_vec(),
             index,
         }
@@ -111,7 +87,7 @@ mod test {
     #[rstest]
     #[case(edit_stack(&[1, 2, 3][..], 2), 2)]
     #[case(edit_stack(&[1][..], 0), 1)]
-    fn undo_works(#[case] stack: BasicEditStack<isize>, #[case] value_after_undo: isize) {
+    fn undo_works(#[case] stack: EditStack<isize>, #[case] value_after_undo: isize) {
         let mut stack = stack;
 
         let value = stack.undo();
@@ -121,7 +97,7 @@ mod test {
     #[rstest]
     #[case(edit_stack(&[1, 2, 3][..], 1), 3)]
     #[case(edit_stack(&[1][..], 0), 1)]
-    fn redo_works(#[case] stack: BasicEditStack<isize>, #[case] value_after_undo: isize) {
+    fn redo_works(#[case] stack: EditStack<isize>, #[case] value_after_undo: isize) {
         let mut stack = stack;
 
         let value = stack.redo();
@@ -132,9 +108,9 @@ mod test {
     #[case(edit_stack(&[1, 2, 3][..], 1), 4, edit_stack(&[1, 2, 4], 2))]
     #[case(edit_stack(&[1, 2, 3][..], 2), 3, edit_stack(&[1, 2, 3, 3], 3))]
     fn insert_works(
-        #[case] old_stack: BasicEditStack<isize>,
+        #[case] old_stack: EditStack<isize>,
         #[case] value_to_insert: isize,
-        #[case] expected_stack: BasicEditStack<isize>,
+        #[case] expected_stack: EditStack<isize>,
     ) {
         let mut stack = old_stack;
 

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -1,4 +1,7 @@
-use super::{Clipboard, ClipboardMode, LineBuffer};
+use super::{
+    edit_stack::{BasicEditStack, EditStack},
+    Clipboard, ClipboardMode, LineBuffer,
+};
 use crate::{core_editor::get_default_clipboard, EditCommand, UndoBehavior};
 
 /// Stateful editor executing changes to the underlying [`LineBuffer`]
@@ -9,8 +12,7 @@ pub struct Editor {
     line_buffer: LineBuffer,
     cut_buffer: Box<dyn Clipboard>,
 
-    edits: Vec<LineBuffer>,
-    index_undo: usize,
+    edit_stack: Box<dyn EditStack<LineBuffer>>,
 }
 
 impl Default for Editor {
@@ -18,10 +20,7 @@ impl Default for Editor {
         Editor {
             line_buffer: LineBuffer::new(),
             cut_buffer: Box::new(get_default_clipboard()),
-
-            // Note: Using list-zipper we can reduce these to one field
-            edits: vec![LineBuffer::new()],
-            index_undo: 2,
+            edit_stack: Box::new(BasicEditStack::new()),
         }
     }
 }
@@ -155,8 +154,7 @@ impl Editor {
     }
 
     pub fn reset_undo_stack(&mut self) {
-        self.edits = vec![LineBuffer::new()];
-        self.index_undo = 2;
+        self.edit_stack.reset();
     }
 
     pub fn move_to_start(&mut self) {
@@ -176,58 +174,25 @@ impl Editor {
         self.line_buffer.move_to_line_end();
     }
 
-    fn get_index_undo(&self) -> usize {
-        if let Some(c) = self.edits.len().checked_sub(self.index_undo) {
-            c
-        } else {
-            0
-        }
-    }
-
     fn undo(&mut self) {
-        // NOTE: Try-blocks should help us get rid of this indirection too
-        self.undo_internal();
+        let val = self.edit_stack.undo();
+        self.line_buffer = val.clone();
     }
 
     fn redo(&mut self) {
-        // NOTE: Try-blocks should help us get rid of this indirection too
-        self.redo_internal();
-    }
-
-    fn redo_internal(&mut self) -> Option<()> {
-        if self.index_undo > 2 {
-            self.index_undo = self.index_undo.checked_sub(2)?;
-            self.undo_internal()
-        } else {
-            None
-        }
-    }
-
-    fn undo_internal(&mut self) -> Option<()> {
-        self.line_buffer = self.edits.get(self.get_index_undo())?.clone();
-
-        if self.index_undo <= self.edits.len() {
-            self.index_undo = self.index_undo.checked_add(1)?;
-        }
-        Some(())
+        let val = self.edit_stack.redo();
+        self.line_buffer = val.clone();
     }
 
     pub fn remember_undo_state(&mut self, is_after_action: bool) -> Option<()> {
-        self.reset_index_undo();
-
-        if self.edits.len() > 1
-            && self.edits.last()?.word_count() == self.line_buffer.word_count()
+        if self.edit_stack.current().word_count() == self.line_buffer.word_count()
             && !is_after_action
         {
-            self.edits.pop();
+            self.edit_stack.undo();
         }
-        self.edits.push(self.line_buffer.clone());
+        self.edit_stack.insert(self.line_buffer.clone());
 
         Some(())
-    }
-
-    fn reset_index_undo(&mut self) {
-        self.index_undo = 2;
     }
 
     fn cut_current_line(&mut self) {
@@ -431,7 +396,12 @@ mod test {
                 LineBuffer::from("ab "),
                 LineBuffer::from("ab c")
             ],
-            editor.edits
+            editor
+                .edit_stack
+                .edits()
+                .into_iter()
+                .cloned()
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -1,7 +1,4 @@
-use super::{
-    edit_stack::{BasicEditStack, EditStack},
-    Clipboard, ClipboardMode, LineBuffer,
-};
+use super::{edit_stack::EditStack, Clipboard, ClipboardMode, LineBuffer};
 use crate::{core_editor::get_default_clipboard, EditCommand, UndoBehavior};
 
 /// Stateful editor executing changes to the underlying [`LineBuffer`]
@@ -12,7 +9,7 @@ pub struct Editor {
     line_buffer: LineBuffer,
     cut_buffer: Box<dyn Clipboard>,
 
-    edit_stack: Box<dyn EditStack<LineBuffer>>,
+    edit_stack: EditStack<LineBuffer>,
 }
 
 impl Default for Editor {
@@ -20,7 +17,7 @@ impl Default for Editor {
         Editor {
             line_buffer: LineBuffer::new(),
             cut_buffer: Box::new(get_default_clipboard()),
-            edit_stack: Box::new(BasicEditStack::new()),
+            edit_stack: EditStack::new(),
         }
     }
 }

--- a/src/core_editor/mod.rs
+++ b/src/core_editor/mod.rs
@@ -1,4 +1,5 @@
 mod clip_buffer;
+mod edit_stack;
 mod editor;
 mod line_buffer;
 


### PR DESCRIPTION
Hey, I was looking at the #193 and wanted to pick it up. Though before I went into fixing it I decided to clean up the undo-redo logic by adding an edit stack in the mix. The benefits that I envision from this approach are 
- We were maintaining edits and a cursor in the `Editor` which seemed like a responsibility that it should not have to deal with 
- Simplifies the undo-redo logic (now we only need to think about maintaining a single stack then keeping track of edits vector and cursor 

Let me know if this is acceptable.