### PR TITLE
Add better options for screen clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ fn main() -> io::Result<()> {
                 println!("\nAborted!");
                 break Ok(());
             }
-            Signal::CtrlL => {
-                line_editor.clear_screen().unwrap();
-            }
         }
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -384,6 +384,13 @@ impl Reedline {
         Ok(())
     }
 
+    /// Clear the screen and the scollback buffer of the terminal
+    pub fn clear_scrollback(&mut self) -> Result<()> {
+        self.painter.clear_scrollback()?;
+
+        Ok(())
+    }
+
     /// Helper implementing the logic for [`Reedline::read_line()`] to be wrapped
     /// in a `raw_mode` context.
     fn read_line_helper(&mut self, prompt: &dyn Prompt) -> Result<Signal> {
@@ -523,7 +530,14 @@ impl Reedline {
                 self.input_mode = InputMode::Regular;
                 Ok(EventStatus::Exits(Signal::CtrlC))
             }
-            ReedlineEvent::ClearScreen => Ok(EventStatus::Exits(Signal::CtrlL)),
+            ReedlineEvent::ClearScreen => {
+                self.painter.clear_screen()?;
+                Ok(EventStatus::Handled)
+            }
+            ReedlineEvent::ClearScrollback => {
+                self.painter.clear_scrollback()?;
+                Ok(EventStatus::Handled)
+            }
             ReedlineEvent::Enter | ReedlineEvent::HistoryHintComplete => {
                 if let Some(string) = self.history.string_at_cursor() {
                     self.editor.set_buffer(string);
@@ -715,9 +729,7 @@ impl Reedline {
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::Esc => {
-                self.menus
-                    .iter_mut()
-                    .for_each(|menu| menu.menu_event(MenuEvent::Deactivate));
+                self.deactivate_menus();
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::CtrlD => {
@@ -730,18 +742,20 @@ impl Reedline {
                 }
             }
             ReedlineEvent::CtrlC => {
-                self.menus
-                    .iter_mut()
-                    .for_each(|menu| menu.menu_event(MenuEvent::Deactivate));
+                self.deactivate_menus();
                 self.run_edit_commands(&[EditCommand::Clear]);
                 self.editor.reset_undo_stack();
                 Ok(EventStatus::Exits(Signal::CtrlC))
             }
             ReedlineEvent::ClearScreen => {
-                self.menus
-                    .iter_mut()
-                    .for_each(|menu| menu.menu_event(MenuEvent::Deactivate));
-                Ok(EventStatus::Exits(Signal::CtrlL))
+                self.deactivate_menus();
+                self.painter.clear_screen()?;
+                Ok(EventStatus::Handled)
+            }
+            ReedlineEvent::ClearScrollback => {
+                self.deactivate_menus();
+                self.painter.clear_scrollback()?;
+                Ok(EventStatus::Handled)
             }
             ReedlineEvent::Enter => {
                 for menu in self.menus.iter_mut() {
@@ -890,6 +904,12 @@ impl Reedline {
 
     fn active_menu(&mut self) -> Option<&mut ReedlineMenu> {
         self.menus.iter_mut().find(|menu| menu.is_active())
+    }
+
+    fn deactivate_menus(&mut self) {
+        self.menus
+            .iter_mut()
+            .for_each(|menu| menu.menu_event(MenuEvent::Deactivate));
     }
 
     fn previous_history(&mut self) {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -11,8 +11,6 @@ pub enum Signal {
     CtrlC, // Interrupt current editing
     /// Abort with `Ctrl+D` signalling `EOF` or abort of a whole interactive session
     CtrlD, // End terminal session
-    /// Signal to clear the current screen. Buffer content remains untouched.
-    CtrlL, // FormFeed/Clear current screen
 }
 
 /// Editing actions which can be mapped to key bindings.
@@ -302,6 +300,11 @@ pub enum ReedlineEvent {
     /// Clears the screen and sets prompt to first line
     ClearScreen,
 
+    /// Clears the screen and the scrollback buffer
+    ///
+    /// Sets the prompt back to the first line
+    ClearScrollback,
+
     /// Handle enter event
     Enter,
 
@@ -389,6 +392,7 @@ impl Display for ReedlineEvent {
             ReedlineEvent::CtrlD => write!(f, "CtrlD"),
             ReedlineEvent::CtrlC => write!(f, "CtrlC"),
             ReedlineEvent::ClearScreen => write!(f, "ClearScreen"),
+            ReedlineEvent::ClearScrollback => write!(f, "ClearScrollback"),
             ReedlineEvent::Enter => write!(f, "Enter"),
             ReedlineEvent::Esc => write!(f, "Esc"),
             ReedlineEvent::Mouse => write!(f, "Mouse"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,6 @@
 //!              println!("\nAborted!");
 //!              break;
 //!          }
-//!          Ok(Signal::CtrlL) => {
-//!              line_editor.clear_screen();
-//!          }
 //!          x => {
 //!              println!("Event: {:?}", x);
 //!          }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ fn main() -> Result<()> {
                     break;
                 }
                 if buffer.trim() == "clear" {
-                    line_editor.clear_screen()?;
+                    line_editor.clear_scrollback()?;
                     continue;
                 }
                 if buffer.trim() == "history" {
@@ -132,9 +132,6 @@ fn main() -> Result<()> {
             }
             Ok(Signal::CtrlC) => {
                 // Prompt has been cleared and should start on the next line
-            }
-            Ok(Signal::CtrlL) => {
-                line_editor.clear_screen()?;
             }
             Err(err) => {
                 println!("Error: {:?}", err);

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -423,7 +423,17 @@ impl Painter {
         self.stdout.queue(MoveTo(0, 0))?;
         self.stdout.queue(cursor::Show)?;
 
-        self.stdout.flush()
+        self.stdout.flush()?;
+        self.initialize_prompt_position()
+    }
+
+    pub(crate) fn clear_scrollback(&mut self) -> Result<()> {
+        self.stdout
+            .queue(crossterm::terminal::Clear(ClearType::Purge))?
+            .queue(crossterm::terminal::Clear(ClearType::All))?
+            .queue(cursor::MoveTo(0, 0))?
+            .flush()?;
+        self.initialize_prompt_position()
     }
 
     // The prompt is moved to the end of the buffer after the event was handled


### PR DESCRIPTION
**Warning API break:** removes a variant from `Signal`

- Remove the `Signal::CtrlL` as it requires explicit handling and
cooperation but we offer configurable keybindings already
- Default keybinding of `Ctrl-l` is `ReedlineEvent::ClearScreen` that
directly performs the scrollback buffer preserving clear of the current
screen.
- Add `ReedlineEvent::ClearScrollback` to perform screen clearing with
removal of the scrollback buffer. (Demo will now do that on clear as
seen in bash, zsh etc.)

Fixes #120

Helps with nushell/nushell#5089
