### PR TITLE
clean up query output so that it's closer to matching what key bindings want

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 use strum_macros::EnumIter;
 
 /// Valid ways how `Reedline::read_line()` can return
@@ -144,6 +145,55 @@ pub enum EditCommand {
 
     /// CutUntil left before char
     MoveLeftBefore(char),
+}
+
+impl Display for EditCommand {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            EditCommand::MoveToStart => write!(f, "MoveToStart"),
+            EditCommand::MoveToLineStart => write!(f, "MoveToLineStart"),
+            EditCommand::MoveToEnd => write!(f, "MoveToEnd"),
+            EditCommand::MoveToLineEnd => write!(f, "MoveToLineEnd"),
+            EditCommand::MoveLeft => write!(f, "MoveLeft"),
+            EditCommand::MoveRight => write!(f, "MoveRight"),
+            EditCommand::MoveWordLeft => write!(f, "MoveWordLeft"),
+            EditCommand::MoveWordRight => write!(f, "MoveWordRight"),
+            EditCommand::MoveToPosition(_) => write!(f, "MoveToPosition  Value: <int>"),
+            EditCommand::InsertChar(_) => write!(f, "InsertChar  Value: <char>"),
+            EditCommand::InsertString(_) => write!(f, "InsertString Value: <string>"),
+            EditCommand::ReplaceChars(_, _) => write!(f, "ReplaceChars <int> <string>"),
+            EditCommand::Backspace => write!(f, "Backspace"),
+            EditCommand::Delete => write!(f, "Delete"),
+            EditCommand::BackspaceWord => write!(f, "BackspaceWord"),
+            EditCommand::DeleteWord => write!(f, "DeleteWord"),
+            EditCommand::Clear => write!(f, "Clear"),
+            EditCommand::ClearToLineEnd => write!(f, "ClearToLineEnd"),
+            EditCommand::CutCurrentLine => write!(f, "CutCurrentLine"),
+            EditCommand::CutFromStart => write!(f, "CutFromStart"),
+            EditCommand::CutFromLineStart => write!(f, "CutFromLineStart"),
+            EditCommand::CutToEnd => write!(f, "CutToEnd"),
+            EditCommand::CutToLineEnd => write!(f, "CutToLineEnd"),
+            EditCommand::CutWordLeft => write!(f, "CutWordLeft"),
+            EditCommand::CutWordRight => write!(f, "CutWordRight"),
+            EditCommand::PasteCutBufferBefore => write!(f, "PasteCutBufferBefore"),
+            EditCommand::PasteCutBufferAfter => write!(f, "PasteCutBufferAfter"),
+            EditCommand::UppercaseWord => write!(f, "UppercaseWord"),
+            EditCommand::LowercaseWord => write!(f, "LowercaseWord"),
+            EditCommand::CapitalizeChar => write!(f, "CapitalizeChar"),
+            EditCommand::SwapWords => write!(f, "SwapWords"),
+            EditCommand::SwapGraphemes => write!(f, "SwapGraphemes"),
+            EditCommand::Undo => write!(f, "Undo"),
+            EditCommand::Redo => write!(f, "Redo"),
+            EditCommand::CutRightUntil(_) => write!(f, "CutRightUntil Value: <char>"),
+            EditCommand::CutRightBefore(_) => write!(f, "CutRightBefore Value: <char>"),
+            EditCommand::MoveRightUntil(_) => write!(f, "MoveRightUntil Value: <char>"),
+            EditCommand::MoveRightBefore(_) => write!(f, "MoveRightBefore Value: <char>"),
+            EditCommand::CutLeftUntil(_) => write!(f, "CutLeftUntil Value: <char>"),
+            EditCommand::CutLeftBefore(_) => write!(f, "CutLeftBefore Value: <char>"),
+            EditCommand::MoveLeftUntil(_) => write!(f, "MoveLeftUntil Value: <char>"),
+            EditCommand::MoveLeftBefore(_) => write!(f, "MoveLeftBefore Value: <char>"),
+        }
+    }
 }
 
 impl EditCommand {
@@ -327,6 +377,48 @@ pub enum ReedlineEvent {
 
     /// Way to bind the execution of a whole command (directly returning from [`crate::Reedline::read_line()`]) to a keybinding
     ExecuteHostCommand(String),
+}
+
+impl Display for ReedlineEvent {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            ReedlineEvent::None => write!(f, "None"),
+            ReedlineEvent::HistoryHintComplete => write!(f, "HistoryHintComplete"),
+            ReedlineEvent::HistoryHintWordComplete => write!(f, "HistoryHintWordComplete"),
+            ReedlineEvent::ActionHandler => write!(f, "ActionHandler"),
+            ReedlineEvent::CtrlD => write!(f, "CtrlD"),
+            ReedlineEvent::CtrlC => write!(f, "CtrlC"),
+            ReedlineEvent::ClearScreen => write!(f, "ClearScreen"),
+            ReedlineEvent::Enter => write!(f, "Enter"),
+            ReedlineEvent::Esc => write!(f, "Esc"),
+            ReedlineEvent::Mouse => write!(f, "Mouse"),
+            ReedlineEvent::Resize(_, _) => write!(f, "Resize <int> <int>"),
+            ReedlineEvent::Edit(_) => write!(
+                f,
+                "Edit: <EditCommand> or Edit: <EditCommand> value: <string>"
+            ),
+            ReedlineEvent::Repaint => write!(f, "Repaint"),
+            ReedlineEvent::PreviousHistory => write!(f, "PreviousHistory"),
+            ReedlineEvent::Up => write!(f, "Up"),
+            ReedlineEvent::Down => write!(f, "Down"),
+            ReedlineEvent::Right => write!(f, "Right"),
+            ReedlineEvent::Left => write!(f, "Left"),
+            ReedlineEvent::NextHistory => write!(f, "NextHistory"),
+            ReedlineEvent::SearchHistory => write!(f, "SearchHistory"),
+            ReedlineEvent::Multiple(_) => write!(f, "Multiple[ {{ ReedLineEvents, }} ]"),
+            ReedlineEvent::UntilFound(_) => write!(f, "UntilFound [ {{ ReedLineEvents, }} ]"),
+            ReedlineEvent::Menu(_) => write!(f, "Menu Name: <string>"),
+            ReedlineEvent::MenuNext => write!(f, "MenuNext"),
+            ReedlineEvent::MenuPrevious => write!(f, "MenuPrevious"),
+            ReedlineEvent::MenuUp => write!(f, "MenuUp"),
+            ReedlineEvent::MenuDown => write!(f, "MenuDown"),
+            ReedlineEvent::MenuLeft => write!(f, "MenuLeft"),
+            ReedlineEvent::MenuRight => write!(f, "MenuRight"),
+            ReedlineEvent::MenuPageNext => write!(f, "MenuPageNext"),
+            ReedlineEvent::MenuPagePrevious => write!(f, "MenuPagePrevious"),
+            ReedlineEvent::ExecuteHostCommand(_) => write!(f, "ExecuteHostCommand"),
+        }
+    }
 }
 
 pub(crate) enum EventStatus {

--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -3,47 +3,62 @@ use crate::{
     EditCommand, Keybindings, PromptEditMode, ReedlineEvent,
 };
 use crossterm::event::KeyCode;
+use std::fmt::{Display, Formatter};
 use strum::IntoEnumIterator;
 
-#[derive(Debug)]
-struct KeyCodes;
-impl KeyCodes {
-    pub fn iterator() -> std::slice::Iter<'static, KeyCode> {
-        static KEYCODE: [KeyCode; 29] = [
-            crossterm::event::KeyCode::Backspace,
-            crossterm::event::KeyCode::Enter,
-            crossterm::event::KeyCode::Left,
-            crossterm::event::KeyCode::Right,
-            crossterm::event::KeyCode::Up,
-            crossterm::event::KeyCode::Down,
-            crossterm::event::KeyCode::Home,
-            crossterm::event::KeyCode::End,
-            crossterm::event::KeyCode::PageUp,
-            crossterm::event::KeyCode::PageDown,
-            crossterm::event::KeyCode::Tab,
-            crossterm::event::KeyCode::BackTab,
-            crossterm::event::KeyCode::Delete,
-            crossterm::event::KeyCode::Insert,
-            crossterm::event::KeyCode::F(1),
-            crossterm::event::KeyCode::F(2),
-            crossterm::event::KeyCode::F(3),
-            crossterm::event::KeyCode::F(4),
-            crossterm::event::KeyCode::F(5),
-            crossterm::event::KeyCode::F(6),
-            crossterm::event::KeyCode::F(7),
-            crossterm::event::KeyCode::F(8),
-            crossterm::event::KeyCode::F(9),
-            crossterm::event::KeyCode::F(10),
-            crossterm::event::KeyCode::F(11),
-            crossterm::event::KeyCode::F(12),
-            crossterm::event::KeyCode::Char('a'),
-            crossterm::event::KeyCode::Null,
-            crossterm::event::KeyCode::Esc,
+struct ReedLineCrossTermKeyCode(crossterm::event::KeyCode);
+impl ReedLineCrossTermKeyCode {
+    fn iterator() -> std::slice::Iter<'static, ReedLineCrossTermKeyCode> {
+        static KEYCODE: [ReedLineCrossTermKeyCode; 18] = [
+            ReedLineCrossTermKeyCode(KeyCode::Backspace),
+            ReedLineCrossTermKeyCode(KeyCode::Enter),
+            ReedLineCrossTermKeyCode(KeyCode::Left),
+            ReedLineCrossTermKeyCode(KeyCode::Right),
+            ReedLineCrossTermKeyCode(KeyCode::Up),
+            ReedLineCrossTermKeyCode(KeyCode::Down),
+            ReedLineCrossTermKeyCode(KeyCode::Home),
+            ReedLineCrossTermKeyCode(KeyCode::End),
+            ReedLineCrossTermKeyCode(KeyCode::PageUp),
+            ReedLineCrossTermKeyCode(KeyCode::PageDown),
+            ReedLineCrossTermKeyCode(KeyCode::Tab),
+            ReedLineCrossTermKeyCode(KeyCode::BackTab),
+            ReedLineCrossTermKeyCode(KeyCode::Delete),
+            ReedLineCrossTermKeyCode(KeyCode::Insert),
+            ReedLineCrossTermKeyCode(KeyCode::F(1)),
+            ReedLineCrossTermKeyCode(KeyCode::Char('a')),
+            ReedLineCrossTermKeyCode(KeyCode::Null),
+            ReedLineCrossTermKeyCode(KeyCode::Esc),
         ];
         KEYCODE.iter()
     }
 }
 
+impl Display for ReedLineCrossTermKeyCode {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            ReedLineCrossTermKeyCode(kc) => match kc {
+                KeyCode::Backspace => write!(f, "Backspace"),
+                KeyCode::Enter => write!(f, "Enter"),
+                KeyCode::Left => write!(f, "Left"),
+                KeyCode::Right => write!(f, "Right"),
+                KeyCode::Up => write!(f, "Up"),
+                KeyCode::Down => write!(f, "Down"),
+                KeyCode::Home => write!(f, "Home"),
+                KeyCode::End => write!(f, "End"),
+                KeyCode::PageUp => write!(f, "PageUp"),
+                KeyCode::PageDown => write!(f, "PageDown"),
+                KeyCode::Tab => write!(f, "Tab"),
+                KeyCode::BackTab => write!(f, "BackTab"),
+                KeyCode::Delete => write!(f, "Delete"),
+                KeyCode::Insert => write!(f, "Insert"),
+                KeyCode::F(_) => write!(f, "F<number>"),
+                KeyCode::Char(_) => write!(f, "Char_<letter>"),
+                KeyCode::Null => write!(f, "Null"),
+                KeyCode::Esc => write!(f, "Esc"),
+            },
+        }
+    }
+}
 /// Return a `Vec` of the Reedline Keybinding Modifiers
 pub fn get_reedline_keybinding_modifiers() -> Vec<String> {
     vec![
@@ -61,21 +76,19 @@ pub fn get_reedline_prompt_edit_modes() -> Vec<String> {
 
 /// Return a `Vec<String>` of the Reedline `KeyCode`s
 pub fn get_reedline_keycodes() -> Vec<String> {
-    KeyCodes::iterator().map(|kc| format!("{:?}", kc)).collect()
+    ReedLineCrossTermKeyCode::iterator()
+        .map(|kc| format!("{}", kc))
+        .collect()
 }
 
 /// Return a `Vec<String>` of the Reedline [`ReedlineEvent`]s
 pub fn get_reedline_reedline_events() -> Vec<String> {
-    ReedlineEvent::iter()
-        .map(|rle| format!("{:?}", rle))
-        .collect()
+    ReedlineEvent::iter().map(|rle| rle.to_string()).collect()
 }
 
 /// Return a `Vec<String>` of the Reedline [`EditCommand`]s
 pub fn get_reedline_edit_commands() -> Vec<String> {
-    EditCommand::iter()
-        .map(|edit| format!("{:?}", edit))
-        .collect()
+    EditCommand::iter().map(|edit| edit.to_string()).collect()
 }
 
 /// Get the default keybindings and return a `Vec<(String, String, String, String)>`


### PR DESCRIPTION
This is related to conversations had on Discord where the way we output the keybindings doesn't match how we use them in nushell. This is a first attempt at cleaning that up.

This is what the output of `reedline.exe --list` looks like now.
```
--Key Modifiers--
Alt
Control
Shift
None

--Modes--
Default
Emacs
Vi_Normal
Vi_Insert
Custom_

--Key Codes--
Backspace
Enter
Left
Right
Up
Down
Home
End
PageUp
PageDown
Tab
BackTab
Delete
Insert
F<number>
Char_<letter>
Null
Esc

--Reedline Events--
None
HistoryHintComplete
HistoryHintWordComplete
ActionHandler
CtrlD
CtrlC
ClearScreen
Enter
Esc
Mouse
Resize <int> <int>
Edit: <EditCommand> or Edit: <EditCommand> value: <string>
Repaint
PreviousHistory
Up
Down
Right
Left
NextHistory
SearchHistory
Multiple[ { ReedLineEvents, } ]
UntilFound [ { ReedLineEvents, } ]
Menu Name: <string>
MenuNext
MenuPrevious
MenuUp
MenuDown
MenuLeft
MenuRight
MenuPageNext
MenuPagePrevious
ExecuteHostCommand

--Edit Commands--
MoveToStart
MoveToLineStart
MoveToEnd
MoveToLineEnd
MoveLeft
MoveRight
MoveWordLeft
MoveWordRight
MoveToPosition  Value: <int>
InsertChar  Value: <char>
InsertString Value: <string>
ReplaceChars <int> <string>
Backspace
Delete
BackspaceWord
DeleteWord
Clear
ClearToLineEnd
CutCurrentLine
CutFromStart
CutFromLineStart
CutToEnd
CutToLineEnd
CutWordLeft
CutWordRight
PasteCutBufferBefore
PasteCutBufferAfter
UppercaseWord
LowercaseWord
CapitalizeChar
SwapWords
SwapGraphemes
Undo
Redo
CutRightUntil Value: <char>
CutRightBefore Value: <char>
MoveRightUntil Value: <char>
MoveRightBefore Value: <char>
CutLeftUntil Value: <char>
CutLeftBefore Value: <char>
MoveLeftUntil Value: <char>
MoveLeftBefore Value: <char>
```