### PR TITLE
Add explicit `EditCommand::InsertNewline`

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -44,6 +44,7 @@ impl Editor {
             EditCommand::MoveWordRight => self.line_buffer.move_word_right(),
             EditCommand::InsertChar(c) => self.insert_char(*c),
             EditCommand::InsertString(str) => self.line_buffer.insert_str(str),
+            EditCommand::InsertNewline => self.line_buffer.insert_newline(),
             EditCommand::ReplaceChars(n_chars, str) => self.replace_chars(*n_chars, str),
             EditCommand::Backspace => self.line_buffer.delete_left_grapheme(),
             EditCommand::Delete => self.line_buffer.delete_right_grapheme(),

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -226,6 +226,17 @@ impl LineBuffer {
         self.insertion_point = self.insertion_point() + string.len();
     }
 
+    /// Inserts the system specific new line character
+    ///
+    /// - On Unix systems LF (`"\n"`)
+    /// - On Windows CRLF (`"\r\n"`)
+    pub fn insert_newline(&mut self) {
+        #[cfg(target_os = "windows")]
+        self.insert_str("\r\n");
+        #[cfg(not(target_os = "windows"))]
+        self.insert_char('\n');
+    }
+
     /// Empty buffer and reset cursor
     pub fn clear(&mut self) {
         self.lines = String::new();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -771,11 +771,7 @@ impl Reedline {
                         Ok(EventStatus::Exits(Signal::Success(buffer)))
                     }
                     Some(ValidationResult::Incomplete) => {
-                        #[cfg(windows)]
-                        {
-                            self.run_edit_commands(&[EditCommand::InsertChar('\r')]);
-                        }
-                        self.run_edit_commands(&[EditCommand::InsertChar('\n')]);
+                        self.run_edit_commands(&[EditCommand::InsertNewline]);
 
                         Ok(EventStatus::Handled)
                     }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -53,6 +53,12 @@ pub enum EditCommand {
     /// Insert a string at the current insertion point
     InsertString(String),
 
+    /// Inserts the system specific new line character
+    ///
+    /// - On Unix systems LF (`"\n"`)
+    /// - On Windows CRLF (`"\r\n"`)
+    InsertNewline,
+
     /// Repace characters with string
     ReplaceChars(usize, String),
 
@@ -161,6 +167,7 @@ impl Display for EditCommand {
             EditCommand::MoveToPosition(_) => write!(f, "MoveToPosition  Value: <int>"),
             EditCommand::InsertChar(_) => write!(f, "InsertChar  Value: <char>"),
             EditCommand::InsertString(_) => write!(f, "InsertString Value: <string>"),
+            EditCommand::InsertNewline => write!(f, "InsertNewline"),
             EditCommand::ReplaceChars(_, _) => write!(f, "ReplaceChars <int> <string>"),
             EditCommand::Backspace => write!(f, "Backspace"),
             EditCommand::Delete => write!(f, "Delete"),
@@ -223,6 +230,7 @@ impl EditCommand {
             EditCommand::Backspace
             | EditCommand::Delete
             | EditCommand::InsertString(_)
+            | EditCommand::InsertNewline
             | EditCommand::ReplaceChars(_, _)
             | EditCommand::BackspaceWord
             | EditCommand::DeleteWord

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use reedline::{DefaultValidator, ReedlineMenu};
+use reedline::{DefaultValidator, EditCommand, ReedlineMenu};
 
 use {
     crossterm::{
@@ -97,10 +97,13 @@ fn main() -> Result<()> {
         add_menu_keybindings(&mut normal_keybindings);
         add_menu_keybindings(&mut insert_keybindings);
 
+        add_newline_keybinding(&mut insert_keybindings);
+
         Box::new(Vi::new(insert_keybindings, normal_keybindings))
     } else {
         let mut keybindings = default_emacs_keybindings();
         add_menu_keybindings(&mut keybindings);
+        add_newline_keybinding(&mut keybindings);
 
         Box::new(Emacs::new(keybindings))
     };
@@ -232,6 +235,15 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
         KeyModifiers::SHIFT,
         KeyCode::BackTab,
         ReedlineEvent::MenuPrevious,
+    );
+}
+
+fn add_newline_keybinding(keybindings: &mut Keybindings) {
+    // This doesn't work for macOS
+    keybindings.add_binding(
+        KeyModifiers::ALT,
+        KeyCode::Enter,
+        ReedlineEvent::Edit(vec![EditCommand::InsertNewline]),
     );
 }
 


### PR DESCRIPTION
Uses the system newline separator

Example in main with `Alt+Enter` (according to @fdncred `cmd-option-enter` or `shift-option-enter` on macOS to get the same key event)
