### PR TITLE
generic reedline menus

### DIFF
--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -31,6 +31,28 @@ pub trait Completer: Send {
     /// the action that will take the line and position and convert it to a vector of completions, which include the
     /// span to replace and the contents of that replacement
     fn complete(&self, line: &str, pos: usize) -> Vec<Suggestion>;
+
+    /// action that will return a partial section of available completions
+    /// this command comes handy when trying to avoid to pull all the data at once
+    /// from the completer
+    fn partial_complete(
+        &self,
+        line: &str,
+        pos: usize,
+        start: usize,
+        offset: usize,
+    ) -> Vec<Suggestion> {
+        self.complete(line, pos)
+            .into_iter()
+            .skip(start)
+            .take(offset)
+            .collect()
+    }
+
+    /// number of available completions
+    fn total_completions(&self, line: &str, pos: usize) -> usize {
+        self.complete(line, pos).len()
+    }
 }
 
 /// Suggestion returned by the Completer
@@ -40,6 +62,9 @@ pub struct Suggestion {
     pub value: String,
     /// Optional description for the replacement
     pub description: Option<String>,
+    /// Optional vector of strings in the suggestion. These can be used to
+    /// represent examples comming from a suggestion
+    pub extra: Option<Vec<String>>,
     /// Replacement span in the buffer
     pub span: Span,
 }

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -55,17 +55,17 @@ impl Completer for DefaultCompleter {
     /// assert_eq!(
     ///     completions.complete("bat",3),
     ///     vec![
-    ///         Suggestion {value: "batcave".into(), description: None, span: Span { start: 0, end: 3 }},
-    ///         Suggestion {value: "batman".into(), description: None, span: Span { start: 0, end: 3 }},
-    ///         Suggestion {value: "batmobile".into(), description: None, span: Span { start: 0, end: 3 }},
+    ///         Suggestion {value: "batcave".into(), description: None, extra: None, span: Span { start: 0, end: 3 }},
+    ///         Suggestion {value: "batman".into(), description: None, extra: None, span: Span { start: 0, end: 3 }},
+    ///         Suggestion {value: "batmobile".into(), description: None, extra: None, span: Span { start: 0, end: 3 }},
     ///     ]);
     ///
     /// assert_eq!(
     ///     completions.complete("to the bat",10),
     ///     vec![
-    ///         Suggestion {value: "batcave".into(), description: None, span: Span { start: 7, end: 10 }},
-    ///         Suggestion {value: "batman".into(), description: None, span: Span { start: 7, end: 10 }},
-    ///         Suggestion {value: "batmobile".into(), description: None, span: Span { start: 7, end: 10 }},
+    ///         Suggestion {value: "batcave".into(), description: None, extra: None, span: Span { start: 7, end: 10 }},
+    ///         Suggestion {value: "batman".into(), description: None, extra: None, span: Span { start: 7, end: 10 }},
+    ///         Suggestion {value: "batmobile".into(), description: None, extra: None, span: Span { start: 7, end: 10 }},
     ///     ]);
     /// ```
     fn complete(&self, line: &str, pos: usize) -> Vec<Suggestion> {
@@ -172,15 +172,15 @@ impl DefaultCompleter {
     /// completions.insert(vec!["test-hyphen","test_underscore"].iter().map(|s| s.to_string()).collect());
     /// assert_eq!(
     ///     completions.complete("te",2),
-    ///     vec![Suggestion {value: "test".into(), description: None, span: Span { start: 0, end: 2 }}]);
+    ///     vec![Suggestion {value: "test".into(), description: None, extra: None, span: Span { start: 0, end: 2 }}]);
     ///
     /// let mut completions = DefaultCompleter::with_inclusions(&['-', '_']);
     /// completions.insert(vec!["test-hyphen","test_underscore"].iter().map(|s| s.to_string()).collect());
     /// assert_eq!(
     ///     completions.complete("te",2),
     ///     vec![
-    ///         Suggestion {value: "test-hyphen".into(), description: None, span: Span { start: 0, end: 2 }},
-    ///         Suggestion {value: "test_underscore".into(), description: None, span: Span { start: 0, end: 2 }},
+    ///         Suggestion {value: "test-hyphen".into(), description: None, extra: None, span: Span { start: 0, end: 2 }},
+    ///         Suggestion {value: "test_underscore".into(), description: None, extra: None, span: Span { start: 0, end: 2 }},
     ///     ]);
     /// ```
     pub fn with_inclusions(incl: &[char]) -> Self {

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -99,6 +99,7 @@ impl Completer for DefaultCompleter {
                                     Suggestion {
                                         value: format!("{}{}", span_line, ext),
                                         description: None,
+                                        extra: None,
                                         span,
                                     }
                                 })
@@ -369,16 +370,19 @@ mod tests {
                 Suggestion {
                     value: "ｎｕｌｌ".into(),
                     description: None,
+                    extra: None,
                     span: Span { start: 0, end: 3 },
                 },
                 Suggestion {
                     value: "ｎｕｍｂｅｒ".into(),
                     description: None,
+                    extra: None,
                     span: Span { start: 0, end: 3 },
                 },
                 Suggestion {
                     value: "ｎｕｓｈｅｌｌ".into(),
                     description: None,
+                    extra: None,
                     span: Span { start: 0, end: 3 },
                 },
             ]

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -1,0 +1,65 @@
+use std::ops::Deref;
+
+use crate::{menu_functions::parse_selection_char, Completer, History, Span, Suggestion};
+
+const SELECTION_CHAR: char = '!';
+
+// The HistoryCompleter is created just before updating the menu
+// It pulls data from the object that contains access to the History
+pub(crate) struct HistoryCompleter<'menu>(&'menu dyn History);
+
+// Safe to implement Send since the Historycompleter should only be used when
+// updating the menu and that should happen in the same thread
+unsafe impl<'menu> Send for HistoryCompleter<'menu> {}
+
+impl<'menu> Completer for HistoryCompleter<'menu> {
+    fn complete(&self, line: &str, pos: usize) -> Vec<Suggestion> {
+        let parsed = parse_selection_char(line, SELECTION_CHAR);
+        let values = self.0.query_entries(parsed.remainder);
+
+        values
+            .into_iter()
+            .map(|value| self.create_suggestion(line, pos, value.deref()))
+            .collect()
+    }
+
+    fn partial_complete(
+        &self,
+        line: &str,
+        pos: usize,
+        start: usize,
+        offset: usize,
+    ) -> Vec<Suggestion> {
+        self.0
+            .iter_chronologic()
+            .rev()
+            .skip(start)
+            .take(offset)
+            .map(|value| self.create_suggestion(line, pos, value.deref()))
+            .collect()
+    }
+
+    fn total_completions(&self, _line: &str, _pos: usize) -> usize {
+        self.0.max_values()
+    }
+}
+
+impl<'menu> HistoryCompleter<'menu> {
+    pub fn new(history: &'menu dyn History) -> Self {
+        Self(history)
+    }
+
+    fn create_suggestion(&self, line: &str, pos: usize, value: &str) -> Suggestion {
+        let span = Span {
+            start: pos,
+            end: pos + line.len(),
+        };
+
+        Suggestion {
+            value: value.to_string(),
+            description: None,
+            extra: None,
+            span,
+        }
+    }
+}

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -9,7 +9,7 @@ const SELECTION_CHAR: char = '!';
 pub(crate) struct HistoryCompleter<'menu>(&'menu dyn History);
 
 // Safe to implement Send since the Historycompleter should only be used when
-// updating the menu and that should happen in the same thread
+// updating the menu and that must happen in the same thread
 unsafe impl<'menu> Send for HistoryCompleter<'menu> {}
 
 impl<'menu> Completer for HistoryCompleter<'menu> {

--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -1,6 +1,7 @@
 mod base;
 mod circular;
 mod default;
+pub(crate) mod history;
 
 pub use base::{Completer, Span, Suggestion};
 pub use circular::CircularCompletionHandler;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -299,13 +299,8 @@ impl Reedline {
 
     /// A builder that appends a menu to the engine
     #[must_use]
-    pub fn with_menu(mut self, menu: Box<dyn Menu>, completer: Option<Box<dyn Completer>>) -> Self {
-        if let Some(completer) = completer {
-            self.menus
-                .push(ReedlineMenu::WithCompleter { menu, completer })
-        } else {
-            self.menus.push(ReedlineMenu::EngineCompleter(menu))
-        }
+    pub fn with_menu(mut self, menu: ReedlineMenu) -> Self {
+        self.menus.push(menu);
 
         self
     }
@@ -581,8 +576,8 @@ impl Reedline {
                         if self.quick_completions && menu.can_quick_complete() {
                             menu.update_values(
                                 self.editor.line_buffer(),
-                                self.history.as_ref(),
                                 self.completer.as_ref(),
+                                self.history.as_ref(),
                             );
 
                             if menu.get_values().len() == 1 {
@@ -594,8 +589,8 @@ impl Reedline {
                             && menu.can_partially_complete(
                                 self.quick_completions,
                                 self.editor.line_buffer(),
-                                self.history.as_ref(),
                                 self.completer.as_ref(),
+                                self.history.as_ref(),
                             )
                         {
                             return Ok(EventStatus::Handled);
@@ -769,8 +764,8 @@ impl Reedline {
                         menu.menu_event(MenuEvent::Edit(self.quick_completions));
                         menu.update_values(
                             self.editor.line_buffer(),
-                            self.history.as_ref(),
                             self.completer.as_ref(),
+                            self.history.as_ref(),
                         );
 
                         if menu.get_values().len() == 1 {
@@ -1182,8 +1177,8 @@ impl Reedline {
             if menu.is_active() {
                 menu.update_working_details(
                     self.editor.line_buffer(),
-                    self.history.as_ref(),
                     self.completer.as_ref(),
+                    self.history.as_ref(),
                     &self.painter,
                 );
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -301,7 +301,13 @@ impl Reedline {
     #[must_use]
     pub fn with_menu(mut self, menu: ReedlineMenu) -> Self {
         self.menus.push(menu);
+        self
+    }
 
+    /// A builder that clears the list of menus added to the engine
+    #[must_use]
+    pub fn clear_menus(mut self) -> Self {
+        self.menus = Vec::new();
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ pub use validator::{DefaultValidator, ValidationResult, Validator};
 
 mod menu;
 pub use menu::{
-    menu_functions, ColumnarMenu, Menu, MenuEvent, MenuTextStyle, ReedlineMenu, SearchMenu,
+    menu_functions, ColumnarMenu, ListMenu, Menu, MenuEvent, MenuTextStyle, ReedlineMenu,
 };
 
 mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,9 @@ mod validator;
 pub use validator::{DefaultValidator, ValidationResult, Validator};
 
 mod menu;
-pub use menu::{menu_functions, CompletionMenu, HistoryMenu, Menu, MenuEvent, MenuTextStyle};
+pub use menu::{
+    menu_functions, ColumnarMenu, Menu, MenuEvent, MenuTextStyle, ReedlineMenu, SearchMenu,
+};
 
 mod utils;
 pub use utils::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@
 //! ```rust,no_run
 //! // Create a reedline object with tab completions support
 //!
-//! use reedline::{DefaultCompleter, Reedline, CompletionMenu};
+//! use reedline::{ColumnarMenu, DefaultCompleter, Reedline, ReedlineMenu};
 //!
 //! let commands = vec![
 //!   "test".into(),
@@ -109,9 +109,10 @@
 //! ];
 //! let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 //! // Use the interactive menu to select options from the completer
-//! let completion_menu = Box::new(CompletionMenu::default());
+//! let completion_menu = Box::new(ColumnarMenu::default().with_name("completion_menu"));
 //!
-//! let mut line_editor = Reedline::create().with_completer(completer).with_menu(completion_menu, None);
+//! let mut line_editor =
+//! Reedline::create().with_completer(completer).with_menu(ReedlineMenu::EngineCompleter(completion_menu));
 //! ```
 //!
 //! ## Integrate with [`Hinter`] for fish-style history autosuggestions

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ use {
         get_reedline_default_keybindings, get_reedline_edit_commands,
         get_reedline_keybinding_modifiers, get_reedline_keycodes, get_reedline_prompt_edit_modes,
         get_reedline_reedline_events, ColumnarMenu, DefaultCompleter, DefaultHinter, DefaultPrompt,
-        EditMode, Emacs, ExampleHighlighter, FileBackedHistory, Keybindings, Reedline,
-        ReedlineEvent, SearchMenu, Signal, Vi,
+        EditMode, Emacs, ExampleHighlighter, FileBackedHistory, Keybindings, ListMenu, Reedline,
+        ReedlineEvent, Signal, Vi,
     },
     std::{
         io::{stdout, Write},
@@ -86,7 +86,7 @@ fn main() -> Result<()> {
             ColumnarMenu::default().with_name("completion_menu"),
         )))
         .with_menu(ReedlineMenu::HistoryMenu(Box::new(
-            SearchMenu::default().with_name("history_menu"),
+            ListMenu::default().with_name("history_menu"),
         )));
 
     let edit_mode: Box<dyn EditMode> = if vi_mode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use reedline::ReedlineMenu;
+
 use {
     crossterm::{
         event::{poll, Event, KeyCode, KeyEvent, KeyModifiers},
@@ -8,9 +10,9 @@ use {
         default_emacs_keybindings, default_vi_insert_keybindings, default_vi_normal_keybindings,
         get_reedline_default_keybindings, get_reedline_edit_commands,
         get_reedline_keybinding_modifiers, get_reedline_keycodes, get_reedline_prompt_edit_modes,
-        get_reedline_reedline_events, CompletionMenu, DefaultCompleter, DefaultHinter,
-        DefaultPrompt, EditMode, Emacs, ExampleHighlighter, FileBackedHistory, HistoryMenu,
-        Keybindings, Reedline, ReedlineEvent, Signal, Vi,
+        get_reedline_reedline_events, ColumnarMenu, DefaultCompleter, DefaultHinter, DefaultPrompt,
+        EditMode, Emacs, ExampleHighlighter, FileBackedHistory, Keybindings, Reedline,
+        ReedlineEvent, SearchMenu, Signal, Vi,
     },
     std::{
         io::{stdout, Write},
@@ -79,11 +81,13 @@ fn main() -> Result<()> {
         .with_ansi_colors(true);
 
     // Adding default menus for the compiled reedline
-    let completion_menu = Box::new(CompletionMenu::default());
-    let history_menu = Box::new(HistoryMenu::default());
     line_editor = line_editor
-        .with_menu(completion_menu, None)
-        .with_menu(history_menu, None);
+        .with_menu(ReedlineMenu::EngineCompleter(Box::new(
+            ColumnarMenu::default().with_name("completion_menu"),
+        )))
+        .with_menu(ReedlineMenu::HistoryMenu(Box::new(
+            SearchMenu::default().with_name("history_menu"),
+        )));
 
     let edit_mode: Box<dyn EditMode> = if vi_mode {
         let mut normal_keybindings = default_vi_normal_keybindings();

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -405,7 +405,7 @@ impl ColumnarMenu {
 impl Menu for ColumnarMenu {
     /// Menu name
     fn name(&self) -> &str {
-        "completion_menu"
+        self.name.as_str()
     }
 
     /// Menu indicator

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -589,10 +589,12 @@ impl Menu for ColumnarMenu {
     /// The buffer gets replaced in the Span location
     fn replace_in_buffer(&self, line_buffer: &mut LineBuffer) {
         if let Some(Suggestion { value, span, .. }) = self.get_value() {
-            let mut offset = line_buffer.insertion_point();
-            offset += value.len() - (span.end - span.start);
+            let start = span.start.min(line_buffer.len());
+            let end = span.end.min(line_buffer.len());
+            line_buffer.replace(start..end, &value);
 
-            line_buffer.replace(span.start..span.end, &value);
+            let mut offset = line_buffer.insertion_point();
+            offset += value.len().saturating_sub(end.saturating_sub(start));
             line_buffer.set_insertion_point(offset);
         }
     }

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -159,7 +159,7 @@ impl ColumnarMenu {
     }
 }
 
-// Menu functionality 
+// Menu functionality
 impl ColumnarMenu {
     /// Move menu cursor to the next element
     fn move_next(&mut self) {

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -143,7 +143,7 @@ impl ListMenu {
     }
 }
 
-// Menu functionality 
+// Menu functionality
 impl ListMenu {
     /// Menu builder with menu marker
     #[must_use]
@@ -388,7 +388,14 @@ impl Menu for ListMenu {
     fn update_values(&mut self, line_buffer: &mut LineBuffer, completer: &dyn Completer) {
         let (start, input) = if self.only_buffer_difference {
             match &self.input {
-                Some(old_string) => string_difference(line_buffer.get_buffer(), old_string),
+                Some(old_string) => {
+                    let (start, input) = string_difference(line_buffer.get_buffer(), old_string);
+                    if input.is_empty() {
+                        (line_buffer.insertion_point(), "")
+                    } else {
+                        (start, input)
+                    }
+                }
                 None => (line_buffer.insertion_point(), ""),
             }
         } else {

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -38,7 +38,7 @@ impl<'a> Sum<&'a Page> for Page {
 
 /// Struct to store the menu style
 /// Context menu definition
-pub struct SearchMenu {
+pub struct ListMenu {
     /// Menu name
     name: String,
     /// Menu coloring
@@ -73,7 +73,7 @@ pub struct SearchMenu {
     input: Option<String>,
 }
 
-impl Default for SearchMenu {
+impl Default for ListMenu {
     fn default() -> Self {
         Self {
             name: "search_menu".to_string(),
@@ -94,7 +94,7 @@ impl Default for SearchMenu {
     }
 }
 
-impl SearchMenu {
+impl ListMenu {
     /// Menu builder with new name
     #[must_use]
     pub fn with_name(mut self, name: &str) -> Self {
@@ -324,7 +324,7 @@ impl SearchMenu {
     }
 }
 
-impl Menu for SearchMenu {
+impl Menu for ListMenu {
     fn name(&self) -> &str {
         self.name.as_str()
     }
@@ -432,10 +432,12 @@ impl Menu for SearchMenu {
     /// The buffer gets cleared with the actual value
     fn replace_in_buffer(&self, line_buffer: &mut LineBuffer) {
         if let Some(Suggestion { value, span, .. }) = self.get_value() {
-            line_buffer.replace(span.start..span.end, &value);
+            let start = span.start.min(line_buffer.len());
+            let end = span.end.min(line_buffer.len());
+            line_buffer.replace(start..end, &value);
 
             let mut offset = line_buffer.insertion_point();
-            offset += value.len() - (span.end - span.start);
+            offset += value.len().saturating_sub(end.saturating_sub(start));
             line_buffer.set_insertion_point(offset);
         }
     }

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -383,6 +383,15 @@ mod tests {
     }
 
     #[test]
+    fn string_difference_inserting() {
+        let new_string = "let a = (insert) | ";
+        let old_string = "let a = () | ";
+
+        let res = string_difference(new_string, old_string);
+        assert_eq!(res, (9, "insert"));
+    }
+
+    #[test]
     fn string_difference_longer_string() {
         let new_string = "this is a new another";
         let old_string = "this is a string";

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -445,6 +445,7 @@ mod tests {
             .map(|s| Suggestion {
                 value: s.into(),
                 description: None,
+                extra: None,
                 span: Span::new(0, s.len()),
             })
             .collect();
@@ -462,6 +463,7 @@ mod tests {
             .map(|s| Suggestion {
                 value: s.into(),
                 description: None,
+                extra: None,
                 span: Span::new(0, s.len()),
             })
             .collect();

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -1,14 +1,14 @@
 mod columnar_menu;
+mod list_menu;
 pub mod menu_functions;
-mod search_menu;
 
 use crate::{
     completion::history::HistoryCompleter, painting::Painter, Completer, History, LineBuffer,
     Suggestion,
 };
 pub use columnar_menu::ColumnarMenu;
+pub use list_menu::ListMenu;
 use nu_ansi_term::{Color, Style};
-pub use search_menu::SearchMenu;
 
 /// Struct to store the menu style
 pub struct MenuTextStyle {

--- a/src/menu/search_menu.rs
+++ b/src/menu/search_menu.rs
@@ -1,13 +1,17 @@
-use super::{
-    menu_functions::{parse_selection_char, string_difference},
-    Menu, MenuEvent, MenuTextStyle,
+use {
+    super::{
+        menu_functions::{parse_selection_char, string_difference},
+        Menu, MenuEvent, MenuTextStyle,
+    },
+    crate::{
+        painting::{estimate_single_line_wraps, Painter},
+        Completer, LineBuffer, Suggestion,
+    },
+    nu_ansi_term::{ansi::RESET, Style},
+    std::iter::Sum,
 };
-use crate::{
-    painting::{estimate_single_line_wraps, Painter},
-    Completer, History, LineBuffer, Span, Suggestion,
-};
-use nu_ansi_term::{ansi::RESET, Style};
-use std::iter::Sum;
+
+const SELECTION_CHAR: char = '!';
 
 struct Page {
     size: usize,
@@ -34,29 +38,28 @@ impl<'a> Sum<&'a Page> for Page {
 
 /// Struct to store the menu style
 /// Context menu definition
-pub struct HistoryMenu {
+pub struct SearchMenu {
+    /// Menu name
+    name: String,
     /// Menu coloring
     color: MenuTextStyle,
-    /// Number of history records pulled until page is full
+    /// Number of records pulled until page is full
     page_size: usize,
     /// Menu marker displayed when the menu is active
     marker: String,
-    /// Character that will start a selection via a number. E.g let!5 will select
-    /// the fifth entry in the current page
-    selection_char: char,
-    /// History menu active status
+    /// Menu active status
     active: bool,
-    /// Cached values collected when querying the history.
+    /// Cached values collected when querying the completer.
     /// When collecting chronological values, the menu only caches at least
     /// page_size records.
-    /// When performing a query to the history object, the cached values will
+    /// When performing a query to the completer, the cached values will
     /// be the result from such query
     values: Vec<Suggestion>,
     /// row position in the menu. Starts from 0
     row_position: u16,
-    /// Max size of the history when querying without a search buffer
-    history_size: Option<usize>,
-    /// Max number of lines that are shown with large history entries
+    /// Max size of the suggestions when querying without a search buffer
+    query_size: Option<usize>,
+    /// Max number of lines that are shown with large suggestions entries
     max_lines: u16,
     /// Multiline marker
     multiline_marker: String,
@@ -70,17 +73,17 @@ pub struct HistoryMenu {
     input: Option<String>,
 }
 
-impl Default for HistoryMenu {
+impl Default for SearchMenu {
     fn default() -> Self {
         Self {
+            name: "search_menu".to_string(),
             color: MenuTextStyle::default(),
             page_size: 10,
-            selection_char: '!',
             active: false,
             values: Vec::new(),
             row_position: 0,
             page: 0,
-            history_size: None,
+            query_size: None,
             marker: "? ".to_string(),
             max_lines: 5,
             multiline_marker: ":::".to_string(),
@@ -91,7 +94,14 @@ impl Default for HistoryMenu {
     }
 }
 
-impl HistoryMenu {
+impl SearchMenu {
+    /// Menu builder with new name
+    #[must_use]
+    pub fn with_name(mut self, name: &str) -> Self {
+        self.name = name.into();
+        self
+    }
+
     /// Menu builder with new value for text style
     #[must_use]
     pub fn with_text_style(mut self, text_style: Style) -> Self {
@@ -106,17 +116,17 @@ impl HistoryMenu {
         self
     }
 
+    /// Menu builder with new value for description style
+    #[must_use]
+    pub fn with_description_text_style(mut self, description_text_style: Style) -> Self {
+        self.color.description_style = description_text_style;
+        self
+    }
+
     /// Menu builder with page size
     #[must_use]
     pub fn with_page_size(mut self, page_size: usize) -> Self {
         self.page_size = page_size;
-        self
-    }
-
-    /// Menu builder with row char
-    #[must_use]
-    pub fn with_selection_char(mut self, selection_char: char) -> Self {
-        self.selection_char = selection_char;
         self
     }
 
@@ -144,33 +154,13 @@ impl HistoryMenu {
         }
     }
 
-    fn create_values_no_query(&mut self, history: &dyn History) -> Vec<String> {
-        // When there is no line buffer it is better to get a partial list of all
-        // the values that can be queried from the history. There is no point to
-        // replicate the whole entries list in the history menu
-        let skip = self.pages.iter().take(self.page).sum::<Page>().size;
-        let take = self
-            .pages
-            .get(self.page)
-            .map(|page| page.size)
-            .unwrap_or(self.page_size);
-
-        history
-            .iter_chronologic()
-            .rev()
-            .skip(skip)
-            .take(take)
-            .cloned()
-            .collect::<Vec<String>>()
-    }
-
     /// The number of rows an entry from the menu can take considering wrapping
     fn number_of_lines(&self, entry: &str, terminal_columns: u16) -> u16 {
         number_of_lines(entry, self.max_lines as usize, terminal_columns)
     }
 
     fn total_values(&self) -> usize {
-        self.history_size.unwrap_or(self.values.len())
+        self.query_size.unwrap_or(self.values.len())
     }
 
     fn values_until_current_page(&self) -> usize {
@@ -203,7 +193,7 @@ impl HistoryMenu {
 
     fn printable_entries(&self, painter: &Painter) -> usize {
         // The number 2 comes from the prompt line and the banner printed at the bottom
-        // of the history menu
+        // of the menu
         let available_lines = painter.screen_height().saturating_sub(2);
         let (printable_entries, _) =
             self.get_values()
@@ -291,27 +281,41 @@ impl HistoryMenu {
     fn create_string(
         &self,
         line: &str,
+        description: Option<&str>,
         index: usize,
         row_number: &str,
         use_ansi_coloring: bool,
     ) -> String {
+        let description = description.map_or("".to_string(), |desc| {
+            if use_ansi_coloring {
+                format!(
+                    "{}({}) {}",
+                    self.color.description_style.prefix(),
+                    desc,
+                    RESET
+                )
+            } else {
+                format!("({}) ", desc)
+            }
+        });
+
         if use_ansi_coloring {
             format!(
                 "{}{}{}{}{}{}",
                 row_number,
+                description,
                 self.text_style(index),
                 &line,
                 RESET,
-                "",
                 Self::end_of_line(),
             )
         } else {
             // If no ansi coloring is found, then the selection word is
             // the line in uppercase
             let line_str = if index == self.index() {
-                format!("{}>{}", row_number, line.to_uppercase())
+                format!("{}{}>{}", row_number, description, line.to_uppercase())
             } else {
-                format!("{}{}", row_number, line)
+                format!("{}{}{}", row_number, description, line)
             };
 
             // Final string with formatting
@@ -320,9 +324,9 @@ impl HistoryMenu {
     }
 }
 
-impl Menu for HistoryMenu {
+impl Menu for SearchMenu {
     fn name(&self) -> &str {
-        "history_menu"
+        self.name.as_str()
     }
 
     /// Menu indicator
@@ -335,18 +339,17 @@ impl Menu for HistoryMenu {
         self.active
     }
 
-    /// There is no use for quick complete for the history menu
+    /// There is no use for quick complete for the menu
     fn can_quick_complete(&self) -> bool {
         false
     }
 
-    /// The history menu should not try to auto complete to avoid comparing
+    /// The menu should not try to auto complete to avoid comparing
     /// all registered values
     fn can_partially_complete(
         &mut self,
         _values_updated: bool,
         _line_buffer: &mut LineBuffer,
-        _history: &dyn History,
         _completer: &dyn Completer,
     ) -> bool {
         false
@@ -366,19 +369,14 @@ impl Menu for HistoryMenu {
         self.event = Some(event);
     }
 
-    /// Collecting the value from the history to be shown in the menu
-    fn update_values(
-        &mut self,
-        line_buffer: &mut LineBuffer,
-        history: &dyn History,
-        _completer: &dyn Completer,
-    ) {
+    /// Collecting the value from the completer to be shown in the menu
+    fn update_values(&mut self, line_buffer: &mut LineBuffer, completer: &dyn Completer) {
         let (start, input) = match &self.input {
             Some(old_string) => string_difference(line_buffer.get_buffer(), old_string),
             None => (line_buffer.insertion_point(), ""),
         };
 
-        let parsed = parse_selection_char(input, self.selection_char);
+        let parsed = parse_selection_char(input, SELECTION_CHAR);
         self.update_row_pos(parsed.index);
 
         // If there are no row selector and the menu has an Edit event, this clears
@@ -387,39 +385,31 @@ impl Menu for HistoryMenu {
             self.reset_position();
         }
 
-        let values = if parsed.remainder.is_empty() {
-            self.history_size = Some(history.max_values());
-            self.create_values_no_query(history)
+        self.values = if parsed.remainder.is_empty() {
+            self.query_size = Some(completer.total_completions(parsed.remainder, start));
+
+            let skip = self.pages.iter().take(self.page).sum::<Page>().size;
+            let take = self
+                .pages
+                .get(self.page)
+                .map(|page| page.size)
+                .unwrap_or(self.page_size);
+
+            completer.partial_complete(input, start, skip, take)
         } else {
-            self.history_size = None;
-            history.query_entries(parsed.remainder)
+            self.query_size = None;
+            completer.complete(input, start)
         };
-
-        self.values = values
-            .into_iter()
-            .map(|value| {
-                let span = Span {
-                    start,
-                    end: start + input.len(),
-                };
-
-                Suggestion {
-                    value,
-                    description: None,
-                    span,
-                }
-            })
-            .collect();
     }
 
     /// Gets values from cached values that will be displayed in the menu
     fn get_values(&self) -> &[Suggestion] {
-        if self.history_size.is_some() {
-            // When there is a history size value it means that only a chunk of the
+        if self.query_size.is_some() {
+            // When there is a size value it means that only a chunk of the
             // chronological data from the database was collected
             &self.values
         } else {
-            // If no history record then it means that the values hold the result
+            // If no record then it means that the values hold the result
             // from the query to the database. This slice can be used to get the
             // data that will be shown in the menu
             if self.values.is_empty() {
@@ -453,7 +443,6 @@ impl Menu for HistoryMenu {
     fn update_working_details(
         &mut self,
         line_buffer: &mut LineBuffer,
-        history: &dyn History,
         completer: &dyn Completer,
         painter: &Painter,
     ) {
@@ -462,7 +451,7 @@ impl Menu for HistoryMenu {
                 MenuEvent::Activate(_) => {
                     self.reset_position();
                     self.input = Some(line_buffer.get_buffer().to_string());
-                    self.update_values(line_buffer, history, completer);
+                    self.update_values(line_buffer, completer);
 
                     self.pages.push(Page {
                         size: self.printable_entries(painter),
@@ -474,7 +463,7 @@ impl Menu for HistoryMenu {
                     self.input = None;
                 }
                 MenuEvent::Edit(_) => {
-                    self.update_values(line_buffer, history, completer);
+                    self.update_values(line_buffer, completer);
                     self.pages.push(Page {
                         size: self.printable_entries(painter),
                         full: false,
@@ -486,7 +475,7 @@ impl Menu for HistoryMenu {
                     if let Some(page) = self.pages.get(self.page) {
                         if new_pos >= page.size as u16 {
                             self.event = Some(MenuEvent::NextPage);
-                            self.update_working_details(line_buffer, history, completer, painter);
+                            self.update_working_details(line_buffer, completer, painter);
                         } else {
                             self.row_position = new_pos;
                         }
@@ -507,7 +496,7 @@ impl Menu for HistoryMenu {
                         }
 
                         self.event = Some(MenuEvent::PreviousPage);
-                        self.update_working_details(line_buffer, history, completer, painter);
+                        self.update_working_details(line_buffer, completer, painter);
                     }
                 }
                 MenuEvent::NextPage => {
@@ -527,12 +516,12 @@ impl Menu for HistoryMenu {
                             }
                         }
 
-                        self.update_values(line_buffer, history, completer);
+                        self.update_values(line_buffer, completer);
                         self.set_actual_page_size(self.printable_entries(painter));
                     } else {
                         self.row_position = 0;
                         self.page = 0;
-                        self.update_values(line_buffer, history, completer);
+                        self.update_values(line_buffer, completer);
                     }
                 }
                 MenuEvent::PreviousPage => {
@@ -540,7 +529,7 @@ impl Menu for HistoryMenu {
                         Some(page_num) => self.page = page_num,
                         None => self.page = self.pages.len().saturating_sub(1),
                     }
-                    self.update_values(line_buffer, history, completer);
+                    self.update_values(line_buffer, completer);
                 }
             }
 
@@ -583,7 +572,13 @@ impl Menu for HistoryMenu {
 
                         let row_number = format!("{}: ", index + values_before_page);
 
-                        self.create_string(&line, index, &row_number, use_ansi_coloring)
+                        self.create_string(
+                            &line,
+                            suggestion.description.as_deref(),
+                            index,
+                            &row_number,
+                            use_ansi_coloring,
+                        )
                     })
                     .collect::<String>();
 


### PR DESCRIPTION
Changes the completion and history menu to become generic templates that can be used with different sources. These templates can be used in nushell and they could be fed using a nushell block