### PR TITLE
Remove `Hinter` and `Validator` from the default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use reedline::ReedlineMenu;
+use reedline::{DefaultValidator, ReedlineMenu};
 
 use {
     crossterm::{
@@ -78,6 +78,7 @@ fn main() -> Result<()> {
         .with_hinter(Box::new(
             DefaultHinter::default().with_style(Style::new().fg(Color::DarkGray)),
         ))
+        .with_validator(Box::new(DefaultValidator))
         .with_ansi_colors(true);
 
     // Adding default menus for the compiled reedline

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -8,6 +8,7 @@ pub trait Validator: Send {
     fn validate(&self, line: &str) -> ValidationResult;
 }
 
+#[derive(Clone, Copy)]
 /// Whether or not the validation shows the input was complete
 pub enum ValidationResult {
     /// An incomplete input which may need to span multiple lines to be complete


### PR DESCRIPTION
Default constructor created a Hinter and Validator.
Disabling those required writing a noop versoin of the trait.
Now they are off by default and can be added or removed via the
"builder" pattern.
