### PR TITLE
Minimal / simple implementation of SQLite-backed history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 history.txt
+history.sqlite3
 .DS_Store
 target-coverage/
 tarpaulin-report.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +157,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +186,35 @@ dependencies = [
  "cfg-if",
  "rustix",
  "windows-sys 0.30.0",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -187,10 +239,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "libc"
 version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -224,6 +292,12 @@ checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "mio"
@@ -315,6 +389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +431,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.32.0",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "pretty_assertions"
@@ -402,7 +488,9 @@ dependencies = [
  "nu-ansi-term",
  "pretty_assertions",
  "rstest",
+ "rusqlite",
  "serde",
+ "serde_json",
  "strip-ansi-escapes",
  "strum",
  "strum_macros",
@@ -431,6 +519,21 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
 ]
 
 [[package]]
@@ -463,6 +566,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +601,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -617,6 +737,18 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vte"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ strip-ansi-escapes = "0.1.1"
 strum = "0.24"
 strum_macros = "0.24"
 fd-lock = "3.0.3"
+rusqlite = { version = "0.27.0", optional = true }
+serde_json = { version = "1.0.79", optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"
@@ -36,3 +38,4 @@ rstest = "0.12.0"
 [features]
 system_clipboard = ["clipboard"]
 bashisms = []
+sqlite = ["rusqlite", "serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ strip-ansi-escapes = "0.1.1"
 strum = "0.24"
 strum_macros = "0.24"
 fd-lock = "3.0.3"
-rusqlite = { version = "0.27.0", optional = true }
+rusqlite = { version = "0.27.0", optional = true, features = ["bundled"] }
 serde_json = { version = "1.0.79", optional = true }
 
 [dev-dependencies]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -320,7 +320,6 @@ impl Reedline {
         let history: Vec<_> = self
             .history
             .iter_chronologic()
-            .cloned()
             .enumerate()
             .collect();
 

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -1,5 +1,4 @@
 use crate::core_editor::LineBuffer;
-use std::collections::vec_deque::Iter;
 
 /// Browsing modes for a [`History`]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,7 +19,7 @@ pub trait History: Send {
     fn append(&mut self, entry: &str);
 
     /// Chronologic interaction over all entries present in the history
-    fn iter_chronologic(&self) -> Iter<'_, String>;
+    fn iter_chronologic(&self) -> Box<dyn DoubleEndedIterator<Item=String> + '_>;
 
     /// This moves the cursor backwards respecting the navigation query that is set
     /// - Results in a no-op if the cursor is at the initial point

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -68,8 +68,8 @@ impl History for FileBackedHistory {
         self.reset_cursor();
     }
 
-    fn iter_chronologic(&self) -> Iter<'_, String> {
-        self.entries.iter()
+    fn iter_chronologic(&self) -> Box<(dyn DoubleEndedIterator<Item = String> + '_)> {
+        Box::new(self.entries.iter().map(|e| e.to_string()))
     }
 
     fn back(&mut self) {
@@ -121,7 +121,6 @@ impl History for FileBackedHistory {
         self.iter_chronologic()
             .rev()
             .filter(|entry| entry.contains(search))
-            .cloned()
             .collect::<Vec<String>>()
     }
 

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -1,5 +1,9 @@
 mod base;
 mod file_backed;
+#[cfg(feature="sqlite")]
+mod sqlite_backed;
+#[cfg(feature="sqlite")]
+pub use sqlite_backed::SqliteBackedHistory;
 
 pub use base::{History, HistoryNavigationQuery};
 pub use file_backed::{FileBackedHistory, HISTORY_SIZE};

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -182,7 +182,7 @@ impl<ContextType: HistoryEntryContext> History for SqliteBackedHistory<ContextTy
         if self.last_run_command_id == None {
             self.last_run_command_id = self
                 .db
-                .prepare("select max(id) from history")
+                .prepare("select coalesce(max(id), 0) from history")
                 .unwrap()
                 .query_row(params![], |e| e.get(0))
                 .optional()

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -1,0 +1,621 @@
+use rusqlite::{named_params, params, Connection};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use super::{base::HistoryNavigationQuery, History};
+use crate::core_editor::LineBuffer;
+use std::{
+    collections::{vec_deque::Iter, VecDeque},
+    fs::OpenOptions,
+    io::{BufRead, BufReader, BufWriter, Seek, SeekFrom, Write},
+    ops::{Deref, DerefMut},
+    path::PathBuf,
+    sync::{Arc, Mutex, RwLock},
+};
+
+pub trait HistoryEntryContext: Serialize + DeserializeOwned + Default + Send {}
+impl<T> HistoryEntryContext for T where T: Serialize + DeserializeOwned + Default + Send {}
+
+/// A history that stores the values to an SQLite database.
+/// In addition to storing the command, the history can store an additional arbitrary HistoryEntryContext,
+/// to add information such as a timestamp, running directory, result...
+#[derive(Clone)]
+pub struct SqliteBackedHistory<ContextType>
+where
+    ContextType: HistoryEntryContext,
+{
+    inner: Arc<Mutex<SqliteBackedHistoryInner<ContextType>>>,
+    dummy: VecDeque<String>,
+}
+struct SqliteBackedHistoryInner<ContextType> {
+    db: rusqlite::Connection,
+    last_command_id: Option<i64>,
+    last_command_context: Option<ContextType>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct CommandSqlite<'a> {
+    id: i64,
+    command: &'a str,
+}
+impl<ContextType: HistoryEntryContext> History for SqliteBackedHistory<ContextType> {
+    /// Appends an entry if non-empty and not repetition of the previous entry.
+    /// Resets the browsing cursor to the default state in front of the most recent entry.
+    ///
+    fn append(&mut self, entry: &str) {
+        let mut inner = self.inner.lock().expect("lock poisoned");
+        let ctx = ContextType::default();
+        let ret: i64 = inner
+            .db
+            .prepare(
+                "insert into history (command, context) values (:command, :context) returning id",
+            )
+            .unwrap()
+            .query_row(
+                named_params! {
+                    ":command": entry,
+                    ":context": serde_json::to_string(&ctx).unwrap()
+                },
+                |row| row.get(0),
+            )
+            .unwrap();
+        inner.last_command_id = Some(ret);
+        inner.last_command_context = Some(ctx);
+    }
+
+    fn iter_chronologic(&self) -> Iter<'_, String> {
+        self.dummy.iter()
+        // self.entries.iter()
+    }
+
+    fn back(&mut self) {
+        todo!()
+    }
+
+    fn forward(&mut self) {
+        todo!()
+    }
+
+    fn string_at_cursor(&self) -> Option<String> {
+        todo!()
+    }
+
+    fn set_navigation(&mut self, navigation: HistoryNavigationQuery) {
+        todo!()
+    }
+
+    fn get_navigation(&self) -> HistoryNavigationQuery {
+        todo!()
+    }
+
+    fn query_entries(&self, search: &str) -> Vec<String> {
+        self.iter_chronologic()
+            .rev()
+            .filter(|entry| entry.contains(search))
+            .cloned()
+            .collect::<Vec<String>>()
+    }
+
+    fn max_values(&self) -> usize {
+        todo!()
+    }
+
+    /// Writes unwritten history contents to disk.
+    ///
+    /// If file would exceed `capacity` truncates the oldest entries.
+    fn sync(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    /// Reset the internal browsing cursor
+    fn reset_cursor(&mut self) {
+        todo!()
+    }
+}
+fn map_sqlite_err(err: rusqlite::Error) -> std::io::Error {
+    // todo: better error mapping
+    std::io::Error::new(std::io::ErrorKind::Other, err)
+}
+
+impl<ContextType: HistoryEntryContext> SqliteBackedHistory<ContextType> {
+    /*pub fn new() -> Self {
+        SqliteBackedHistory::with_file(":memory:")
+    }*/
+
+    /// Creates a new history with an associated history file.
+    ///
+    /// History file format: commands separated by new lines.
+    /// If file exists file will be read otherwise empty file will be created.
+    ///
+    ///
+    /// **Side effects:** creates all nested directories to the file
+    ///
+    pub fn with_file(file: PathBuf) -> std::io::Result<Self> {
+        let db = Connection::open(&file).map_err(map_sqlite_err)?;
+        db.pragma_update(None, "journal_mode", "wal").map_err(map_sqlite_err)?;
+        db.execute(
+            "
+        create table if not exists history (
+            id integer primary key autoincrement,
+            command text not null,
+            context text not null
+        ) strict
+        ",
+            params![],
+        ).map_err(map_sqlite_err)?;
+        Ok(SqliteBackedHistory {
+            dummy: VecDeque::new(),
+            inner: Arc::new(Mutex::new(SqliteBackedHistoryInner {
+                db,
+                last_command_id: None,
+                last_command_context: None,
+            })),
+        })
+    }
+
+    // todo: better error type (which one?)
+    /// updates the context stored for the last saved command
+    pub fn update_context<F>(&self, callback: F) -> Result<(), String>
+    where
+        F: FnOnce(ContextType) -> ContextType,
+    {
+        let mut inner = self.inner.lock().expect("lock poisoned");
+        if let (Some(id), Some(ctx)) = (inner.last_command_id, inner.last_command_context.take()) {
+            let mapped_ctx = callback(ctx);
+            inner
+                .db
+                .execute(
+                    "update history set context = :context where id = :id",
+                    named_params! {
+                        ":context": serde_json::to_string(&mapped_ctx).map_err(|e| format!("{e}"))?,
+                        ":id": id
+                    },
+                )
+                .map_err(|e| format!("{e}"))?;
+            inner.last_command_context.replace(mapped_ctx);
+            Ok(())
+        } else {
+            Err(format!("No command has been executed yet"))
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn accessing_empty_history_returns_nothing() {
+        let hist = FileBackedHistory::default();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn going_forward_in_empty_history_does_not_error_out() {
+        let mut hist = FileBackedHistory::default();
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn going_backwards_in_empty_history_does_not_error_out() {
+        let mut hist = FileBackedHistory::default();
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn going_backwards_bottoms_out() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("command1");
+        hist.append("command2");
+        hist.back();
+        hist.back();
+        hist.back();
+        hist.back();
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("command1".to_string()));
+    }
+
+    #[test]
+    fn going_forwards_bottoms_out() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("command1");
+        hist.append("command2");
+        hist.forward();
+        hist.forward();
+        hist.forward();
+        hist.forward();
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn appends_only_unique() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("unique_old");
+        hist.append("test");
+        hist.append("test");
+        hist.append("unique");
+        assert_eq!(hist.entries.len(), 3);
+    }
+    #[test]
+    fn appends_no_empties() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("");
+        assert_eq!(hist.entries.len(), 0);
+    }
+
+    #[test]
+    fn prefix_search_works() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("find me as well");
+        hist.append("test");
+        hist.append("find me");
+
+        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+    }
+
+    #[test]
+    fn prefix_search_bottoms_out() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("find me as well");
+        hist.append("test");
+        hist.append("find me");
+
+        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+        hist.back();
+        hist.back();
+        hist.back();
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+    }
+    #[test]
+    fn prefix_search_returns_to_none() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("find me as well");
+        hist.append("test");
+        hist.append("find me");
+
+        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), None);
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn prefix_search_ignores_consecutive_equivalent_entries_going_backwards() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("find me as well");
+        hist.append("find me once");
+        hist.append("test");
+        hist.append("find me once");
+
+        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me once".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+    }
+
+    #[test]
+    fn prefix_search_ignores_consecutive_equivalent_entries_going_forwards() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("find me once");
+        hist.append("test");
+        hist.append("find me once");
+        hist.append("find me as well");
+
+        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        hist.back();
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me once".to_string()));
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn substring_search_works() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("substring");
+        hist.append("don't find me either");
+        hist.append("prefix substring");
+        hist.append("don't find me");
+        hist.append("prefix substring suffix");
+
+        hist.set_navigation(HistoryNavigationQuery::SubstringSearch(
+            "substring".to_string(),
+        ));
+        hist.back();
+        assert_eq!(
+            hist.string_at_cursor(),
+            Some("prefix substring suffix".to_string())
+        );
+        hist.back();
+        assert_eq!(
+            hist.string_at_cursor(),
+            Some("prefix substring".to_string())
+        );
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("substring".to_string()));
+    }
+
+    #[test]
+    fn substring_search_with_empty_value_returns_none() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("substring");
+
+        hist.set_navigation(HistoryNavigationQuery::SubstringSearch("".to_string()));
+
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn writes_to_new_file() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        // check that it also works for a path where the directory has not been created yet
+        let histfile = tmp.path().join("nested_path").join(".history");
+
+        let entries = vec!["test", "text", "more test text"];
+
+        {
+            let mut hist = FileBackedHistory::with_file(5, histfile.clone()).unwrap();
+
+            entries.iter().for_each(|e| hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let reading_hist = FileBackedHistory::with_file(5, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+        assert_eq!(entries, actual);
+
+        tmp.close().unwrap();
+    }
+
+    #[test]
+    fn persists_newlines_in_entries() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let histfile = tmp.path().join(".history");
+
+        let entries = vec![
+            "test",
+            "multiline\nentry\nunix",
+            "multiline\r\nentry\r\nwindows",
+            "more test text",
+        ];
+
+        {
+            let mut writing_hist = FileBackedHistory::with_file(5, histfile.clone()).unwrap();
+
+            entries.iter().for_each(|e| writing_hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let reading_hist = FileBackedHistory::with_file(5, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+        assert_eq!(entries, actual);
+
+        tmp.close().unwrap();
+    }
+
+    #[test]
+    fn truncates_file_to_capacity() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let histfile = tmp.path().join(".history");
+
+        let capacity = 5;
+        let initial_entries = vec!["test 1", "test 2"];
+        let appending_entries = vec!["test 3", "test 4"];
+        let expected_appended_entries = vec!["test 1", "test 2", "test 3", "test 4"];
+        let truncating_entries = vec!["test 5", "test 6", "test 7", "test 8"];
+        let expected_truncated_entries = vec!["test 4", "test 5", "test 6", "test 7", "test 8"];
+
+        {
+            let mut writing_hist =
+                FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            initial_entries.iter().for_each(|e| writing_hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        {
+            let mut appending_hist =
+                FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            appending_entries
+                .iter()
+                .for_each(|e| appending_hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+            let actual: Vec<_> = appending_hist.iter_chronologic().collect();
+            assert_eq!(expected_appended_entries, actual);
+        }
+
+        {
+            let mut truncating_hist =
+                FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            truncating_entries
+                .iter()
+                .for_each(|e| truncating_hist.append(e));
+
+            let actual: Vec<_> = truncating_hist.iter_chronologic().collect();
+            assert_eq!(expected_truncated_entries, actual);
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let reading_hist = FileBackedHistory::with_file(capacity, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+        assert_eq!(expected_truncated_entries, actual);
+
+        tmp.close().unwrap();
+    }
+
+    #[test]
+    fn truncates_too_large_file() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let histfile = tmp.path().join(".history");
+
+        let overly_large_previous_entries = vec![
+            "test 1", "test 2", "test 3", "test 4", "test 5", "test 6", "test 7", "test 8",
+        ];
+        let expected_truncated_entries = vec!["test 4", "test 5", "test 6", "test 7", "test 8"];
+
+        {
+            let mut writing_hist = FileBackedHistory::with_file(10, histfile.clone()).unwrap();
+
+            overly_large_previous_entries
+                .iter()
+                .for_each(|e| writing_hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        {
+            let truncating_hist = FileBackedHistory::with_file(5, histfile.clone()).unwrap();
+
+            let actual: Vec<_> = truncating_hist.iter_chronologic().collect();
+            assert_eq!(expected_truncated_entries, actual);
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let reading_hist = FileBackedHistory::with_file(5, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+        assert_eq!(expected_truncated_entries, actual);
+
+        tmp.close().unwrap();
+    }
+
+    #[test]
+    fn concurrent_histories_dont_erase_eachother() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let histfile = tmp.path().join(".history");
+
+        let capacity = 7;
+        let initial_entries = vec!["test 1", "test 2", "test 3", "test 4", "test 5"];
+        let entries_a = vec!["A1", "A2", "A3"];
+        let entries_b = vec!["B1", "B2", "B3"];
+        let expected_entries = vec!["test 5", "B1", "B2", "B3", "A1", "A2", "A3"];
+
+        {
+            let mut writing_hist =
+                FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            initial_entries.iter().for_each(|e| writing_hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        {
+            let mut hist_a = FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            {
+                let mut hist_b = FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+                entries_b.iter().for_each(|e| hist_b.append(e));
+
+                // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+            }
+            entries_a.iter().for_each(|e| hist_a.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let reading_hist = FileBackedHistory::with_file(capacity, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+        assert_eq!(expected_entries, actual);
+
+        tmp.close().unwrap();
+    }
+
+    #[test]
+    fn concurrent_histories_are_threadsafe() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let histfile = tmp.path().join(".history");
+
+        let num_threads = 16;
+        let capacity = 2 * num_threads + 1;
+
+        let initial_entries = (0..capacity).map(|i| format!("initial {i}"));
+
+        {
+            let mut writing_hist =
+                FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            initial_entries.for_each(|e| writing_hist.append(&e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let threads = (0..num_threads)
+            .map(|i| {
+                let cap = capacity;
+                let hfile = histfile.clone();
+                std::thread::spawn(move || {
+                    let mut hist = FileBackedHistory::with_file(cap, hfile).unwrap();
+                    hist.append(&format!("A{}", i));
+                    hist.sync().unwrap();
+                    hist.append(&format!("B{}", i));
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for t in threads {
+            t.join().unwrap();
+        }
+
+        let reading_hist = FileBackedHistory::with_file(capacity, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+
+        assert!(
+            actual.contains(&&format!("initial {}", capacity - 1)),
+            "Overwrote entry from before threading test"
+        );
+
+        for i in 0..num_threads {
+            assert!(actual.contains(&&format!("A{}", i)),);
+            assert!(actual.contains(&&format!("B{}", i)),);
+        }
+
+        tmp.close().unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,8 @@ pub use engine::Reedline;
 
 mod history;
 pub use history::{FileBackedHistory, History, HistoryNavigationQuery, HISTORY_SIZE};
+#[cfg(feature="sqlite")]
+pub use history::{SqliteBackedHistory};
 
 mod prompt;
 pub use prompt::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ fn main() -> Result<()> {
                 history.update_context(|mut c| {
                     c.timestamp = "foo".to_string();
                     c
-                });
+                }).unwrap();
                 if (buffer.trim() == "exit") || (buffer.trim() == "logout") {
                     break;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ fn main() -> Result<()> {
                     history_clone
                         .lock()
                         .expect("lock poisoned")
-                        .update_context(|mut c| {
+                        .update_last_command_context(|mut c| {
                             c.timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
                             c
                         })

--- a/src/menu/history_menu.rs
+++ b/src/menu/history_menu.rs
@@ -160,7 +160,6 @@ impl HistoryMenu {
             .rev()
             .skip(skip)
             .take(take)
-            .cloned()
             .collect::<Vec<String>>()
     }
 


### PR DESCRIPTION
This PR implements a SQLite-based history. I kept it minimal for easy merging and future expansion.

It should reproduce all features of the txt-backed history (arrow navigation, prefix filtering, history menu etc) and passes all the tests from file_backed. The History trait stayed almost the same so far.

It doesn't really offer any additional features currently except storing an arbitrary context together with each history entry. In the future there should be functionality to filter by session, PWD, hostname, etc, but those will require deeper changes.

when run with `--features sqlite`, the demo binary will store the history into `history.sqlite3` and also add the run timestamp as metadata.

some notes:

- most of the history methods I think should probably be fallible. i didn't change this since i don't know what kind of error propagation you want - so right now there's more unwrap than should be.
- the tests for file and sqlite backend should probably be merged (same for every "History" impl). right now i copy-pasted all the tests to the sqlite backed history, but barely modified anything.
- i think the "cursor" functionality (back, forward, etc) should be separated out into a separate trait, but it works as is
- i (intentionally) didn't implement the capacity limiting feature
- the iterator currently loads everything in memory (like the file-based one does), to fix that some of the ownership / lifetimes would need changing
- right now i json-serialize the context so the library user can decide what to store. this is inefficient in regards to storage, but it's going to be hard to store structured data in a generic manner otherwise. One solution might be to use a binary serialization method that's more efficient, but due to the sqlite json functions it's easy to create efficient indices on the schema as it is right now (e.g. `create index on history(context->>'cwd', context->>'timestamp') for directory-based history`