### PR TITLE
Cleanup some stuff found by pedantic clippy

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ For more ideas check out the [feature discussion](https://github.com/nushell/ree
 
 ### Development history
 
-If you want to follow along with the history of how reedline got started, you can watch the [recordings](https://youtube.com/playlist?list=PLP2yfE2-FXdQw0I6O4YdIX_mzBeF5TDdv) of [JT](https://github.com/jntrnr)`s [live-coding streams](https://www.twitch.tv/jntrnr).
+If you want to follow along with the history of how reedline got started, you can watch the [recordings](https://youtube.com/playlist?list=PLP2yfE2-FXdQw0I6O4YdIX_mzBeF5TDdv) of [JT](https://github.com/jntrnr)'s [live-coding streams](https://www.twitch.tv/jntrnr).
 
 [Playlist: Creating a line editor in Rust](https://youtube.com/playlist?list=PLP2yfE2-FXdQw0I6O4YdIX_mzBeF5TDdv)
 

--- a/src/core_editor/edit_stack.rs
+++ b/src/core_editor/edit_stack.rs
@@ -18,9 +18,7 @@ impl<T> EditStack<T> {
 
 impl<T> EditStack<T>
 where
-    T: Default,
-    T: Clone,
-    T: Send,
+    T: Default + Clone + Send,
 {
     /// Go back one point in the undo stack. If present on first edit do nothing
     pub(super) fn undo(&mut self) -> &T {

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -181,15 +181,13 @@ impl Editor {
         self.line_buffer = val.clone();
     }
 
-    pub fn remember_undo_state(&mut self, is_after_action: bool) -> Option<()> {
+    pub fn remember_undo_state(&mut self, is_after_action: bool) {
         if self.edit_stack.current().word_count() == self.line_buffer.word_count()
             && !is_after_action
         {
             self.edit_stack.undo();
         }
         self.edit_stack.insert(self.line_buffer.clone());
-
-        Some(())
     }
 
     fn cut_current_line(&mut self) {

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -51,11 +51,7 @@ where
             let _ = input.next();
             Some(Command::EnterViAppend)
         }
-        Some('0') => {
-            let _ = input.next();
-            Some(Command::MoveToLineStart)
-        }
-        Some('^') => {
+        Some('0' | '^') => {
             let _ = input.next();
             Some(Command::MoveToLineStart)
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -810,7 +810,6 @@ impl Reedline {
 
                 Ok(EventStatus::Handled)
             }
-            ReedlineEvent::Mouse => Ok(EventStatus::Inapplicable),
             ReedlineEvent::Resize(width, height) => {
                 self.painter.handle_resize(width, height);
                 Ok(EventStatus::Handled)
@@ -885,7 +884,7 @@ impl Reedline {
                 // Exhausting the event handlers is still considered handled
                 Ok(EventStatus::Inapplicable)
             }
-            ReedlineEvent::None => Ok(EventStatus::Inapplicable),
+            ReedlineEvent::None | ReedlineEvent::Mouse => Ok(EventStatus::Inapplicable),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@
 //!
 //! ### Development history
 //!
-//! If you want to follow along with the history how reedline got started, you can watch the [recordings](https://youtube.com/playlist?list=PLP2yfE2-FXdQw0I6O4YdIX_mzBeF5TDdv) of [JT](https://github.com/jntrnr)`s [live-coding streams](https://www.twitch.tv/jntrnr).
+//! If you want to follow along with the history how reedline got started, you can watch the [recordings](https://youtube.com/playlist?list=PLP2yfE2-FXdQw0I6O4YdIX_mzBeF5TDdv) of [JT](https://github.com/jntrnr)'s [live-coding streams](https://www.twitch.tv/jntrnr).
 //!
 //! [Playlist: Creating a line editor in Rust](https://youtube.com/playlist?list=PLP2yfE2-FXdQw0I6O4YdIX_mzBeF5TDdv)
 //!

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -140,17 +140,17 @@ pub enum ReedlineMenu {
 impl ReedlineMenu {
     fn as_ref(&self) -> &dyn Menu {
         match self {
-            Self::EngineCompleter(menu) => menu.as_ref(),
-            Self::HistoryMenu(menu) => menu.as_ref(),
-            Self::WithCompleter { menu, .. } => menu.as_ref(),
+            Self::EngineCompleter(menu)
+            | Self::HistoryMenu(menu)
+            | Self::WithCompleter { menu, .. } => menu.as_ref(),
         }
     }
 
     fn as_mut(&mut self) -> &mut dyn Menu {
         match self {
-            Self::EngineCompleter(menu) => menu.as_mut(),
-            Self::HistoryMenu(menu) => menu.as_mut(),
-            Self::WithCompleter { menu, .. } => menu.as_mut(),
+            Self::EngineCompleter(menu)
+            | Self::HistoryMenu(menu)
+            | Self::WithCompleter { menu, .. } => menu.as_mut(),
         }
     }
 
@@ -186,12 +186,14 @@ impl ReedlineMenu {
             Self::EngineCompleter(menu) => menu.update_values(line_buffer, completer),
             Self::HistoryMenu(menu) => {
                 let mut history_completer = HistoryCompleter::new(history);
-                menu.update_values(line_buffer, &mut history_completer)
+                menu.update_values(line_buffer, &mut history_completer);
             }
             Self::WithCompleter {
                 menu,
                 completer: own_completer,
-            } => menu.update_values(line_buffer, own_completer.as_mut()),
+            } => {
+                menu.update_values(line_buffer, own_completer.as_mut());
+            }
         }
     }
 
@@ -204,16 +206,18 @@ impl ReedlineMenu {
     ) {
         match self {
             Self::EngineCompleter(menu) => {
-                menu.update_working_details(line_buffer, completer, painter)
+                menu.update_working_details(line_buffer, completer, painter);
             }
             Self::HistoryMenu(menu) => {
                 let mut history_completer = HistoryCompleter::new(history);
-                menu.update_working_details(line_buffer, &mut history_completer, painter)
+                menu.update_working_details(line_buffer, &mut history_completer, painter);
             }
             Self::WithCompleter {
                 menu,
                 completer: own_completer,
-            } => menu.update_working_details(line_buffer, own_completer.as_mut(), painter),
+            } => {
+                menu.update_working_details(line_buffer, own_completer.as_mut(), painter);
+            }
         }
     }
 }
@@ -232,7 +236,7 @@ impl Menu for ReedlineMenu {
     }
 
     fn menu_event(&mut self, event: MenuEvent) {
-        self.as_mut().menu_event(event)
+        self.as_mut().menu_event(event);
     }
 
     fn can_quick_complete(&self) -> bool {
@@ -246,10 +250,7 @@ impl Menu for ReedlineMenu {
         completer: &mut dyn Completer,
     ) -> bool {
         match self {
-            Self::EngineCompleter(menu) => {
-                menu.can_partially_complete(values_updated, line_buffer, completer)
-            }
-            Self::HistoryMenu(menu) => {
+            Self::EngineCompleter(menu) | Self::HistoryMenu(menu) => {
                 menu.can_partially_complete(values_updated, line_buffer, completer)
             }
             Self::WithCompleter {
@@ -261,12 +262,15 @@ impl Menu for ReedlineMenu {
 
     fn update_values(&mut self, line_buffer: &mut LineBuffer, completer: &mut dyn Completer) {
         match self {
-            Self::EngineCompleter(menu) => menu.update_values(line_buffer, completer),
-            Self::HistoryMenu(menu) => menu.update_values(line_buffer, completer),
+            Self::EngineCompleter(menu) | Self::HistoryMenu(menu) => {
+                menu.update_values(line_buffer, completer);
+            }
             Self::WithCompleter {
                 menu,
                 completer: own_completer,
-            } => menu.update_values(line_buffer, own_completer.as_mut()),
+            } => {
+                menu.update_values(line_buffer, own_completer.as_mut());
+            }
         }
     }
 
@@ -277,19 +281,20 @@ impl Menu for ReedlineMenu {
         painter: &Painter,
     ) {
         match self {
-            Self::EngineCompleter(menu) => {
-                menu.update_working_details(line_buffer, completer, painter)
+            Self::EngineCompleter(menu) | Self::HistoryMenu(menu) => {
+                menu.update_working_details(line_buffer, completer, painter);
             }
-            Self::HistoryMenu(menu) => menu.update_working_details(line_buffer, completer, painter),
             Self::WithCompleter {
                 menu,
                 completer: own_completer,
-            } => menu.update_working_details(line_buffer, own_completer.as_mut(), painter),
+            } => {
+                menu.update_working_details(line_buffer, own_completer.as_mut(), painter);
+            }
         }
     }
 
     fn replace_in_buffer(&self, line_buffer: &mut LineBuffer) {
-        self.as_ref().replace_in_buffer(line_buffer)
+        self.as_ref().replace_in_buffer(line_buffer);
     }
 
     fn menu_required_lines(&self, terminal_columns: u16) -> u16 {


### PR DESCRIPTION
e.g.

- making modifying, non-returning functions more obvious by `;`
termination.
- merging match arms where it improves legibility
