### PR TITLE
Hack to allow disabling hints.

### DIFF
--- a/src/hinter/mod.rs
+++ b/src/hinter/mod.rs
@@ -1,5 +1,7 @@
 mod default;
+mod noop;
 pub use default::DefaultHinter;
+pub use noop::NoOpHinter;
 
 use crate::History;
 /// A trait that's responsible for returning the hint for the current line and position

--- a/src/hinter/noop.rs
+++ b/src/hinter/noop.rs
@@ -1,0 +1,27 @@
+use super::Hinter;
+
+/// Hinter that does not show or complete a hint
+///
+/// Hacky way of allowing to disable hints
+#[derive(Default)]
+pub struct NoOpHinter {}
+
+impl Hinter for NoOpHinter {
+    fn handle(
+        &mut self,
+        _line: &str,
+        _pos: usize,
+        _history: &dyn crate::History,
+        _use_ansi_coloring: bool,
+    ) -> String {
+        String::new()
+    }
+
+    fn complete_hint(&self) -> String {
+        String::new()
+    }
+
+    fn next_hint_token(&self) -> String {
+        String::new()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ mod completion;
 pub use completion::{Completer, DefaultCompleter, Span, Suggestion};
 
 mod hinter;
-pub use hinter::{DefaultHinter, Hinter};
+pub use hinter::{DefaultHinter, Hinter, NoOpHinter};
 
 mod validator;
 pub use validator::{DefaultValidator, ValidationResult, Validator};


### PR DESCRIPTION
With the current architecture the hints aren't optional and always
active per default.
This can be annoying in environments without ANSI colors as the hint
gets indistinguishable from the normal text.
Simple workaround: have a NoOpHinter

Alternative make the hinter an option throughout its use
