### PR TITLE
change up prompt with traditional nushell colors

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -7,7 +7,7 @@ use {
     },
     crossterm::{
         cursor::{self, MoveTo, RestorePosition, SavePosition},
-        style::{Print, ResetColor, SetForegroundColor},
+        style::{Attribute, Print, ResetColor, SetAttribute, SetForegroundColor},
         terminal::{self, Clear, ClearType, ScrollUp},
         QueueableCommand, Result,
     },
@@ -229,7 +229,8 @@ impl Painter {
         // print our prompt with color
         if use_ansi_coloring {
             self.stdout
-                .queue(SetForegroundColor(prompt.get_prompt_color()))?;
+                .queue(SetForegroundColor(prompt.get_prompt_color()))?
+                .queue(SetAttribute(Attribute::Bold))?;
         }
 
         self.stdout
@@ -239,7 +240,20 @@ impl Painter {
             Some(menu) => menu.indicator(),
             None => &lines.prompt_indicator,
         };
+
+        if use_ansi_coloring {
+            self.stdout
+                .queue(SetForegroundColor(prompt.get_indicator_color()))?
+                .queue(SetAttribute(Attribute::Bold))?;
+        }
+
         self.stdout.queue(Print(&coerce_crlf(prompt_indicator)))?;
+
+        if use_ansi_coloring {
+            self.stdout
+                .queue(SetForegroundColor(prompt.get_prompt_right_color()))?
+                .queue(SetAttribute(Attribute::Bold))?;
+        }
 
         self.print_right_prompt(lines)?;
 

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -8,8 +8,10 @@ use {
     strum_macros::EnumIter,
 };
 
-/// The default color for the prompt
-pub static DEFAULT_PROMPT_COLOR: Color = Color::Blue;
+/// The default color for the prompt, indicator, and right prompt
+pub static DEFAULT_PROMPT_COLOR: Color = Color::Green;
+pub static DEFAULT_INDICATOR_COLOR: Color = Color::Cyan;
+pub static DEFAULT_PROMPT_RIGHT_COLOR: Color = Color::AnsiValue(208);
 
 /// The current success/failure of the history search
 pub enum PromptHistorySearchStatus {
@@ -99,8 +101,16 @@ pub trait Prompt: Send {
         &self,
         history_search: PromptHistorySearch,
     ) -> Cow<str>;
-    /// Get back the prompt color
+    /// Get the default prompt color
     fn get_prompt_color(&self) -> Color {
         DEFAULT_PROMPT_COLOR
+    }
+    /// Get the default indicator color
+    fn get_indicator_color(&self) -> Color {
+        DEFAULT_INDICATOR_COLOR
+    }
+    /// Get the default right prompt color
+    fn get_prompt_right_color(&self) -> Color {
+        DEFAULT_PROMPT_RIGHT_COLOR
     }
 }

--- a/src/prompt/default.rs
+++ b/src/prompt/default.rs
@@ -86,7 +86,7 @@ fn get_working_dir() -> Result<String, std::io::Error> {
         },
     };
     let new_path = if path_str != homedir {
-        path_str.replace(&homedir, "~").replace("\\", "/")
+        path_str.replace(&homedir, "~")
     } else {
         path_str
     };

--- a/src/prompt/default.rs
+++ b/src/prompt/default.rs
@@ -77,7 +77,20 @@ impl DefaultPrompt {
 
 fn get_working_dir() -> Result<String, std::io::Error> {
     let path = env::current_dir()?;
-    Ok(path.display().to_string())
+    let path_str = path.display().to_string();
+    let homedir: String = match env::var("USERPROFILE") {
+        Ok(win_home) => win_home,
+        Err(_) => match env::var("HOME") {
+            Ok(maclin_home) => maclin_home,
+            Err(_) => path_str.clone(),
+        },
+    };
+    let new_path = if path_str != homedir {
+        path_str.replace(&homedir, "~").replace("\\", "/")
+    } else {
+        path_str
+    };
+    Ok(new_path)
 }
 
 fn get_now() -> String {


### PR DESCRIPTION
This is totally up for debate. Just looking for something less boring, and less ugly blue. :) I'm up for just about any colors other than everything being the same boring blue.

![image](https://user-images.githubusercontent.com/343840/162253905-5e4e5fbb-8320-476e-aa3e-541858806251.png)
that's in windows - left prompt is `green bold` (like old nushell), indicator is `cyan bold` (like old nushell), right prompt is `dark orange`. left prompt replaces `home dir` with `~` if appropriate and also changes `\\` to `/`.