### PR TITLE
SQLite History (third version)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ jobs:
       matrix:
         rust:
           - stable
+        features:
+          - ""
+          - sqlite
+          - bashisms
+          - bashisms,sqlite
 
     steps:
       - uses: actions/checkout@v2
@@ -22,17 +27,11 @@ jobs:
 
       - uses: actions-rs/cargo@v1
         with:
-          command: build
-
+          command: build --features ${{ matrix.features }}
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace 
-      
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --features sqlite
+          args: --workspace --features ${{ matrix.features }}
 
       - uses: actions-rs/cargo@v1
         with:
@@ -42,9 +41,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features sqlite -- -D warnings
+          args: --features ${{ matrix.features }} -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,12 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all 
+          args: --workspace 
+      
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --features sqlite
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,8 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features sqlite -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 history.txt
+history.sqlite3
 .DS_Store
 target-coverage/
 tarpaulin-report.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 target/
 history.txt
-history.sqlite3
+history.sqlite3*
 .DS_Store
 target-coverage/
 tarpaulin-report.html

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ history.sqlite3*
 target-coverage/
 tarpaulin-report.html
 .vscode
+.helix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
+ "thiserror",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -713,6 +714,26 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +157,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +186,35 @@ dependencies = [
  "cfg-if",
  "rustix",
  "windows-sys 0.30.0",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -187,10 +239,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "libc"
 version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -224,6 +292,12 @@ checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "mio"
@@ -315,6 +389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +431,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.32.0",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "pretty_assertions"
@@ -402,7 +488,9 @@ dependencies = [
  "nu-ansi-term",
  "pretty_assertions",
  "rstest",
+ "rusqlite",
  "serde",
+ "serde_json",
  "strip-ansi-escapes",
  "strum",
  "strum_macros",
@@ -431,6 +519,21 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
 ]
 
 [[package]]
@@ -463,6 +566,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +601,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -617,6 +737,18 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vte"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +496,7 @@ dependencies = [
  "clipboard",
  "crossterm",
  "fd-lock",
+ "gethostname",
  "nu-ansi-term",
  "pretty_assertions",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ strum_macros = "0.24"
 fd-lock = "3.0.3"
 rusqlite = { version = "0.27.0", optional = true, features = ["bundled"] }
 serde_json = { version = "1.0.79", optional = true }
+gethostname = { version = "0.2.3", optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"
@@ -38,4 +39,4 @@ rstest = "0.12.0"
 [features]
 system_clipboard = ["clipboard"]
 bashisms = []
-sqlite = ["rusqlite", "serde_json"]
+sqlite = ["rusqlite", "serde_json", "gethostname"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ strip-ansi-escapes = "0.1.1"
 strum = "0.24"
 strum_macros = "0.24"
 fd-lock = "3.0.3"
+rusqlite = { version = "0.27.0", optional = true }
+serde_json = { version = "1.0.79", optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"
@@ -36,3 +38,4 @@ rstest = "0.12.0"
 [features]
 system_clipboard = ["clipboard"]
 bashisms = []
+sqlite = ["rusqlite", "serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ fd-lock = "3.0.3"
 rusqlite = { version = "0.27.0", optional = true, features = ["bundled"] }
 serde_json = { version = "1.0.79", optional = true }
 gethostname = { version = "0.2.3", optional = true }
+thiserror = "1.0.31"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ strip-ansi-escapes = "0.1.1"
 strum = "0.24"
 strum_macros = "0.24"
 fd-lock = "3.0.3"
-rusqlite = { version = "0.27.0", optional = true }
+rusqlite = { version = "0.27.0", optional = true, features = ["bundled"] }
 serde_json = { version = "1.0.79", optional = true }
 
 [dev-dependencies]

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -31,13 +31,7 @@ impl<'menu> Completer for HistoryCompleter<'menu> {
             .collect()
     }
 
-    /*TODO: fn partial_complete(
-        &mut self,
-        line: &str,
-        pos: usize,
-        start: usize,
-        offset: usize,
-    ) -> Vec<Suggestion> {*/
+    // TODO: Implement `fn partial_complete()`
 
     fn total_completions(&mut self, line: &str, _pos: usize) -> usize {
         let parsed = parse_selection_char(line, SELECTION_CHAR);

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -1,6 +1,9 @@
 use std::ops::Deref;
 
-use crate::{menu_functions::parse_selection_char, Completer, History, Span, Suggestion};
+use crate::{
+    history::SearchQuery, menu_functions::parse_selection_char, Completer, History, Span,
+    Suggestion,
+};
 
 const SELECTION_CHAR: char = '!';
 
@@ -15,32 +18,36 @@ unsafe impl<'menu> Send for HistoryCompleter<'menu> {}
 impl<'menu> Completer for HistoryCompleter<'menu> {
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
         let parsed = parse_selection_char(line, SELECTION_CHAR);
-        let values = self.0.query_entries(parsed.remainder);
+        let values = self
+            .0
+            .search(SearchQuery::all_that_contain_rev(
+                parsed.remainder.to_string(),
+            ))
+            .expect("todo: error handling");
 
         values
             .into_iter()
-            .map(|value| self.create_suggestion(line, pos, value.deref()))
+            .map(|value| self.create_suggestion(line, pos, value.command_line.deref()))
             .collect()
     }
 
-    fn partial_complete(
+    /*TODO: fn partial_complete(
         &mut self,
         line: &str,
         pos: usize,
         start: usize,
         offset: usize,
-    ) -> Vec<Suggestion> {
-        self.0
-            .iter_chronologic()
-            .rev()
-            .skip(start)
-            .take(offset)
-            .map(|value| self.create_suggestion(line, pos, value.deref()))
-            .collect()
-    }
+    ) -> Vec<Suggestion> {*/
 
-    fn total_completions(&mut self, _line: &str, _pos: usize) -> usize {
-        self.0.max_values()
+    fn total_completions(&mut self, line: &str, _pos: usize) -> usize {
+        let parsed = parse_selection_char(line, SELECTION_CHAR);
+        let count = self
+            .0
+            .count(SearchQuery::all_that_contain_rev(
+                parsed.remainder.to_string(),
+            ))
+            .expect("todo: error handling");
+        count as usize
     }
 }
 

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -23,6 +23,9 @@ impl Default for Editor {
 }
 
 impl Editor {
+    pub fn line_buffer_immut(&self) -> &LineBuffer {
+        &self.line_buffer
+    }
     pub fn line_buffer(&mut self) -> &mut LineBuffer {
         &mut self.line_buffer
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -397,7 +397,9 @@ impl Reedline {
         if let Some(r) = &self.history_last_run_id {
             self.history.update(*r, f)?;
         } else {
-            return Err(ReedlineError(ReedlineErrorVariants::OtherHistoryError("No command run")));
+            return Err(ReedlineError(ReedlineErrorVariants::OtherHistoryError(
+                "No command run",
+            )));
         }
         Ok(())
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,7 +6,7 @@ use {
         enums::{EventStatus, ReedlineEvent},
         highlighter::SimpleMatchHighlighter,
         hinter::Hinter,
-        history::{FileBackedHistory, HistoryNavigationQuery, Result as HistoryResult},
+        history::{FileBackedHistory, HistoryNavigationQuery},
         painting::{Painter, PromptLines},
         prompt::{PromptEditMode, PromptHistorySearchStatus},
         utils::text_manipulation,
@@ -21,9 +21,12 @@ use {
     std::{borrow::Borrow, io, time::Duration},
 };
 
-use crate::{history::History, ReedlineMenu, Menu, MenuEvent};
 #[cfg(feature = "bashisms")]
 use crate::menu_functions::{parse_selection_char, ParseAction};
+use crate::{
+    history::{History, HistoryCursor, HistoryItem, HistoryItemId, SearchDirection, SearchQuery},
+    LineBuffer, Menu, MenuEvent, ReedlineMenu,
+};
 
 // The POLL_WAIT is used to specify for how long the POLL should wait for
 // events, to accelerate the handling of paste or compound resize events. Having
@@ -79,6 +82,8 @@ pub struct Reedline {
 
     // History
     history: Box<dyn History>,
+    history_cursor: HistoryCursor,
+    history_last_run_id: Option<HistoryItemId>,
     input_mode: InputMode,
 
     // Validator
@@ -138,6 +143,10 @@ impl Reedline {
         Reedline {
             editor: Editor::default(),
             history,
+            history_cursor: HistoryCursor::new(HistoryNavigationQuery::Normal(
+                LineBuffer::default(),
+            )),
+            history_last_run_id: None,
             input_mode: InputMode::Regular,
             painter,
             edit_mode,
@@ -334,12 +343,11 @@ impl Reedline {
     pub fn print_history(&mut self) -> Result<()> {
         let history: Vec<_> = self
             .history
-            .iter_chronologic()
-            .enumerate()
-            .collect();
+            .search(SearchQuery::everything(SearchDirection::Forward))
+            .expect("todo: error handling");
 
-        for (i, entry) in history {
-            self.print_line(&format!("{}\t{}", i, entry))?;
+        for (i, entry) in history.iter().enumerate() {
+            self.print_line(&format!("{}\t{}", i, entry.command_line))?;
         }
         Ok(())
     }
@@ -350,9 +358,22 @@ impl Reedline {
     }
 
     /// Update the underlying [`History`] to/from disk
-    pub fn sync_history(&mut self) -> HistoryResult<()> {
+    pub fn sync_history(&mut self) -> std::io::Result<()> {
         // TODO: check for interactions in the non-submitting events
         self.history.sync()
+    }
+
+    /// update the last history item with more information
+    pub fn update_last_command_context(
+        &mut self,
+        f: &dyn Fn(HistoryItem) -> HistoryItem,
+    ) -> crate::history::Result<()> {
+        if let Some(r) = &self.history_last_run_id {
+            self.history.update(*r, f)?;
+        } else {
+            return Err("No command run".to_string());
+        }
+        Ok(())
     }
 
     /// Wait for input and provide the user with a specified [`Prompt`].
@@ -524,7 +545,7 @@ impl Reedline {
             }
             ReedlineEvent::ClearScreen => Ok(EventStatus::Exits(Signal::CtrlL)),
             ReedlineEvent::Enter | ReedlineEvent::HistoryHintComplete => {
-                if let Some(string) = self.history.string_at_cursor() {
+                if let Some(string) = self.history_cursor.string_at_cursor() {
                     self.editor.set_buffer(string);
                     self.editor.remember_undo_state(true);
                 }
@@ -550,14 +571,14 @@ impl Reedline {
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::PreviousHistory | ReedlineEvent::Up | ReedlineEvent::SearchHistory => {
-                self.history.back();
+                self.history_cursor.back(self.history.as_ref()).expect("todo: error handling");
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::NextHistory | ReedlineEvent::Down => {
-                self.history.forward();
+                self.history_cursor.forward(self.history.as_ref()).expect("todo: error handling");
                 // Hacky way to ensure that we don't fall of into failed search going forward
-                if self.history.string_at_cursor().is_none() {
-                    self.history.back();
+                if self.history_cursor.string_at_cursor().is_none() {
+                    self.history_cursor.back(self.history.as_ref()).expect("todo: error handling");
                 }
                 Ok(EventStatus::Handled)
             }
@@ -763,7 +784,9 @@ impl Reedline {
                         self.hide_hints = true;
                         // Additional repaint to show the content without hints etc.
                         self.repaint(prompt)?;
-                        self.history.append(self.editor.get_buffer());
+                        let entry = HistoryItem::from_command_line(self.editor.get_buffer().to_string());
+                        let entry = self.history.save(entry).expect("todo: error handling");
+                        self.history_last_run_id = entry.id;
                         self.run_edit_commands(&[EditCommand::Clear]);
                         self.editor.reset_undo_stack();
 
@@ -894,10 +917,13 @@ impl Reedline {
     fn previous_history(&mut self) {
         if self.input_mode != InputMode::HistoryTraversal {
             self.input_mode = InputMode::HistoryTraversal;
-            self.set_history_navigation_based_on_line_buffer();
+            self.history_cursor =
+                HistoryCursor::new(self.get_history_navigation_based_on_line_buffer());
         }
 
-        self.history.back();
+        self.history_cursor
+            .back(self.history.as_ref())
+            .expect("todo: error handling");
         self.update_buffer_from_history();
         self.editor.move_to_start();
         self.editor.move_to_line_end();
@@ -906,10 +932,13 @@ impl Reedline {
     fn next_history(&mut self) {
         if self.input_mode != InputMode::HistoryTraversal {
             self.input_mode = InputMode::HistoryTraversal;
-            self.set_history_navigation_based_on_line_buffer();
+            self.history_cursor =
+                HistoryCursor::new(self.get_history_navigation_based_on_line_buffer());
         }
 
-        self.history.forward();
+        self.history_cursor
+            .forward(self.history.as_ref())
+            .expect("todo: error handling");
         self.update_buffer_from_history();
         self.editor.move_to_end();
     }
@@ -917,13 +946,13 @@ impl Reedline {
     /// Enable the search and navigation through the history from the line buffer prompt
     ///
     /// Enables either prefix search with output in the line buffer or simple traversal
-    fn set_history_navigation_based_on_line_buffer(&mut self) {
+    fn get_history_navigation_based_on_line_buffer(&self) -> HistoryNavigationQuery {
         if self.editor.is_empty() || !self.editor.is_cursor_at_buffer_end() {
             // Perform bash-style basic up/down entry walking
-            self.history.set_navigation(HistoryNavigationQuery::Normal(
+            HistoryNavigationQuery::Normal(
                 // Hack: Tight coupling point to be able to restore previously typed input
-                self.editor.line_buffer().clone(),
-            ));
+                self.editor.line_buffer_immut().clone(),
+            )
         } else {
             // Prefix search like found in fish, zsh, etc.
             // Search string is set once from the current buffer
@@ -931,8 +960,7 @@ impl Reedline {
             // Continuing with typing will leave the search
             // but next invocation of this method will start the next search
             let buffer = self.editor.get_buffer().to_string();
-            self.history
-                .set_navigation(HistoryNavigationQuery::PrefixSearch(buffer));
+            HistoryNavigationQuery::PrefixSearch(buffer)
         }
     }
 
@@ -940,9 +968,9 @@ impl Reedline {
     ///
     /// This mode uses a separate prompt and handles keybindings slightly differently!
     fn enter_history_search(&mut self) {
+        self.history_cursor =
+            HistoryCursor::new(HistoryNavigationQuery::SubstringSearch("".to_string()));
         self.input_mode = InputMode::HistorySearch;
-        self.history
-            .set_navigation(HistoryNavigationQuery::SubstringSearch("".to_string()));
     }
 
     /// Dispatches the applicable [`EditCommand`] actions for editing the history search string.
@@ -952,30 +980,28 @@ impl Reedline {
         for command in commands {
             match command {
                 EditCommand::InsertChar(c) => {
-                    let navigation = self.history.get_navigation();
+                    let navigation = self.history_cursor.get_navigation();
                     if let HistoryNavigationQuery::SubstringSearch(mut substring) = navigation {
                         substring.push(*c);
-                        self.history
-                            .set_navigation(HistoryNavigationQuery::SubstringSearch(substring));
+                        self.history_cursor =
+                            HistoryCursor::new(HistoryNavigationQuery::SubstringSearch(substring));
                     } else {
-                        self.history
-                            .set_navigation(HistoryNavigationQuery::SubstringSearch(String::from(
-                                *c,
-                            )));
+                        self.history_cursor = HistoryCursor::new(
+                            HistoryNavigationQuery::SubstringSearch(String::from(*c)),
+                        );
                     }
-                    self.history.back();
+                    self.history_cursor.back(self.history.as_mut()).expect("todo: error handling");
                 }
                 EditCommand::Backspace => {
-                    let navigation = self.history.get_navigation();
+                    let navigation = self.history_cursor.get_navigation();
 
                     if let HistoryNavigationQuery::SubstringSearch(substring) = navigation {
                         let new_substring = text_manipulation::remove_last_grapheme(&substring);
 
-                        self.history
-                            .set_navigation(HistoryNavigationQuery::SubstringSearch(
-                                new_substring.to_string(),
-                            ));
-                        self.history.back();
+                        self.history_cursor = HistoryCursor::new(
+                            HistoryNavigationQuery::SubstringSearch(new_substring.to_string()),
+                        );
+                        self.history_cursor.back(self.history.as_mut()).expect("todo: error handling");
                     }
                 }
                 _ => {
@@ -990,9 +1016,9 @@ impl Reedline {
     /// When using the up/down traversal or fish/zsh style prefix search update the main line buffer accordingly.
     /// Not used for the separate modal reverse search!
     fn update_buffer_from_history(&mut self) {
-        match self.history.get_navigation() {
+        match self.history_cursor.get_navigation() {
             HistoryNavigationQuery::Normal(original) => {
-                if let Some(buffer_to_paint) = self.history.string_at_cursor() {
+                if let Some(buffer_to_paint) = self.history_cursor.string_at_cursor() {
                     self.editor.set_buffer(buffer_to_paint.clone());
                     self.editor.set_insertion_point(buffer_to_paint.len());
                 } else {
@@ -1001,7 +1027,7 @@ impl Reedline {
                 }
             }
             HistoryNavigationQuery::PrefixSearch(prefix) => {
-                if let Some(prefix_result) = self.history.string_at_cursor() {
+                if let Some(prefix_result) = self.history_cursor.string_at_cursor() {
                     self.editor.set_buffer(prefix_result.clone());
                     self.editor.set_insertion_point(prefix_result.len());
                 } else {
@@ -1017,10 +1043,10 @@ impl Reedline {
     fn run_edit_commands(&mut self, commands: &[EditCommand]) {
         if self.input_mode == InputMode::HistoryTraversal {
             if matches!(
-                self.history.get_navigation(),
+                self.history_cursor.get_navigation(),
                 HistoryNavigationQuery::Normal(_)
             ) {
-                if let Some(string) = self.history.string_at_cursor() {
+                if let Some(string) = self.history_cursor.string_at_cursor() {
                     self.editor.set_buffer(string);
                 }
             }
@@ -1055,7 +1081,7 @@ impl Reedline {
 
     /// Checks if hints should be displayed and are able to be completed
     fn hints_active(&self) -> bool {
-        !self.hide_hints && self.input_mode == InputMode::Regular
+        !self.hide_hints && matches!(self.input_mode, InputMode::Regular)
     }
 
     /// Repaint of either the buffer or the parts for reverse history search
@@ -1121,18 +1147,19 @@ impl Reedline {
     /// Overwrites the prompt indicator and highlights the search string
     /// separately from the result buffer.
     fn history_search_paint(&mut self, prompt: &dyn Prompt) -> Result<()> {
-        let navigation = self.history.get_navigation();
+        let navigation = self.history_cursor.get_navigation();
 
         if let HistoryNavigationQuery::SubstringSearch(substring) = navigation {
-            let status = if !substring.is_empty() && self.history.string_at_cursor().is_none() {
-                PromptHistorySearchStatus::Failing
-            } else {
-                PromptHistorySearchStatus::Passing
-            };
+            let status =
+                if !substring.is_empty() && self.history_cursor.string_at_cursor().is_none() {
+                    PromptHistorySearchStatus::Failing
+                } else {
+                    PromptHistorySearchStatus::Passing
+                };
 
             let prompt_history_search = PromptHistorySearch::new(status, substring.clone());
 
-            let res_string = self.history.string_at_cursor().unwrap_or_default();
+            let res_string = self.history_cursor.string_at_cursor().unwrap_or_default();
 
             // Highlight matches
             let res_string = if self.use_ansi_coloring {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -837,14 +837,12 @@ impl Reedline {
                         if !buf.is_empty() {
                             let mut entry = HistoryItem::from_command_line(buf);
                             // todo: in theory there's a race condition here because another shell might get the next session id at the same time
-                            entry.session_id = Some(
-                                *self.history_session_id
-                                    .get_or_insert_with(|| {
-                                        self.history
-                                            .next_session_id()
-                                            .expect("todo: error handling")
-                                    }),
-                            );
+                            entry.session_id =
+                                Some(*self.history_session_id.get_or_insert_with(|| {
+                                    self.history
+                                        .next_session_id()
+                                        .expect("todo: error handling")
+                                }));
                             let entry = self.history.save(entry).expect("todo: error handling");
                             self.history_last_run_id = entry.id;
                         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -575,14 +575,20 @@ impl Reedline {
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::PreviousHistory | ReedlineEvent::Up | ReedlineEvent::SearchHistory => {
-                self.history_cursor.back(self.history.as_ref()).expect("todo: error handling");
+                self.history_cursor
+                    .back(self.history.as_ref())
+                    .expect("todo: error handling");
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::NextHistory | ReedlineEvent::Down => {
-                self.history_cursor.forward(self.history.as_ref()).expect("todo: error handling");
+                self.history_cursor
+                    .forward(self.history.as_ref())
+                    .expect("todo: error handling");
                 // Hacky way to ensure that we don't fall of into failed search going forward
                 if self.history_cursor.string_at_cursor().is_none() {
-                    self.history_cursor.back(self.history.as_ref()).expect("todo: error handling");
+                    self.history_cursor
+                        .back(self.history.as_ref())
+                        .expect("todo: error handling");
                 }
                 Ok(EventStatus::Handled)
             }
@@ -994,7 +1000,9 @@ impl Reedline {
                             HistoryNavigationQuery::SubstringSearch(String::from(*c)),
                         );
                     }
-                    self.history_cursor.back(self.history.as_mut()).expect("todo: error handling");
+                    self.history_cursor
+                        .back(self.history.as_mut())
+                        .expect("todo: error handling");
                 }
                 EditCommand::Backspace => {
                     let navigation = self.history_cursor.get_navigation();
@@ -1005,7 +1013,9 @@ impl Reedline {
                         self.history_cursor = HistoryCursor::new(
                             HistoryNavigationQuery::SubstringSearch(new_substring.to_string()),
                         );
-                        self.history_cursor.back(self.history.as_mut()).expect("todo: error handling");
+                        self.history_cursor
+                            .back(self.history.as_mut())
+                            .expect("todo: error handling");
                     }
                 }
                 _ => {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -356,6 +356,10 @@ impl Reedline {
     pub fn history(&self) -> &dyn History {
         &*self.history
     }
+    /// Read-write view of the history
+    pub fn history_mut(&mut self) -> &mut dyn History {
+        &mut *self.history
+    }
 
     /// Update the underlying [`History`] to/from disk
     pub fn sync_history(&mut self) -> std::io::Result<()> {
@@ -784,7 +788,7 @@ impl Reedline {
                         self.hide_hints = true;
                         // Additional repaint to show the content without hints etc.
                         self.repaint(prompt)?;
-                        let entry = HistoryItem::from_command_line(self.editor.get_buffer().to_string());
+                        let entry = HistoryItem::from_command_line(self.editor.get_buffer());
                         let entry = self.history.save(entry).expect("todo: error handling");
                         self.history_last_run_id = entry.id;
                         self.run_edit_commands(&[EditCommand::Clear]);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -838,13 +838,12 @@ impl Reedline {
                             let mut entry = HistoryItem::from_command_line(buf);
                             // todo: in theory there's a race condition here because another shell might get the next session id at the same time
                             entry.session_id = Some(
-                                self.history_session_id
+                                *self.history_session_id
                                     .get_or_insert_with(|| {
                                         self.history
                                             .next_session_id()
                                             .expect("todo: error handling")
-                                    })
-                                    .clone(),
+                                    }),
                             );
                             let entry = self.history.save(entry).expect("todo: error handling");
                             self.history_last_run_id = entry.id;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "bashisms")]
 use crate::{
-    menu_functions::{parse_selection_char, ParseAction},
     history::SearchFilter,
+    menu_functions::{parse_selection_char, ParseAction},
 };
 
 use crate::result::{ReedlineError, ReedlineErrorVariants};

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -790,17 +790,22 @@ impl Reedline {
                         self.hide_hints = true;
                         // Additional repaint to show the content without hints etc.
                         self.repaint(prompt)?;
-                        let mut entry = HistoryItem::from_command_line(self.editor.get_buffer());
-                        // todo: in theory there's a race condition here because another shell might get the next session id at the same time
-                        entry.session_id = Some(
-                            self.history_session_id
-                                .get_or_insert_with(|| {
-                                    self.history.next_session_id().expect("todo: error handling")
-                                })
-                                .clone(),
-                        );
-                        let entry = self.history.save(entry).expect("todo: error handling");
-                        self.history_last_run_id = entry.id;
+                        let buf = self.editor.get_buffer();
+                        if !buf.is_empty() {
+                            let mut entry = HistoryItem::from_command_line(buf);
+                            // todo: in theory there's a race condition here because another shell might get the next session id at the same time
+                            entry.session_id = Some(
+                                self.history_session_id
+                                    .get_or_insert_with(|| {
+                                        self.history
+                                            .next_session_id()
+                                            .expect("todo: error handling")
+                                    })
+                                    .clone(),
+                            );
+                            let entry = self.history.save(entry).expect("todo: error handling");
+                            self.history_last_run_id = entry.id;
+                        }
                         self.run_edit_commands(&[EditCommand::Clear]);
                         self.editor.reset_undo_stack();
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "bashisms")]
 use crate::menu_functions::{parse_selection_char, ParseAction};
+use crate::result::{ReedlineError, ReedlineErrorVariants};
 use {
     crate::{
         completion::{CircularCompletionHandler, Completer, DefaultCompleter},
@@ -392,11 +393,11 @@ impl Reedline {
     pub fn update_last_command_context(
         &mut self,
         f: &dyn Fn(HistoryItem) -> HistoryItem,
-    ) -> crate::history::Result<()> {
+    ) -> crate::Result<()> {
         if let Some(r) = &self.history_last_run_id {
             self.history.update(*r, f)?;
         } else {
-            return Err("No command run".to_string());
+            return Err(ReedlineError(ReedlineErrorVariants::OtherHistoryError("No command run")));
         }
         Ok(())
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -335,7 +335,6 @@ impl Reedline {
         let history: Vec<_> = self
             .history
             .iter_chronologic()
-            .cloned()
             .enumerate()
             .collect();
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1188,7 +1188,7 @@ impl Reedline {
                         end_time: None,
                         start_id: None,
                         end_id: None,
-                        limit: None,
+                        limit: Some(index as i64), // fetch the latest n entries
                         filter: SearchFilter::anything(),
                     })
                     .unwrap_or_else(|_| Vec::new())
@@ -1208,7 +1208,7 @@ impl Reedline {
                         end_time: None,
                         start_id: None,
                         end_id: None,
-                        limit: None,
+                        limit: Some((index + 1) as i64), // fetch the oldest n entries
                         filter: SearchFilter::anything(),
                     })
                     .unwrap_or_else(|_| Vec::new())
@@ -1222,15 +1222,7 @@ impl Reedline {
                     }),
                 ParseAction::LastToken => self
                     .history
-                    .search(SearchQuery {
-                        direction: SearchDirection::Backward,
-                        start_time: None,
-                        end_time: None,
-                        start_id: None,
-                        end_id: None,
-                        limit: None,
-                        filter: SearchFilter::anything(),
-                    })
+                    .search(SearchQuery::last_with_search(SearchFilter::anything()))
                     .unwrap_or_else(|_| Vec::new())
                     .get(0)
                     .and_then(|history| history.command_line.split_whitespace().rev().next())

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,8 +6,7 @@ use {
         enums::{EventStatus, ReedlineEvent},
         highlighter::SimpleMatchHighlighter,
         hinter::Hinter,
-        history::{FileBackedHistory, History, HistoryNavigationQuery},
-        menu::{Menu, MenuEvent, ReedlineMenu},
+        history::{FileBackedHistory, HistoryNavigationQuery, Result as HistoryResult},
         painting::{Painter, PromptLines},
         prompt::{PromptEditMode, PromptHistorySearchStatus},
         utils::text_manipulation,
@@ -22,6 +21,7 @@ use {
     std::{borrow::Borrow, io, time::Duration},
 };
 
+use crate::{history::History, ReedlineMenu, Menu, MenuEvent};
 #[cfg(feature = "bashisms")]
 use crate::menu_functions::{parse_selection_char, ParseAction};
 
@@ -350,7 +350,7 @@ impl Reedline {
     }
 
     /// Update the underlying [`History`] to/from disk
-    pub fn sync_history(&mut self) -> std::io::Result<()> {
+    pub fn sync_history(&mut self) -> HistoryResult<()> {
         // TODO: check for interactions in the non-submitting events
         self.history.sync()
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,5 +1,9 @@
 #[cfg(feature = "bashisms")]
-use crate::menu_functions::{parse_selection_char, ParseAction};
+use crate::{
+    menu_functions::{parse_selection_char, ParseAction},
+    history::SearchFilter,
+};
+
 use crate::result::{ReedlineError, ReedlineErrorVariants};
 use {
     crate::{
@@ -11,7 +15,7 @@ use {
         hinter::Hinter,
         history::{
             FileBackedHistory, History, HistoryCursor, HistoryItem, HistoryItemId,
-            HistoryNavigationQuery, HistorySessionId, SearchDirection, SearchFilter, SearchQuery,
+            HistoryNavigationQuery, HistorySessionId, SearchDirection, SearchQuery,
         },
         painting::{Painter, PromptLines},
         prompt::{PromptEditMode, PromptHistorySearchStatus},

--- a/src/hinter/default.rs
+++ b/src/hinter/default.rs
@@ -1,4 +1,4 @@
-use crate::{Hinter, History};
+use crate::{history::SearchQuery, Hinter, History};
 use nu_ansi_term::{Color, Style};
 
 /// A hinter that use the completions or the history to show a hint to the user
@@ -20,10 +20,12 @@ impl Hinter for DefaultHinter {
     ) -> String {
         self.current_hint = if line.chars().count() >= self.min_chars {
             history
-                .iter_chronologic()
-                .rev()
-                .find(|entry| entry.starts_with(line))
-                .map_or_else(String::new, |entry| entry[line.len()..].to_string())
+                .search(SearchQuery::last_with_prefix(line.to_string()))
+                .expect("todo: error handling")
+                .get(0)
+                .map_or_else(String::new, |entry| {
+                    entry.command_line[line.len()..].to_string()
+                })
         } else {
             String::new()
         };

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -21,44 +21,72 @@ pub enum HistoryNavigationQuery {
     // Fuzzy Search
 }
 
-#[derive(Copy, Clone)]
+// todo: merge with [HistoryNavigationQuery]
+pub enum CommandLineSearch {
+    Prefix(String),
+    Substring(String),
+    Exact(String),
+}
+
+#[derive(Debug, Copy, Clone)]
 pub struct HistoryItemId(pub(crate) i64);
 impl HistoryItemId {
-    pub fn new(i: i64) -> HistoryItemId {
+    pub(crate) fn new(i: i64) -> HistoryItemId {
         HistoryItemId(i)
     }
 }
+pub struct HistorySessionId(pub(crate) i64);
+impl HistorySessionId {
+    pub(crate) fn new(i: i64) -> HistorySessionId {
+        HistorySessionId(i)
+    }
+}
 /// This trait represents additional context to be added to a history (see [HistoryItem])
-pub trait HistoryEntryContext: Serialize + DeserializeOwned + Default + Send {}
-impl HistoryEntryContext for () {}
-#[derive(Clone)]
-pub struct HistoryItem<ExtraInfo: HistoryEntryContext = ()> {
+pub trait HistoryItemExtraInfo: Serialize + DeserializeOwned + Default + Send {}
+impl HistoryItemExtraInfo for () {}
+/// Represents one run command with some optional historical context
+#[derive(Clone, Debug)]
+pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = ()> {
+    /// primary key, unique across one history
     pub id: Option<HistoryItemId>,
-    pub start_timestamp: chrono::DateTime<Utc>,
+    /// date-time when this command was started
+    pub start_timestamp: Option<chrono::DateTime<Utc>>,
+    /// the full command line as text
     pub command_line: String,
+    /// a unique id for one shell session
     pub session_id: Option<i64>,
+    /// the hostname the commands were run in
     pub hostname: Option<String>,
+    /// the current working directory
     pub cwd: Option<String>,
+    /// the duration the command took to complete
     pub duration: Option<Duration>,
+    /// the exit status of the command
     pub exit_status: Option<i64>,
-    pub more_info: Option<ExtraInfo>, // pub more_info: Option<Box<dyn HistoryEntryContext>>
+    /// arbitrary additional information that might be interesting
+    pub more_info: Option<ExtraInfo>,
 }
 
-impl Default for HistoryItem {
-    fn default() -> HistoryItem {
-        todo!()
+impl HistoryItem {
+    /// create a history item purely from the command line with everything else set to None
+    pub fn from_command_line(cmd: String) -> HistoryItem {
+        HistoryItem {
+            id: None,
+            start_timestamp: None,
+            command_line: cmd,
+            session_id: None,
+            hostname: None,
+            cwd: None,
+            duration: None,
+            exit_status: None,
+            more_info: None,
+        }
     }
 }
 
 pub enum SearchDirection {
     Backward,
     Forward,
-}
-
-pub enum CommandLineSearch {
-    Prefix(String),
-    Substring(String),
-    Exact(String),
 }
 
 pub struct SearchFilter {
@@ -68,64 +96,108 @@ pub struct SearchFilter {
     pub cwd_prefix: Option<String>,
     pub exit_successful: Option<bool>,
 }
+impl SearchFilter {
+    pub fn from_text_search(cmd: CommandLineSearch) -> SearchFilter {
+        let mut s = SearchFilter::anything();
+        s.command_line = Some(cmd);
+        s
+    }
+    pub fn anything() -> SearchFilter {
+        SearchFilter {
+            command_line: None,
+            hostname: None,
+            cwd_exact: None,
+            cwd_prefix: None,
+            exit_successful: None,
+        }
+    }
+}
 
-pub trait History {
-    // returns the same history item but with the correct id set
+pub struct SearchQuery {
+    pub direction: SearchDirection,
+    /// if given, only get results after/before this time (depending on direction)
+    pub start_time: Option<chrono::DateTime<Utc>>,
+    pub end_time: Option<chrono::DateTime<Utc>>,
+    /// if given, only get results after/before this id (depending on direction)
+    pub start_id: Option<HistoryItemId>,
+    pub end_id: Option<HistoryItemId>,
+    pub limit: Option<i64>,
+    pub filter: SearchFilter,
+}
+/// some utility functions
+impl SearchQuery {
+    /// all that contain string in reverse chronological order
+    pub fn all_that_contain_rev(contains: String) -> SearchQuery {
+        return SearchQuery {
+            direction: SearchDirection::Backward,
+            start_time: None,
+            end_time: None,
+            start_id: None,
+            end_id: None,
+            limit: None,
+            filter: SearchFilter::from_text_search(CommandLineSearch::Substring(contains)),
+        };
+    }
+    pub fn last_with_search(filter: SearchFilter) -> SearchQuery {
+        return SearchQuery {
+            direction: SearchDirection::Backward,
+            start_time: None,
+            end_time: None,
+            start_id: None,
+            end_id: None,
+            limit: Some(1),
+            filter,
+        };
+    }
+    pub fn last_with_prefix(prefix: String) -> SearchQuery {
+        SearchQuery::last_with_search(SearchFilter::from_text_search(CommandLineSearch::Prefix(
+            prefix,
+        )))
+    }
+    pub fn everything(direction: SearchDirection) -> SearchQuery {
+        SearchQuery {
+            direction,
+            start_time: None,
+            end_time: None,
+            start_id: None,
+            end_id: None,
+            limit: None,
+            filter: SearchFilter::anything(),
+        }
+    }
+}
+
+/// Represents a history file or database
+/// Data could be stored e.g. in a plain text file, in a JSONL file, in a SQLite database
+pub trait History: Send {
+    /// save a history item to the database
+    /// if given id is None, a new id is created and set in the return value
+    /// if given id is Some, the existing entry is updated
     fn save(&mut self, h: HistoryItem) -> Result<HistoryItem>;
+    /// load a history item by its id
     fn load(&mut self, id: HistoryItemId) -> Result<HistoryItem>;
-    fn search(
-        &self,
-        start: chrono::DateTime<Utc>,
-        direction: SearchDirection,
-        end: Option<chrono::DateTime<Utc>>,
-        limit: Option<i64>,
-        filter: SearchFilter,
-    ) -> Result<Vec<HistoryItem>>;
+    /// gets the newest item id in this history
+    fn newest(&self) -> Result<Option<HistoryItemId>> {
+        let res = self.search(SearchQuery::last_with_search(SearchFilter::anything()))?;
+        Ok(res.get(0).and_then(|e| e.id))
+    }
 
+    /// creates a new unique session id
+    fn new_session_id(&mut self) -> Result<HistorySessionId>;
+
+    /// count the results of a query
+    fn count(&self, query: SearchQuery) -> Result<i64>;
+    /// return the results of a query
+    fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>>;
+
+    /// update an item atomically
     fn update(
         &mut self,
         id: HistoryItemId,
-        updater: Box<dyn FnOnce(HistoryItem) -> HistoryItem>,
+        updater: &dyn Fn(HistoryItem) -> HistoryItem,
     ) -> Result<()>;
-
-    fn entry_count(&self) -> Result<i64>;
+    /// remove an item from this history
     fn delete(&mut self, h: HistoryItemId) -> Result<()>;
-    fn sync(&mut self) -> Result<()>;
-}
-
-/// Interface of a history datastructure that supports stateful navigation via [`HistoryNavigationQuery`].
-pub trait HistoryCursor: Send {
-    /// Chronologic interaction over all entries present in the history
-    fn iter_chronologic(&self) -> Box<dyn DoubleEndedIterator<Item = String> + '_>;
-
-    /// This moves the cursor backwards respecting the navigation query that is set
-    /// - Results in a no-op if the cursor is at the initial point
-    fn back(&mut self);
-
-    /// This moves the cursor forwards respecting the navigation-query that is set
-    /// - Results in a no-op if the cursor is at the latest point
-    fn forward(&mut self);
-
-    /// Returns the string (if present) at the cursor
-    fn string_at_cursor(&self) -> Option<String>;
-
-    /// Set a new navigation mode for search based on input query defined in [`HistoryNavigationQuery`]
-    ///
-    /// By current convention, resets the position in the stateful browsing to the default.
-    fn set_navigation(&mut self, navigation: HistoryNavigationQuery);
-
-    /// Poll the current [`HistoryNavigationQuery`] mode
-    fn get_navigation(&self) -> HistoryNavigationQuery;
-
-    /// Query the values in the history entries
-    fn query_entries(&self, search: &str) -> Vec<String>;
-
-    /// Max number of values that can be queried from the history
-    fn max_values(&self) -> usize;
-
-    /// Synchronize the state of the history with the backing filesystem or database if available
+    /// ensure that this history is written to disk
     fn sync(&mut self) -> std::io::Result<()>;
-
-    /// Reset the browsing cursor back outside the history, does not affect the [`HistoryNavigationQuery`]
-    fn reset_cursor(&mut self);
 }

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -1,9 +1,8 @@
-use std::time::Duration;
-
 use chrono::Utc;
-use serde::{de::DeserializeOwned, Serialize};
 
-use crate::core_editor::LineBuffer;
+use crate::{core_editor::LineBuffer, HistoryItem};
+
+use super::{HistoryItemId, HistorySessionId};
 
 // todo: better error type
 pub type Result<T> = std::result::Result<T, String>;
@@ -26,64 +25,6 @@ pub enum CommandLineSearch {
     Prefix(String),
     Substring(String),
     Exact(String),
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct HistoryItemId(pub(crate) i64);
-impl HistoryItemId {
-    pub(crate) fn new(i: i64) -> HistoryItemId {
-        HistoryItemId(i)
-    }
-}
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct HistorySessionId(pub(crate) i64);
-impl HistorySessionId {
-    pub(crate) fn new(i: i64) -> HistorySessionId {
-        HistorySessionId(i)
-    }
-}
-/// This trait represents additional context to be added to a history (see [HistoryItem])
-pub trait HistoryItemExtraInfo: Serialize + DeserializeOwned + Default + Send {}
-impl HistoryItemExtraInfo for () {}
-/// Represents one run command with some optional historical context
-#[derive(Clone, Debug, PartialEq)]
-pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = ()> {
-    /// primary key, unique across one history
-    pub id: Option<HistoryItemId>,
-    /// date-time when this command was started
-    pub start_timestamp: Option<chrono::DateTime<Utc>>,
-    /// the full command line as text
-    pub command_line: String,
-    /// a unique id for one shell session.
-    /// used so the history can be filtered to a single session
-    pub session_id: Option<HistorySessionId>,
-    /// the hostname the commands were run in
-    pub hostname: Option<String>,
-    /// the current working directory
-    pub cwd: Option<String>,
-    /// the duration the command took to complete
-    pub duration: Option<Duration>,
-    /// the exit status of the command
-    pub exit_status: Option<i64>,
-    /// arbitrary additional information that might be interesting
-    pub more_info: Option<ExtraInfo>,
-}
-
-impl HistoryItem {
-    /// create a history item purely from the command line with everything else set to None
-    pub fn from_command_line(cmd: impl Into<String>) -> HistoryItem {
-        HistoryItem {
-            id: None,
-            start_timestamp: None,
-            command_line: cmd.into(),
-            session_id: None,
-            hostname: None,
-            cwd: None,
-            duration: None,
-            exit_status: None,
-            more_info: None,
-        }
-    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -231,6 +172,8 @@ mod test {
             more_info: None,
         }
     }
+    use std::time::Duration;
+
     use super::*;
     fn create_filled_example_history() -> Result<Box<dyn History>> {
         #[cfg(feature = "sqlite")]

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -1,5 +1,4 @@
 use crate::core_editor::LineBuffer;
-use std::collections::vec_deque::Iter;
 
 /// Browsing modes for a [`History`]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,7 +19,7 @@ pub trait History: Send {
     fn append(&mut self, entry: &str);
 
     /// Chronologic interaction over all entries present in the history
-    fn iter_chronologic(&self) -> Iter<'_, String>;
+    fn iter_chronologic(&self) -> Box<dyn DoubleEndedIterator<Item=String> + '_>;
 
     /// This moves the cursor backwards respecting the navigation query that is set
     /// - Results in a no-op if the cursor is at the initial point

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -1,11 +1,8 @@
 use chrono::Utc;
 
-use crate::{core_editor::LineBuffer, HistoryItem};
+use crate::{core_editor::LineBuffer, HistoryItem, Result};
 
 use super::{HistoryItemId, HistorySessionId};
-
-// todo: better error type
-pub type Result<T> = std::result::Result<T, String>;
 
 /// Browsing modes for a [`History`]
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -218,7 +218,7 @@ mod test {
     ) -> Result<()> {
         let wanted = wanted
             .iter()
-            .map(|id| Ok(history.load(HistoryItemId::new(*id))?))
+            .map(|id| history.load(HistoryItemId::new(*id)))
             .collect::<Result<Vec<HistoryItem>>>()?;
         assert_eq!(res, wanted);
         Ok(())

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -133,7 +133,7 @@ pub struct SearchQuery {
 impl SearchQuery {
     /// all that contain string in reverse chronological order
     pub fn all_that_contain_rev(contains: String) -> SearchQuery {
-        return SearchQuery {
+        SearchQuery {
             direction: SearchDirection::Backward,
             start_time: None,
             end_time: None,
@@ -141,10 +141,10 @@ impl SearchQuery {
             end_id: None,
             limit: None,
             filter: SearchFilter::from_text_search(CommandLineSearch::Substring(contains)),
-        };
+        }
     }
     pub fn last_with_search(filter: SearchFilter) -> SearchQuery {
-        return SearchQuery {
+        SearchQuery {
             direction: SearchDirection::Backward,
             start_time: None,
             end_time: None,
@@ -152,7 +152,7 @@ impl SearchQuery {
             end_id: None,
             limit: Some(1),
             filter,
-        };
+        }
     }
     pub fn last_with_prefix(prefix: String) -> SearchQuery {
         SearchQuery::last_with_search(SearchFilter::from_text_search(CommandLineSearch::Prefix(
@@ -253,6 +253,27 @@ mod test {
         history.save(create_item(1, "/etc/nginx", "vim htpasswd", 0))?; // 11
         history.save(create_item(1, "/etc/nginx", "cat nginx.conf", 0))?; // 12
         Ok(Box::new(history))
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn update_item() -> Result<()> {
+        let mut history = create_filled_example_history()?;
+        let id = HistoryItemId::new(2);
+        let before = history.load(id)?;
+        history.update(id, &|mut e| {
+            e.exit_status = Some(1);
+            e
+        })?;
+        let after = history.load(id)?;
+        assert_eq!(
+            after,
+            HistoryItem {
+                exit_status: Some(1),
+                ..before
+            }
+        );
+        Ok(())
     }
 
     fn search_returned(

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -35,7 +35,7 @@ pub enum SearchDirection {
 
 pub struct SearchFilter {
     pub command_line: Option<CommandLineSearch>,
-    pub not_command_line: Option<String>, // to skip duplicates
+    pub not_command_line: Option<String>, // to skip the currently shown value in up-arrow navigation
     pub hostname: Option<String>,
     pub cwd_exact: Option<String>,
     pub cwd_prefix: Option<String>,
@@ -122,14 +122,9 @@ pub trait History: Send {
     fn save(&mut self, h: HistoryItem) -> Result<HistoryItem>;
     /// load a history item by its id
     fn load(&self, id: HistoryItemId) -> Result<HistoryItem>;
-    /// gets the newest item id in this history
-    fn newest(&self) -> Result<Option<HistoryItemId>> {
-        let res = self.search(SearchQuery::last_with_search(SearchFilter::anything()))?;
-        Ok(res.get(0).and_then(|e| e.id))
-    }
 
-    /// creates a new unique session id
-    fn new_session_id(&mut self) -> Result<HistorySessionId>;
+    /// retrieves the next unused session id
+    fn next_session_id(&mut self) -> Result<HistorySessionId>;
 
     /// count the results of a query
     fn count(&self, query: SearchQuery) -> Result<i64>;

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -28,13 +28,14 @@ pub enum CommandLineSearch {
     Exact(String),
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct HistoryItemId(pub(crate) i64);
 impl HistoryItemId {
     pub(crate) fn new(i: i64) -> HistoryItemId {
         HistoryItemId(i)
     }
 }
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct HistorySessionId(pub(crate) i64);
 impl HistorySessionId {
     pub(crate) fn new(i: i64) -> HistorySessionId {
@@ -45,7 +46,7 @@ impl HistorySessionId {
 pub trait HistoryItemExtraInfo: Serialize + DeserializeOwned + Default + Send {}
 impl HistoryItemExtraInfo for () {}
 /// Represents one run command with some optional historical context
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = ()> {
     /// primary key, unique across one history
     pub id: Option<HistoryItemId>,
@@ -53,8 +54,9 @@ pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = ()> {
     pub start_timestamp: Option<chrono::DateTime<Utc>>,
     /// the full command line as text
     pub command_line: String,
-    /// a unique id for one shell session
-    pub session_id: Option<i64>,
+    /// a unique id for one shell session.
+    /// used so the history can be filtered to a single session
+    pub session_id: Option<HistorySessionId>,
     /// the hostname the commands were run in
     pub hostname: Option<String>,
     /// the current working directory
@@ -69,11 +71,11 @@ pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = ()> {
 
 impl HistoryItem {
     /// create a history item purely from the command line with everything else set to None
-    pub fn from_command_line(cmd: String) -> HistoryItem {
+    pub fn from_command_line(cmd: impl Into<String>) -> HistoryItem {
         HistoryItem {
             id: None,
             start_timestamp: None,
-            command_line: cmd,
+            command_line: cmd.into(),
             session_id: None,
             hostname: None,
             cwd: None,
@@ -84,6 +86,7 @@ impl HistoryItem {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SearchDirection {
     Backward,
     Forward,
@@ -91,6 +94,7 @@ pub enum SearchDirection {
 
 pub struct SearchFilter {
     pub command_line: Option<CommandLineSearch>,
+    pub not_command_line: Option<String>, // to skip duplicates
     pub hostname: Option<String>,
     pub cwd_exact: Option<String>,
     pub cwd_prefix: Option<String>,
@@ -105,6 +109,7 @@ impl SearchFilter {
     pub fn anything() -> SearchFilter {
         SearchFilter {
             command_line: None,
+            not_command_line: None,
             hostname: None,
             cwd_exact: None,
             cwd_prefix: None,
@@ -175,7 +180,7 @@ pub trait History: Send {
     /// if given id is Some, the existing entry is updated
     fn save(&mut self, h: HistoryItem) -> Result<HistoryItem>;
     /// load a history item by its id
-    fn load(&mut self, id: HistoryItemId) -> Result<HistoryItem>;
+    fn load(&self, id: HistoryItemId) -> Result<HistoryItem>;
     /// gets the newest item id in this history
     fn newest(&self) -> Result<Option<HistoryItemId>> {
         let res = self.search(SearchQuery::last_with_search(SearchFilter::anything()))?;
@@ -187,6 +192,10 @@ pub trait History: Send {
 
     /// count the results of a query
     fn count(&self, query: SearchQuery) -> Result<i64>;
+    /// return the total number of history items
+    fn count_all(&self) -> Result<i64> {
+        self.count(SearchQuery::everything(SearchDirection::Forward))
+    }
     /// return the results of a query
     fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>>;
 
@@ -200,4 +209,132 @@ pub trait History: Send {
     fn delete(&mut self, h: HistoryItemId) -> Result<()>;
     /// ensure that this history is written to disk
     fn sync(&mut self) -> std::io::Result<()>;
+}
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "sqlite")]
+    const IS_FILE_BASED: bool = false;
+    #[cfg(not(feature = "sqlite"))]
+    const IS_FILE_BASED: bool = true;
+
+    fn create_item(session: i64, cwd: &str, cmd: &str, exit_status: i64) -> HistoryItem {
+        HistoryItem {
+            id: None,
+            start_timestamp: None,
+            command_line: cmd.to_string(),
+            session_id: Some(HistorySessionId::new(session)),
+            hostname: Some("foohost".to_string()),
+            cwd: Some(cwd.to_string()),
+            duration: Some(Duration::from_millis(1000)),
+            exit_status: Some(exit_status),
+            more_info: None,
+        }
+    }
+    use super::*;
+    fn create_filled_example_history() -> Result<Box<dyn History>> {
+        #[cfg(feature = "sqlite")]
+        let mut history = crate::SqliteBackedHistory::in_memory()?;
+        #[cfg(not(feature = "sqlite"))]
+        let mut history = crate::FileBackedHistory::default();
+        #[cfg(not(feature = "sqlite"))]
+        history.save(create_item(1, "/", "dummy", 0))?; // add dummy item so ids start with 1
+        history.save(create_item(1, "/home/me", "cd ~/Downloads", 0))?; // 1
+        history.save(create_item(1, "/home/me/Downloads", "unzp foo.zip", 1))?; // 2
+        history.save(create_item(1, "/home/me/Downloads", "unzip foo.zip", 0))?; // 3
+        history.save(create_item(1, "/home/me/Downloads", "cd foo", 0))?; // 4
+        history.save(create_item(1, "/home/me/Downloads/foo", "ls", 0))?; // 5
+        history.save(create_item(1, "/home/me/Downloads/foo", "ls -alh", 0))?; // 6
+        history.save(create_item(1, "/home/me/Downloads/foo", "cat x.txt", 0))?; // 7
+
+        history.save(create_item(1, "/home/me", "cd /etc/nginx", 0))?; // 8
+        history.save(create_item(1, "/etc/nginx", "ls -l", 0))?; // 9
+        history.save(create_item(1, "/etc/nginx", "vim nginx.conf", 0))?; // 10
+        history.save(create_item(1, "/etc/nginx", "vim htpasswd", 0))?; // 11
+        history.save(create_item(1, "/etc/nginx", "cat nginx.conf", 0))?; // 12
+        Ok(Box::new(history))
+    }
+
+    fn search_returned(
+        history: &dyn History,
+        res: Vec<HistoryItem>,
+        wanted: Vec<i64>,
+    ) -> Result<()> {
+        let wanted = wanted
+            .iter()
+            .map(|id| Ok(history.load(HistoryItemId::new(*id))?))
+            .collect::<Result<Vec<HistoryItem>>>()?;
+        assert_eq!(res, wanted);
+        Ok(())
+    }
+
+    #[test]
+    fn count_all() -> Result<()> {
+        let history = create_filled_example_history()?;
+        println!(
+            "{:#?}",
+            history.search(SearchQuery::everything(SearchDirection::Forward))
+        );
+
+        assert_eq!(history.count_all()?, if IS_FILE_BASED { 13 } else { 12 });
+        Ok(())
+    }
+
+    #[test]
+    fn get_latest() -> Result<()> {
+        let history = create_filled_example_history()?;
+        let res = history.search(SearchQuery::last_with_search(SearchFilter::anything()))?;
+
+        search_returned(&*history, res, vec![12])?;
+        Ok(())
+    }
+
+    #[test]
+    fn get_earliest() -> Result<()> {
+        let history = create_filled_example_history()?;
+        let res = history.search(SearchQuery {
+            limit: Some(1),
+            ..SearchQuery::everything(SearchDirection::Forward)
+        })?;
+        search_returned(&*history, res, vec![if IS_FILE_BASED { 0 } else { 1 }])?;
+        Ok(())
+    }
+
+    #[test]
+    fn search_prefix() -> Result<()> {
+        let history = create_filled_example_history()?;
+        let res = history.search(SearchQuery {
+            filter: SearchFilter::from_text_search(CommandLineSearch::Prefix("ls ".to_string())),
+            ..SearchQuery::everything(SearchDirection::Backward)
+        })?;
+        search_returned(&*history, res, vec![9, 6])?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn search_includes() -> Result<()> {
+        let history = create_filled_example_history()?;
+        let res = history.search(SearchQuery {
+            filter: SearchFilter::from_text_search(CommandLineSearch::Substring(
+                "foo.zip".to_string(),
+            )),
+            ..SearchQuery::everything(SearchDirection::Forward)
+        })?;
+        search_returned(&*history, res, vec![2, 3])?;
+        Ok(())
+    }
+
+    #[test]
+    fn search_includes_limit() -> Result<()> {
+        let history = create_filled_example_history()?;
+        let res = history.search(SearchQuery {
+            filter: SearchFilter::from_text_search(CommandLineSearch::Substring("c".to_string())),
+            limit: Some(2),
+            ..SearchQuery::everything(SearchDirection::Forward)
+        })?;
+        search_returned(&*history, res, vec![1, 4])?;
+
+        Ok(())
+    }
 }

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -4,8 +4,8 @@ use super::base::CommandLineSearch;
 use super::base::SearchDirection;
 use super::base::SearchFilter;
 use super::HistoryItem;
-use super::Result;
 use super::SearchQuery;
+use crate::Result;
 
 /// Interface of a stateful navigation via [`HistoryNavigationQuery`].
 #[derive(Debug)]
@@ -124,13 +124,16 @@ mod tests {
     }
 
     fn get_all_entry_texts(hist: &dyn History) -> Vec<String> {
-        let res = hist.search(SearchQuery::everything(SearchDirection::Forward)).unwrap();
+        let res = hist
+            .search(SearchQuery::everything(SearchDirection::Forward))
+            .unwrap();
         let actual: Vec<_> = res.iter().map(|e| e.command_line.to_string()).collect();
         actual
     }
     fn add_text_entries(hist: &mut dyn History, entries: &[impl AsRef<str>]) {
         entries.iter().for_each(|e| {
-            hist.save(HistoryItem::from_command_line(e.as_ref())).unwrap();
+            hist.save(HistoryItem::from_command_line(e.as_ref()))
+                .unwrap();
         });
     }
 
@@ -430,7 +433,7 @@ mod tests {
         }
 
         {
-            let  (mut appending_hist, _) = create_history_at(capacity, &histfile);
+            let (mut appending_hist, _) = create_history_at(capacity, &histfile);
             add_text_entries(appending_hist.as_mut(), &appending_entries);
             // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
             let actual: Vec<_> = get_all_entry_texts(appending_hist.as_ref());
@@ -554,9 +557,11 @@ mod tests {
                 let hfile = histfile.clone();
                 std::thread::spawn(move || {
                     let (mut hist, _) = create_history_at(cap, &hfile);
-                    hist.save(HistoryItem::from_command_line(&format!("A{}", i))).unwrap();
+                    hist.save(HistoryItem::from_command_line(&format!("A{}", i)))
+                        .unwrap();
                     hist.sync().unwrap();
-                    hist.save(HistoryItem::from_command_line(&format!("B{}", i))).unwrap();
+                    hist.save(HistoryItem::from_command_line(&format!("B{}", i)))
+                        .unwrap();
                 })
             })
             .collect::<Vec<_>>();

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -4,7 +4,6 @@ use super::base::CommandLineSearch;
 use super::base::SearchDirection;
 use super::base::SearchFilter;
 use super::HistoryItem;
-use super::HistoryItemId;
 use super::Result;
 use super::SearchQuery;
 
@@ -13,6 +12,7 @@ use super::SearchQuery;
 pub struct HistoryCursor {
     query: HistoryNavigationQuery,
     current: Option<HistoryItem>,
+    skip_dupes: bool,
 }
 
 impl HistoryCursor {
@@ -20,6 +20,7 @@ impl HistoryCursor {
         HistoryCursor {
             query,
             current: None,
+            skip_dupes: true,
         }
     }
 
@@ -35,16 +36,8 @@ impl HistoryCursor {
         self.navigate_in_direction(history, SearchDirection::Forward)
     }
 
-    fn get_search_start(&self, history: &dyn History) -> Result<Option<HistoryItemId>> {
-        if let Some(it) = &self.current {
-            Ok(it.id)
-        } else {
-            history.newest()
-        }
-    }
-
     fn get_search_filter(&self) -> SearchFilter {
-        match self.query.clone() {
+        let filter = match self.query.clone() {
             HistoryNavigationQuery::Normal(_) => SearchFilter::anything(),
             HistoryNavigationQuery::PrefixSearch(prefix) => {
                 SearchFilter::from_text_search(CommandLineSearch::Prefix(prefix))
@@ -52,6 +45,14 @@ impl HistoryCursor {
             HistoryNavigationQuery::SubstringSearch(substring) => {
                 SearchFilter::from_text_search(CommandLineSearch::Substring(substring))
             }
+        };
+        if let (true, Some(current)) = (self.skip_dupes, &self.current) {
+            SearchFilter {
+                not_command_line: Some(current.command_line.clone()),
+                ..filter
+            }
+        } else {
+            filter
         }
     }
     fn navigate_in_direction(
@@ -59,19 +60,25 @@ impl HistoryCursor {
         history: &dyn History,
         direction: SearchDirection,
     ) -> Result<()> {
-        if let Some(start_id) = self.get_search_start(history)? {
-            let mut next = history.search(SearchQuery {
-                start_id: Some(start_id),
-                end_id: None,
-                start_time: None,
-                end_time: None,
-                direction,
-                limit: Some(1),
-                filter: self.get_search_filter(),
-            })?;
-            if next.len() == 1 {
-                self.current = Some(next.swap_remove(0));
-            }
+        if direction == SearchDirection::Forward && self.current.is_none() {
+            // if searching forward but we don't have a starting point, assume we are at the end
+            return Ok(());
+        }
+        let start_id = self.current.as_ref().and_then(|e| e.id);
+        let mut next = history.search(SearchQuery {
+            start_id,
+            end_id: None,
+            start_time: None,
+            end_time: None,
+            direction,
+            limit: Some(1),
+            filter: self.get_search_filter(),
+        })?;
+        if next.len() == 1 {
+            self.current = Some(next.swap_remove(0));
+        } else if direction == SearchDirection::Forward {
+            // no result and searching forward: we are at the end
+            self.current = None;
         }
         Ok(())
     }
@@ -85,5 +92,517 @@ impl HistoryCursor {
     pub fn get_navigation(&self) -> HistoryNavigationQuery {
         self.query.clone()
     }
+}
 
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use pretty_assertions::assert_eq;
+
+    use crate::LineBuffer;
+
+    use super::super::*;
+    use super::*;
+
+    fn create_history() -> (Box<dyn History>, HistoryCursor) {
+        #[cfg(feature = "sqlite")]
+        let hist = Box::new(SqliteBackedHistory::in_memory().unwrap());
+        #[cfg(not(feature = "sqlite"))]
+        let hist = Box::new(FileBackedHistory::default());
+        (
+            hist,
+            HistoryCursor::new(HistoryNavigationQuery::Normal(LineBuffer::default())),
+        )
+    }
+    fn create_history_at(cap: usize, path: &Path) -> (Box<dyn History>, HistoryCursor) {
+        let hist = Box::new(FileBackedHistory::with_file(cap, path.to_owned()).unwrap());
+        (
+            hist,
+            HistoryCursor::new(HistoryNavigationQuery::Normal(LineBuffer::default())),
+        )
+    }
+
+    #[test]
+    fn accessing_empty_history_returns_nothing() -> Result<()> {
+        let (_hist, cursor) = create_history();
+        assert_eq!(cursor.string_at_cursor(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn going_forward_in_empty_history_does_not_error_out() -> Result<()> {
+        let (hist, mut cursor) = create_history();
+        cursor.forward(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn going_backwards_in_empty_history_does_not_error_out() -> Result<()> {
+        let (hist, mut cursor) = create_history();
+        cursor.back(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn going_backwards_bottoms_out() -> Result<()> {
+        let (mut hist, mut cursor) = create_history();
+        hist.save(HistoryItem::from_command_line("command1"))?;
+        hist.save(HistoryItem::from_command_line("command2"))?;
+        cursor.back(&*hist)?;
+        cursor.back(&*hist)?;
+        cursor.back(&*hist)?;
+        cursor.back(&*hist)?;
+        cursor.back(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), Some("command1".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn going_forwards_bottoms_out() -> Result<()> {
+        let (mut hist, mut cursor) = create_history();
+        hist.save(HistoryItem::from_command_line("command1"))?;
+        hist.save(HistoryItem::from_command_line("command2"))?;
+        cursor.forward(&*hist)?;
+        cursor.forward(&*hist)?;
+        cursor.forward(&*hist)?;
+        cursor.forward(&*hist)?;
+        cursor.forward(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), None);
+        Ok(())
+    }
+
+    #[cfg(not(feature = "sqlite"))]
+    #[test]
+    fn appends_only_unique() -> Result<()> {
+        let (mut hist, _) = create_history();
+        hist.save(HistoryItem::from_command_line("unique_old"))?;
+        hist.save(HistoryItem::from_command_line("test"))?;
+        hist.save(HistoryItem::from_command_line("test"))?;
+        hist.save(HistoryItem::from_command_line("unique"))?;
+        assert_eq!(hist.count_all()?, 3);
+        Ok(())
+    }
+
+    #[cfg(not(feature = "sqlite"))]
+    #[test]
+    fn appends_no_empties() -> Result<()> {
+        let (mut hist, _) = create_history();
+        hist.save(HistoryItem::from_command_line(""))?;
+        assert_eq!(hist.count_all()?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn prefix_search_works() -> Result<()> {
+        let (mut hist, _) = create_history();
+        hist.save(HistoryItem::from_command_line("find me as well"))?;
+        hist.save(HistoryItem::from_command_line("test"))?;
+        hist.save(HistoryItem::from_command_line("find me"))?;
+
+        let mut cursor =
+            HistoryCursor::new(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+
+        cursor.back(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), Some("find me".to_string()));
+        cursor.back(&*hist)?;
+        assert_eq!(
+            cursor.string_at_cursor(),
+            Some("find me as well".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn prefix_search_bottoms_out() -> Result<()> {
+        let (mut hist, _) = create_history();
+        hist.save(HistoryItem::from_command_line("find me as well"))?;
+        hist.save(HistoryItem::from_command_line("test"))?;
+        hist.save(HistoryItem::from_command_line("find me"))?;
+
+        let mut cursor =
+            HistoryCursor::new(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        cursor.back(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), Some("find me".to_string()));
+        cursor.back(&*hist)?;
+        assert_eq!(
+            cursor.string_at_cursor(),
+            Some("find me as well".to_string())
+        );
+        cursor.back(&*hist)?;
+        cursor.back(&*hist)?;
+        cursor.back(&*hist)?;
+        cursor.back(&*hist)?;
+        assert_eq!(
+            cursor.string_at_cursor(),
+            Some("find me as well".to_string())
+        );
+        Ok(())
+    }
+    #[test]
+    fn prefix_search_returns_to_none() -> Result<()> {
+        let (mut hist, _) = create_history();
+        hist.save(HistoryItem::from_command_line("find me as well"))?;
+        hist.save(HistoryItem::from_command_line("test"))?;
+        hist.save(HistoryItem::from_command_line("find me"))?;
+
+        let mut cursor =
+            HistoryCursor::new(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        cursor.back(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), Some("find me".to_string()));
+        cursor.back(&*hist)?;
+        assert_eq!(
+            cursor.string_at_cursor(),
+            Some("find me as well".to_string())
+        );
+        cursor.forward(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), Some("find me".to_string()));
+        cursor.forward(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), None);
+        cursor.forward(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn prefix_search_ignores_consecutive_equivalent_entries_going_backwards() -> Result<()> {
+        let (mut hist, _) = create_history();
+        hist.save(HistoryItem::from_command_line("find me as well"))?;
+        hist.save(HistoryItem::from_command_line("find me once"))?;
+        hist.save(HistoryItem::from_command_line("test"))?;
+        hist.save(HistoryItem::from_command_line("find me once"))?;
+
+        let mut cursor =
+            HistoryCursor::new(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        cursor.back(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), Some("find me once".to_string()));
+        cursor.back(&*hist)?;
+        assert_eq!(
+            cursor.string_at_cursor(),
+            Some("find me as well".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn prefix_search_ignores_consecutive_equivalent_entries_going_forwards() -> Result<()> {
+        let (mut hist, _) = create_history();
+        hist.save(HistoryItem::from_command_line("find me once"))?;
+        hist.save(HistoryItem::from_command_line("test"))?;
+        hist.save(HistoryItem::from_command_line("find me once"))?;
+        hist.save(HistoryItem::from_command_line("find me as well"))?;
+
+        let mut cursor =
+            HistoryCursor::new(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        cursor.back(&*hist)?;
+        assert_eq!(
+            cursor.string_at_cursor(),
+            Some("find me as well".to_string())
+        );
+        cursor.back(&*hist)?;
+        cursor.back(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), Some("find me once".to_string()));
+        cursor.forward(&*hist)?;
+        assert_eq!(
+            cursor.string_at_cursor(),
+            Some("find me as well".to_string())
+        );
+        cursor.forward(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn substring_search_works() -> Result<()> {
+        let (mut hist, _) = create_history();
+        hist.save(HistoryItem::from_command_line("substring"))?;
+        hist.save(HistoryItem::from_command_line("don't find me either"))?;
+        hist.save(HistoryItem::from_command_line("prefix substring"))?;
+        hist.save(HistoryItem::from_command_line("don't find me"))?;
+        hist.save(HistoryItem::from_command_line("prefix substring suffix"))?;
+
+        let mut cursor = HistoryCursor::new(HistoryNavigationQuery::SubstringSearch(
+            "substring".to_string(),
+        ));
+        cursor.back(&*hist)?;
+        assert_eq!(
+            cursor.string_at_cursor(),
+            Some("prefix substring suffix".to_string())
+        );
+        cursor.back(&*hist)?;
+        assert_eq!(
+            cursor.string_at_cursor(),
+            Some("prefix substring".to_string())
+        );
+        cursor.back(&*hist)?;
+        assert_eq!(cursor.string_at_cursor(), Some("substring".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn substring_search_with_empty_value_returns_none() -> Result<()> {
+        let (mut hist, _) = create_history();
+        hist.save(HistoryItem::from_command_line("substring"))?;
+
+        let cursor = HistoryCursor::new(HistoryNavigationQuery::SubstringSearch("".to_string()));
+
+        assert_eq!(cursor.string_at_cursor(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn writes_to_new_file() -> Result<()> {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        // check that it also works for a path where the directory has not been created yet
+        let histfile = tmp.path().join("nested_path").join(".history");
+
+        let entries = vec!["test", "text", "more test text"];
+
+        {
+            let (mut hist, _) = create_history_at(5, &histfile);
+
+            entries.iter().for_each(|e| {
+                hist.save(HistoryItem::from_command_line(*e)).unwrap();
+            });
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let (reading_hist, _) = create_history_at(5, &histfile);
+        let res = reading_hist.search(SearchQuery::everything(SearchDirection::Forward))?;
+        let actual: Vec<_> = res.iter().map(|e| &e.command_line).collect();
+        assert_eq!(entries, actual);
+
+        tmp.close().unwrap();
+        Ok(())
+    }
+    /*
+       #[test]
+       fn persists_newlines_in_entries() -> Result<()> {
+           use tempfile::tempdir;
+
+           let tmp = tempdir()?;
+           let histfile = tmp.path().join(".history");
+
+           let entries = vec![
+               "test",
+               "multiline\nentry\nunix",
+               "multiline\r\nentry\r\nwindows",
+               "more test text",
+           ];
+
+           {
+           let (mut hist, mut cursor) = create_history();
+
+               entries.iter().for_each(|e| writing_hist.save(HistoryItem::from_command_line(e)))?;
+
+               // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+           }
+
+           let (mut hist, mut cursor) = create_history();
+
+           let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+           assert_eq!(entries, actual);
+
+           tmp.close()?;
+     Ok(())  }
+
+       #[test]
+       fn truncates_file_to_capacity() -> Result<()> {
+           use tempfile::tempdir;
+
+           let tmp = tempdir()?;
+           let histfile = tmp.path().join(".history");
+
+           let capacity = 5;
+           let initial_entries = vec!["test 1", "test 2"];
+           let appending_entries = vec!["test 3", "test 4"];
+           let expected_appended_entries = vec!["test 1", "test 2", "test 3", "test 4"];
+           let truncating_entries = vec!["test 5", "test 6", "test 7", "test 8"];
+           let expected_truncated_entries = vec!["test 4", "test 5", "test 6", "test 7", "test 8"];
+
+           {
+               let mut writing_hist =
+                   FileBackedHistory::with_file(capacity, histfile.clone())?;
+
+               initial_entries.iter().for_each(|e| writing_hist.save(HistoryItem::from_command_line(e)))?;
+
+               // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+           }
+
+           {
+               let mut appending_hist =
+                   FileBackedHistory::with_file(capacity, histfile.clone())?;
+
+               appending_entries
+                   .iter()
+                   .for_each(|e| appending_hist.save(HistoryItem::from_command_line(e)))?;
+
+               // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+               let actual: Vec<_> = appending_hist.iter_chronologic().collect();
+               assert_eq!(expected_appended_entries, actual);
+           }
+
+           {
+               let mut truncating_hist =
+                   FileBackedHistory::with_file(capacity, histfile.clone())?;
+
+               truncating_entries
+                   .iter()
+                   .for_each(|e| truncating_hist.save(HistoryItem::from_command_line(e)))?;
+
+               let actual: Vec<_> = truncating_hist.iter_chronologic().collect();
+               assert_eq!(expected_truncated_entries, actual);
+               // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+           }
+
+           let (mut hist, mut cursor) = create_history();
+
+           let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+           assert_eq!(expected_truncated_entries, actual);
+
+           tmp.close()?;
+    Ok(())   }
+
+       #[test]
+       fn truncates_too_large_file() -> Result<()> {
+           use tempfile::tempdir;
+
+           let tmp = tempdir()?;
+           let histfile = tmp.path().join(".history");
+
+           let overly_large_previous_entries = vec![
+               "test 1", "test 2", "test 3", "test 4", "test 5", "test 6", "test 7", "test 8",
+           ];
+           let expected_truncated_entries = vec!["test 4", "test 5", "test 6", "test 7", "test 8"];
+
+           {
+           let (mut hist, mut cursor) = create_history();
+
+               overly_large_previous_entries
+                   .iter()
+                   .for_each(|e| writing_hist.save(HistoryItem::from_command_line(e)))?;
+
+               // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+           }
+
+           {
+           let (mut hist, mut cursor) = create_history();
+
+               let actual: Vec<_> = truncating_hist.iter_chronologic().collect();
+               assert_eq!(expected_truncated_entries, actual);
+               // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+           }
+
+           let (mut hist, mut cursor) = create_history();
+
+           let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+           assert_eq!(expected_truncated_entries, actual);
+
+           tmp.close()?;
+    Ok(())   }
+
+       #[test]
+       fn concurrent_histories_dont_erase_eachother() -> Result<()> {
+           use tempfile::tempdir;
+
+           let tmp = tempdir()?;
+           let histfile = tmp.path().join(".history");
+
+           let capacity = 7;
+           let initial_entries = vec!["test 1", "test 2", "test 3", "test 4", "test 5"];
+           let entries_a = vec!["A1", "A2", "A3"];
+           let entries_b = vec!["B1", "B2", "B3"];
+           let expected_entries = vec!["test 5", "B1", "B2", "B3", "A1", "A2", "A3"];
+
+           {
+               let mut writing_hist =
+                   FileBackedHistory::with_file(capacity, histfile.clone())?;
+
+               initial_entries.iter().for_each(|e| writing_hist.save(HistoryItem::from_command_line(e)))?;
+
+               // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+           }
+
+           {
+           let (mut hist, mut cursor) = create_history();
+
+               {
+           let (mut hist, mut cursor) = create_history();
+
+                   entries_b.iter().for_each(|e| hist_b.append(e));
+
+                   // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+               }
+               entries_a.iter().for_each(|e| hist_a.append(e));
+
+               // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+           }
+
+           let (mut hist, mut cursor) = create_history();
+
+           let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+           assert_eq!(expected_entries, actual);
+
+           tmp.close()?;
+     Ok(())  }
+
+       #[test]
+       fn concurrent_histories_are_threadsafe() -> Result<()> {
+           use tempfile::tempdir;
+
+           let tmp = tempdir()?;
+           let histfile = tmp.path().join(".history");
+
+           let num_threads = 16;
+           let capacity = 2 * num_threads + 1;
+
+           let initial_entries = (0..capacity).map(|i| format!("initial {i}"));
+
+           {
+               let mut writing_hist =
+                   FileBackedHistory::with_file(capacity, histfile.clone())?;
+
+               initial_entries.for_each(|e| writing_hist.save(HistoryItem::from_command_line(&e)))?;
+
+               // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+           }
+
+           let threads = (0..num_threads)
+               .map(|i| {
+                   let cap = capacity;
+                   let hfile = histfile.clone();
+                   std::thread::spawn(move || {
+           let (mut hist, mut cursor) = create_history();
+                       hist.save(HistoryItem::from_command_line(&format!("A{}", i)))?;
+                       hist.sync()?;
+                       hist.save(HistoryItem::from_command_line(&format!("B{}", i)))?;
+                   })
+               })
+               .collect::<Vec<_>>();
+
+           for t in threads {
+               t.join()?;
+           }
+
+           let (mut hist, mut cursor) = create_history();
+
+           let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+
+           assert!(
+               actual.contains(&&format!("initial {}", capacity - 1)),
+               "Overwrote entry from before threading test"
+           );
+
+           for i in 0..num_threads {
+               assert!(actual.contains(&&format!("A{}", i)),);
+               assert!(actual.contains(&&format!("B{}", i)),);
+           }
+
+           tmp.close()?;
+     Ok(())  }*/
 }

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -1,0 +1,135 @@
+
+impl HistoryCursor for FileBackedHistory {
+    fn iter_chronologic(&self) -> Box<(dyn DoubleEndedIterator<Item = String> + '_)> {
+        Box::new(self.entries.iter().map(|e| e.to_string()))
+    }
+
+    fn back(&mut self) {
+        match self.query.clone() {
+            HistoryNavigationQuery::Normal(_) => {
+                if self.cursor > 0 {
+                    self.cursor -= 1;
+                }
+            }
+            HistoryNavigationQuery::PrefixSearch(prefix) => {
+                self.back_with_criteria(&|entry| entry.starts_with(&prefix));
+            }
+            HistoryNavigationQuery::SubstringSearch(substring) => {
+                self.back_with_criteria(&|entry| entry.contains(&substring));
+            }
+        }
+    }
+
+    fn forward(&mut self) {
+        match self.query.clone() {
+            HistoryNavigationQuery::Normal(_) => {
+                if self.cursor < self.entries.len() {
+                    self.cursor += 1;
+                }
+            }
+            HistoryNavigationQuery::PrefixSearch(prefix) => {
+                self.forward_with_criteria(&|entry| entry.starts_with(&prefix));
+            }
+            HistoryNavigationQuery::SubstringSearch(substring) => {
+                self.forward_with_criteria(&|entry| entry.contains(&substring));
+            }
+        }
+    }
+
+    fn string_at_cursor(&self) -> Option<String> {
+        self.entries.get(self.cursor).cloned()
+    }
+
+    fn set_navigation(&mut self, navigation: HistoryNavigationQuery) {
+        self.query = navigation;
+        self.reset_cursor();
+    }
+
+    fn get_navigation(&self) -> HistoryNavigationQuery {
+        self.query.clone()
+    }
+
+    fn query_entries(&self, search: &str) -> Vec<String> {
+        self.iter_chronologic()
+            .rev()
+            .filter(|entry| entry.contains(search))
+            .collect::<Vec<String>>()
+    }
+
+    fn max_values(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Writes unwritten history contents to disk.
+    ///
+    /// If file would exceed `capacity` truncates the oldest entries.
+    fn sync(&mut self) -> std::io::Result<()> {
+        if let Some(fname) = &self.file {
+            // The unwritten entries
+            let own_entries = self.entries.range(self.len_on_disk..);
+
+            let mut f_lock = fd_lock::RwLock::new(
+                OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .read(true)
+                    .open(fname)?,
+            );
+            let mut writer_guard = f_lock.write()?;
+            let (mut foreign_entries, truncate) = {
+                let reader = BufReader::new(writer_guard.deref());
+                let mut from_file = reader
+                    .lines()
+                    .map(|o| o.map(|i| decode_entry(&i)))
+                    .collect::<Result<VecDeque<_>, _>>()?;
+                if from_file.len() + own_entries.len() > self.capacity {
+                    (
+                        from_file.split_off(from_file.len() - (self.capacity - own_entries.len())),
+                        true,
+                    )
+                } else {
+                    (from_file, false)
+                }
+            };
+
+            {
+                let mut writer = BufWriter::new(writer_guard.deref_mut());
+                if truncate {
+                    writer.seek(SeekFrom::Start(0))?;
+
+                    for line in &foreign_entries {
+                        writer.write_all(encode_entry(line).as_bytes())?;
+                        writer.write_all("\n".as_bytes())?;
+                    }
+                } else {
+                    writer.seek(SeekFrom::End(0))?;
+                }
+                for line in own_entries {
+                    writer.write_all(encode_entry(line).as_bytes())?;
+                    writer.write_all("\n".as_bytes())?;
+                }
+                writer.flush()?;
+            }
+            if truncate {
+                let file = writer_guard.deref_mut();
+                let file_len = file.stream_position()?;
+                file.set_len(file_len)?;
+            }
+
+            let own_entries = self.entries.drain(self.len_on_disk..);
+            foreign_entries.extend(own_entries);
+            self.entries = foreign_entries;
+
+            self.len_on_disk = self.entries.len();
+        }
+
+        self.reset_cursor();
+
+        Ok(())
+    }
+
+    /// Reset the internal browsing cursor
+    fn reset_cursor(&mut self) {
+        self.cursor = self.entries.len();
+    }
+}

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -198,14 +198,6 @@ mod tests {
     }
 
     #[test]
-    fn appends_no_empties() -> Result<()> {
-        let (mut hist, _) = create_history();
-        hist.save(HistoryItem::from_command_line(""))?;
-        assert_eq!(hist.count_all()?, 0);
-        Ok(())
-    }
-
-    #[test]
     fn prefix_search_works() -> Result<()> {
         let (mut hist, _) = create_history();
         hist.save(HistoryItem::from_command_line("find me as well"))?;

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -453,7 +453,7 @@ mod tests {
             // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
         }
 
-        let (reading_hist, _) = create_history();
+        let (reading_hist, _) = create_history_at(capacity, &histfile);
 
         let actual: Vec<_> = get_all_entry_texts(reading_hist.as_ref());
         assert_eq!(expected_truncated_entries, actual);
@@ -481,14 +481,14 @@ mod tests {
         }
 
         {
-            let (truncating_hist, _) = create_history();
+            let (truncating_hist, _) = create_history_at(5, &histfile);
 
             let actual: Vec<_> = get_all_entry_texts(truncating_hist.as_ref());
             assert_eq!(expected_truncated_entries, actual);
             // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
         }
 
-        let (reading_hist, _) = create_history();
+        let (reading_hist, _) = create_history_at(5, &histfile);
 
         let actual: Vec<_> = get_all_entry_texts(reading_hist.as_ref());
         assert_eq!(expected_truncated_entries, actual);
@@ -573,7 +573,7 @@ mod tests {
             t.join().unwrap();
         }
 
-        let (reading_hist, _) = create_history();
+        let (reading_hist, _) = create_history_at(capacity, &histfile);
 
         let actual: Vec<_> = get_all_entry_texts(reading_hist.as_ref());
 

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -575,13 +575,13 @@ mod tests {
         let actual: Vec<_> = get_all_entry_texts(reading_hist.as_ref());
 
         assert!(
-            actual.contains(&&format!("initial {}", capacity - 1)),
+            actual.contains(&format!("initial {}", capacity - 1)),
             "Overwrote entry from before threading test"
         );
 
         for i in 0..num_threads {
-            assert!(actual.contains(&&format!("A{}", i)),);
-            assert!(actual.contains(&&format!("B{}", i)),);
+            assert!(actual.contains(&format!("A{}", i)),);
+            assert!(actual.contains(&format!("B{}", i)),);
         }
 
         tmp.close().unwrap();

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -1,6 +1,6 @@
 use super::{
-    base::{CommandLineSearch, HistorySessionId, Result},
-    History, HistoryItem, HistoryItemId, SearchDirection, SearchQuery,
+    base::{CommandLineSearch, Result},
+    History, HistoryItem, HistoryItemId, HistorySessionId, SearchDirection, SearchQuery,
 };
 
 use std::{

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -68,8 +68,8 @@ impl History for FileBackedHistory {
         self.reset_cursor();
     }
 
-    fn iter_chronologic(&self) -> Iter<'_, String> {
-        self.entries.iter()
+    fn iter_chronologic(&self) -> Box<(dyn DoubleEndedIterator<Item = String> + '_)> {
+        Box::new(self.entries.iter().map(|e| e.to_string()))
     }
 
     fn back(&mut self) {
@@ -121,7 +121,6 @@ impl History for FileBackedHistory {
         self.iter_chronologic()
             .rev()
             .filter(|entry| entry.contains(search))
-            .cloned()
             .collect::<Vec<String>>()
     }
 

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -231,7 +231,8 @@ impl History for FileBackedHistory {
         Ok(())
     }
 
-    fn new_session_id(&mut self) -> Result<HistorySessionId> {
+    fn next_session_id(&mut self) -> Result<HistorySessionId> {
+        // doesn't support separating out different sessions
         Ok(HistorySessionId::new(0))
     }
 }

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -1,6 +1,10 @@
 use super::{
-    base::{CommandLineSearch, Result},
-    History, HistoryItem, HistoryItemId, HistorySessionId, SearchDirection, SearchQuery,
+    base::CommandLineSearch, History, HistoryItem, HistoryItemId, HistorySessionId,
+    SearchDirection, SearchQuery,
+};
+use crate::{
+    result::{ReedlineError, ReedlineErrorVariants},
+    Result,
 };
 
 use std::{
@@ -85,7 +89,12 @@ impl History for FileBackedHistory {
 
     fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>> {
         if query.start_time.is_some() || query.end_time.is_some() {
-            return Err("filtering by time not supported in plain text history".to_string());
+            return Err(ReedlineError(
+                ReedlineErrorVariants::HistoryFeatureUnsupported {
+                    history: "FileBackedHistory",
+                    feature: "filtering by time",
+                },
+            ));
         }
 
         if query.filter.hostname.is_some()
@@ -93,9 +102,12 @@ impl History for FileBackedHistory {
             || query.filter.cwd_prefix.is_some()
             || query.filter.exit_successful.is_some()
         {
-            return Err(
-                "filtering by extra context is not supported in plain text history".to_string(),
-            );
+            return Err(ReedlineError(
+                ReedlineErrorVariants::HistoryFeatureUnsupported {
+                    history: "FileBackedHistory",
+                    feature: "filtering by extra info",
+                },
+            ));
         }
         let (min_id, max_id) = {
             let start = query.start_id.map(|e| e.0);
@@ -159,11 +171,21 @@ impl History for FileBackedHistory {
         _id: super::HistoryItemId,
         _updater: &dyn Fn(super::HistoryItem) -> super::HistoryItem,
     ) -> Result<()> {
-        Err("updating entries is not supported in plain text history".to_string())
+        Err(ReedlineError(
+            ReedlineErrorVariants::HistoryFeatureUnsupported {
+                history: "FileBackedHistory",
+                feature: "updating entries",
+            },
+        ))
     }
 
     fn delete(&mut self, _h: super::HistoryItemId) -> Result<()> {
-        Err("removing entries is not supported in plain text history".to_string())
+        Err(ReedlineError(
+            ReedlineErrorVariants::HistoryFeatureUnsupported {
+                history: "FileBackedHistory",
+                feature: "removing entries",
+            },
+        ))
     }
 
     /// Writes unwritten history contents to disk.

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -21,27 +21,27 @@ impl HistorySessionId {
 pub trait HistoryItemExtraInfo: Serialize + DeserializeOwned + Default + Send {}
 #[derive(Default, Debug, PartialEq, Eq)]
 /// something that is serialized as null and deserialized by ignoring everything
-pub struct Anything;
-impl Serialize for Anything {
+pub struct IgnoreAllExtraInfo;
+impl Serialize for IgnoreAllExtraInfo {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        Option::<Anything>::None.serialize(serializer)
+        Option::<IgnoreAllExtraInfo>::None.serialize(serializer)
     }
 }
-impl<'de> Deserialize<'de> for Anything {
+impl<'de> Deserialize<'de> for IgnoreAllExtraInfo {
     fn deserialize<D>(d: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        serde::de::IgnoredAny::deserialize(d).map(|_| Anything)
+        serde::de::IgnoredAny::deserialize(d).map(|_| IgnoreAllExtraInfo)
     }
 }
-impl HistoryItemExtraInfo for Anything {}
+impl HistoryItemExtraInfo for IgnoreAllExtraInfo {}
 /// Represents one run command with some optional additional context
 #[derive(Clone, Debug, PartialEq)]
-pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = Anything> {
+pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = IgnoreAllExtraInfo> {
     /// primary key, unique across one history
     pub id: Option<HistoryItemId>,
     /// date-time when this command was started

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -40,7 +40,7 @@ impl<'de> Deserialize<'de> for IgnoreAllExtraInfo {
 }
 impl HistoryItemExtraInfo for IgnoreAllExtraInfo {}
 /// Represents one run command with some optional additional context
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = IgnoreAllExtraInfo> {
     /// primary key, unique across one history
     pub id: Option<HistoryItemId>,

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -1,0 +1,81 @@
+use std::time::Duration;
+
+use chrono::Utc;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct HistoryItemId(pub(crate) i64);
+impl HistoryItemId {
+    pub(crate) fn new(i: i64) -> HistoryItemId {
+        HistoryItemId(i)
+    }
+}
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct HistorySessionId(pub(crate) i64);
+impl HistorySessionId {
+    pub(crate) fn new(i: i64) -> HistorySessionId {
+        HistorySessionId(i)
+    }
+}
+/// This trait represents additional arbitrary context to be added to a history (optional, see [HistoryItem])
+pub trait HistoryItemExtraInfo: Serialize + DeserializeOwned + Default + Send {}
+#[derive(Default, Debug, PartialEq, Eq)]
+/// something that is serialized as null and deserialized by ignoring everything
+pub struct Anything;
+impl Serialize for Anything {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Option::<Anything>::None.serialize(serializer)
+    }
+}
+impl<'de> Deserialize<'de> for Anything {
+    fn deserialize<D>(d: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        serde::de::IgnoredAny::deserialize(d).map(|_| Anything)
+    }
+}
+impl HistoryItemExtraInfo for Anything {}
+/// Represents one run command with some optional additional context
+#[derive(Clone, Debug, PartialEq)]
+pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = Anything> {
+    /// primary key, unique across one history
+    pub id: Option<HistoryItemId>,
+    /// date-time when this command was started
+    pub start_timestamp: Option<chrono::DateTime<Utc>>,
+    /// the full command line as text
+    pub command_line: String,
+    /// a unique id for one shell session.
+    /// used so the history can be filtered to a single session
+    pub session_id: Option<HistorySessionId>,
+    /// the hostname the commands were run in
+    pub hostname: Option<String>,
+    /// the current working directory
+    pub cwd: Option<String>,
+    /// the duration the command took to complete
+    pub duration: Option<Duration>,
+    /// the exit status of the command
+    pub exit_status: Option<i64>,
+    /// arbitrary additional information that might be interesting
+    pub more_info: Option<ExtraInfo>,
+}
+
+impl HistoryItem {
+    /// create a history item purely from the command line with everything else set to None
+    pub fn from_command_line(cmd: impl Into<String>) -> HistoryItem {
+        HistoryItem {
+            id: None,
+            start_timestamp: None,
+            command_line: cmd.into(),
+            session_id: None,
+            hostname: None,
+            cwd: None,
+            duration: None,
+            exit_status: None,
+            more_info: None,
+        }
+    }
+}

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -1,12 +1,12 @@
 mod base;
-#[cfg(feature="file-history")]
+mod cursor;
 mod file_backed;
 #[cfg(feature="sqlite")]
 mod sqlite_backed;
 #[cfg(feature="sqlite")]
 pub use sqlite_backed::SqliteBackedHistory;
 
-pub use base::{HistoryCursor, HistoryItem, HistoryItemId, History, HistoryNavigationQuery, Result};
+pub use base::{HistoryItem, HistoryItemId, History, HistoryNavigationQuery, Result, SearchQuery, SearchDirection};
+pub use cursor::HistoryCursor;
 
-#[cfg(feature="file-history")]
 pub use file_backed::{FileBackedHistory, HISTORY_SIZE};

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -7,7 +7,7 @@ mod sqlite_backed;
 #[cfg(feature = "sqlite")]
 pub use sqlite_backed::SqliteBackedHistory;
 
-pub use base::{History, HistoryNavigationQuery, Result, SearchDirection, SearchQuery};
+pub use base::{History, HistoryNavigationQuery, SearchDirection, SearchQuery};
 pub use cursor::HistoryCursor;
 pub use item::{HistoryItem, HistoryItemId, HistorySessionId};
 

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -1,12 +1,15 @@
 mod base;
 mod cursor;
 mod file_backed;
-#[cfg(feature="sqlite")]
+#[cfg(feature = "sqlite")]
 mod sqlite_backed;
-#[cfg(feature="sqlite")]
+#[cfg(feature = "sqlite")]
 pub use sqlite_backed::SqliteBackedHistory;
 
-pub use base::{HistoryItem, HistoryItemId, History, HistoryNavigationQuery, Result, SearchQuery, SearchDirection};
+pub use base::{
+    History, HistoryItem, HistoryItemId, HistoryNavigationQuery, Result, SearchDirection,
+    SearchQuery,
+};
 pub use cursor::HistoryCursor;
 
 pub use file_backed::{FileBackedHistory, HISTORY_SIZE};

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -1,9 +1,12 @@
 mod base;
+#[cfg(feature="file-history")]
 mod file_backed;
 #[cfg(feature="sqlite")]
 mod sqlite_backed;
 #[cfg(feature="sqlite")]
 pub use sqlite_backed::SqliteBackedHistory;
 
-pub use base::{History, HistoryNavigationQuery};
+pub use base::{HistoryCursor, HistoryItem, HistoryItemId, History, HistoryNavigationQuery, Result};
+
+#[cfg(feature="file-history")]
 pub use file_backed::{FileBackedHistory, HISTORY_SIZE};

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -1,15 +1,14 @@
 mod base;
 mod cursor;
 mod file_backed;
+mod item;
 #[cfg(feature = "sqlite")]
 mod sqlite_backed;
 #[cfg(feature = "sqlite")]
 pub use sqlite_backed::SqliteBackedHistory;
 
-pub use base::{
-    History, HistoryItem, HistoryItemId, HistoryNavigationQuery, Result, SearchDirection,
-    SearchQuery,
-};
+pub use base::{History, HistoryNavigationQuery, Result, SearchDirection, SearchQuery};
 pub use cursor::HistoryCursor;
+pub use item::{HistoryItem, HistoryItemId, HistorySessionId};
 
 pub use file_backed::{FileBackedHistory, HISTORY_SIZE};

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -7,7 +7,7 @@ mod sqlite_backed;
 #[cfg(feature = "sqlite")]
 pub use sqlite_backed::SqliteBackedHistory;
 
-pub use base::{History, HistoryNavigationQuery, SearchDirection, SearchQuery};
+pub use base::{History, HistoryNavigationQuery, SearchDirection, SearchFilter, SearchQuery};
 pub use cursor::HistoryCursor;
 pub use item::{HistoryItem, HistoryItemId, HistorySessionId};
 

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -1,5 +1,9 @@
 mod base;
 mod file_backed;
+#[cfg(feature="sqlite")]
+mod sqlite_backed;
+#[cfg(feature="sqlite")]
+pub use sqlite_backed::SqliteBackedHistory;
 
 pub use base::{History, HistoryNavigationQuery};
 pub use file_backed::{FileBackedHistory, HISTORY_SIZE};

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -182,7 +182,7 @@ impl<ContextType: HistoryEntryContext> History for SqliteBackedHistory<ContextTy
         if self.last_run_command_id == None {
             self.last_run_command_id = self
                 .db
-                .prepare("select max(id) from history")
+                .prepare("select coalesce(max(id), 0) from history")
                 .unwrap()
                 .query_row(params![], |e| e.get(0))
                 .optional()

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -101,7 +101,6 @@ impl History for SqliteBackedHistory {
 
     fn count(&self, query: SearchQuery) -> Result<i64> {
         let (query, params) = self.construct_query(&query, "coalesce(count(*), 0)");
-        debug_print_query(&query, &params);
         let params_borrow: Vec<(&str, &dyn ToSql)> = params.iter().map(|e| (e.0, &*e.1)).collect();
         let result: i64 = self
             .db
@@ -114,7 +113,6 @@ impl History for SqliteBackedHistory {
 
     fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>> {
         let (query, params) = self.construct_query(&query, "*");
-        debug_print_query(&query, &params);
         let params_borrow: Vec<(&str, &dyn ToSql)> = params.iter().map(|e| (e.0, &*e.1)).collect();
         let results: Vec<HistoryItem> = self
             .db
@@ -163,7 +161,7 @@ impl History for SqliteBackedHistory {
         Ok(())
     }
 
-    fn new_session_id(&mut self) -> Result<HistorySessionId> {
+    fn next_session_id(&mut self) -> Result<HistorySessionId> {
         Ok(HistorySessionId::new(
             self.db
                 .query_row(
@@ -403,8 +401,4 @@ impl SqliteBackedHistory {
         // aprintln!("query={query}");
         (query, params)
     }
-}
-
-fn debug_print_query<'a>(_query: &'a str, _params: &'a [(&str, Box<dyn ToSql + 'a>)]) {
-    // eprintln!("SQL: {}; -- {:?}", query, params.iter().map(|(k, e)| (k, e.to_sql().unwrap())).collect::<std::collections::HashMap<_, _>>());
 }

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -5,7 +5,10 @@ use super::{
     base::{CommandLineSearch, SearchDirection, SearchQuery},
     History, HistoryItem, HistoryItemId, HistorySessionId,
 };
-use crate::{Result, result::{ReedlineError, ReedlineErrorVariants}};
+use crate::{
+    result::{ReedlineError, ReedlineErrorVariants},
+    Result,
+};
 
 const SQLITE_APPLICATION_ID: i32 = 1151497937;
 
@@ -247,7 +250,10 @@ impl History for SqliteBackedHistory {
 }
 fn map_sqlite_err(err: rusqlite::Error) -> ReedlineError {
     // todo: better error mapping
-    ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(format!("{:?}", err)))
+    ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(format!(
+        "{:?}",
+        err
+    )))
 }
 
 type BoxedNamedParams<'a> = Vec<(&'static str, Box<dyn ToSql + 'a>)>;
@@ -260,7 +266,12 @@ impl SqliteBackedHistory {
     ///
     pub fn with_file(file: PathBuf) -> Result<Self> {
         if let Some(base_dir) = file.parent() {
-            std::fs::create_dir_all(base_dir).map_err(|e| ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(format!("{}", e))))?;
+            std::fs::create_dir_all(base_dir).map_err(|e| {
+                ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(format!(
+                    "{}",
+                    e
+                )))
+            })?;
         }
         let db = Connection::open(&file).map_err(map_sqlite_err)?;
         Self::from_connection(db)

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -1,13 +1,14 @@
 use chrono::{TimeZone, Utc};
-use rusqlite::{named_params, params, Connection, OptionalExtension, ToSql};
-use serde::{de::DeserializeOwned, Serialize};
+use rusqlite::{named_params, params, Connection, ToSql};
 
-use super::{base::{HistoryNavigationQuery, SearchDirection, SearchFilter, CommandLineSearch}, HistoryItem, HistoryItemId, History, Result};
-use crate::core_editor::LineBuffer;
+
+use super::{
+    base::{CommandLineSearch, SearchDirection, SearchQuery, HistorySessionId},
+    History, HistoryItem, HistoryItemId, Result,
+};
+
 use std::{
-    fmt::Display,
     path::PathBuf,
-    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -16,35 +17,21 @@ use std::{
 /// to add information such as a timestamp, running directory, result...
 pub struct SqliteBackedHistory {
     db: rusqlite::Connection,
-    last_run_command: Option<HistoryItem>,
-    cursor: SqliteHistoryCursor,
 }
-
-// for arrow-navigation
-struct SqliteHistoryCursor {
-    id: i64,
-    command: Option<String>,
-    query: HistoryNavigationQuery,
-}
-
-    /*fn append(&mut self, entry: &str) {
-        let item = HistoryItem::default();
-        let item = self.save(item).unwrap();
-        self.last_run_command = Some(item);
-        self.reset_cursor();
-    }*/
 
 fn deserialize_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem> {
     let x: String = row.get("more_info")?;
     Ok(HistoryItem {
         id: Some(HistoryItemId::new(row.get("id")?)),
-        start_timestamp: Utc.timestamp_millis(row.get("start_timestamp")?),
+        start_timestamp: row
+            .get::<&str, Option<i64>>("start_timestamp")?
+            .map(|e| Utc.timestamp_millis(e)),
         command_line: row.get("command_line")?,
         session_id: row.get("session_id")?,
         hostname: row.get("hostname")?,
         cwd: row.get("cwd")?,
         duration: row
-            .get::<&str, Option<i64>>("duration")?
+            .get::<&str, Option<i64>>("duration_ms")?
             .map(|e| Duration::from_millis(e as u64)),
         exit_status: row.get("exit_status")?,
         more_info: serde_json::from_str(&x).unwrap(),
@@ -60,22 +47,22 @@ impl History for SqliteBackedHistory {
             .db
             .prepare(
                 "insert into history
-                               (id,  start_timestamp,  command_line,  session_id,  hostname,  cwd,  duration,  exit_status,  more_info)
-                        values (:id, :start_timestamp, :command_line, :session_id, :hostname, :cwd, :duration, :exit_status, :more_info)
+                               (id,  start_timestamp,  command_line,  session_id,  hostname,  cwd,  duration_ms,  exit_status,  more_info)
+                        values (:id, :start_timestamp, :command_line, :session_id, :hostname, :cwd, :duration_ms, :exit_status, :more_info)
                     returning id",
             )
             .map_err(|e|e.to_string())?
             .query_row(
                 named_params! {
-                    "id": entry.id.map(|id| id.0),
-                    "start_timestamp": entry.start_timestamp.timestamp_millis(),
-                    "command_line": entry.command_line,
-                    "session_id": entry.session_id,
-                    "hostname": entry.hostname,
-                    "cwd": entry.cwd,
-                    "duration": entry.duration.map(|e| e.as_millis() as i64),
-                    "exit_status": entry.exit_status,
-                    "more_info": &serde_json::to_string(&entry.more_info).unwrap()
+                    ":id": entry.id.map(|id| id.0),
+                    ":start_timestamp": entry.start_timestamp.map(|e| e.timestamp_millis()),
+                    ":command_line": entry.command_line,
+                    ":session_id": entry.session_id,
+                    ":hostname": entry.hostname,
+                    ":cwd": entry.cwd,
+                    ":duration_ms": entry.duration.map(|e| e.as_millis() as i64),
+                    ":exit_status": entry.exit_status,
+                    ":more_info": &serde_json::to_string(&entry.more_info).unwrap()
                 },
                 |row| row.get(0),
             )
@@ -94,69 +81,20 @@ impl History for SqliteBackedHistory {
         Ok(entry)
     }
 
-    fn search(
-        &self,
-        start: chrono::DateTime<Utc>,
-        direction: SearchDirection,
-        end: Option<chrono::DateTime<Utc>>,
-        limit: Option<i64>,
-        filter: SearchFilter,
-    ) -> Result<Vec<HistoryItem>> {
-        let (op, asc) = match direction {
-            SearchDirection::Forward => (">", "asc"),
-            SearchDirection::Backward => ("<", "desc"),
-        };
-        let mut wheres: Vec<String> = vec!["timestamp_start {op} :start".to_string()];
-        let mut params: Vec<(&str, Box<dyn ToSql>)> = vec![];
-        if let Some(end) = end {
-            wheres.push(format!("where :end {op}= timestamp_start"));
-            params.push((":end", Box::new(end.timestamp_millis())));
-        }
-        let limit = match limit {
-            Some(l) => {
-                params.push((":limit", Box::new(l)));
-                format!("limit :limit")
-            }
-            None => format!(""),
-        };
+    fn count(&self, query: SearchQuery) -> Result<i64> {
+        let (query, params) = self.construct_query(query, "coalesce(count(*), 0)");
+        let params_borrow: Vec<(&str, &dyn ToSql)> = params.iter().map(|e| (e.0, &*e.1)).collect();
+        let result: i64 = self
+            .db
+            .prepare(&query)
+            .unwrap()
+            .query_row(&params_borrow[..], |r| r.get(0))
+            .map_err(|e| e.to_string())?;
+        Ok(result)
+    }
 
-        if let Some(command_line) = &filter.command_line {
-            // todo: escape %
-            let command_line_like = match command_line {
-                CommandLineSearch::Exact(e) => format!("{e}"),
-                CommandLineSearch::Prefix(prefix) => format!("{prefix}%"),
-                CommandLineSearch::Substring(cont) => format!("%{cont}%"),
-            };
-            wheres.push("command_line like :command_line".to_string());
-            params.push((":command_line", Box::new(command_line_like)));
-        }
-        if let Some(hostname) = filter.hostname {
-            wheres.push("hostname = :hostname".to_string());
-            params.push((":hostname", Box::new(hostname)));
-        }
-        if let Some(cwd_exact) = filter.cwd_exact {
-            wheres.push("cwd = :cwd".to_string());
-            params.push((":cwd", Box::new(cwd_exact)));
-        }
-        if let Some(cwd_prefix) = filter.cwd_prefix {
-            wheres.push("cwd like :cwd_like".to_string());
-            let cwd_like = format!("{cwd_prefix}%");
-            params.push((":cwd_like", Box::new(cwd_like)));
-        }
-        if let Some(exit_successful) = filter.exit_successful {
-            if exit_successful {
-                wheres.push("exit_status = 0".to_string());
-            } else {
-                wheres.push("exit_status != 0".to_string());
-            }
-        }
-        let wheres = wheres.join(" and ");
-        let query = format!(
-            "select * from history
-            where 
-            {wheres}
-            order by id {asc} {limit}"
-        );
+    fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>> {
+        let (query, params) = self.construct_query(query, "*");
         let params_borrow: Vec<(&str, &dyn ToSql)> = params.iter().map(|e| (e.0, &*e.1)).collect();
         let results: Vec<HistoryItem> = self
             .db
@@ -181,21 +119,12 @@ impl History for SqliteBackedHistory {
     fn update(
         &mut self,
         id: HistoryItemId,
-        updater: Box<dyn FnOnce(HistoryItem) -> HistoryItem>,
+        updater: &dyn Fn(HistoryItem) -> HistoryItem,
     ) -> Result<()> {
+        // in theory this should run in a transaction
         let item = self.load(id)?;
         self.save(updater(item))?;
         Ok(())
-    }
-
-    fn entry_count(&self) -> Result<i64> {
-        self.db
-            .query_row(
-                "select coalesce(count(*), 0) from history",
-                params![],
-                |r| r.get::<usize, i64>(0),
-            )
-            .map_err(|e| e.to_string())
     }
 
     fn delete(&mut self, h: HistoryItemId) -> Result<()> {
@@ -209,9 +138,21 @@ impl History for SqliteBackedHistory {
         Ok(())
     }
 
-    fn sync(&mut self) -> Result<()> {
-        // no-op
+    fn sync(&mut self) -> std::io::Result<()> {
+        // no-op (todo?)
         Ok(())
+    }
+
+    fn new_session_id(&mut self) -> Result<HistorySessionId> {
+        Ok(HistorySessionId::new(
+            self.db
+                .query_row(
+                    "select coalesce(max(session_id), 0) + 1 from history",
+                    params![],
+                    |r| r.get(0),
+                )
+                .map_err(map_sqlite_err)?,
+        ))
     }
 
     /*fn iter_chronologic(&self) -> Box<(dyn DoubleEndedIterator<Item = std::string::String> + '_)> {
@@ -283,9 +224,9 @@ impl History for SqliteBackedHistory {
         self.cursor.command = None;
     }*/
 }
-fn map_sqlite_err(err: rusqlite::Error) -> std::io::Error {
+fn map_sqlite_err(err: rusqlite::Error) -> String {
     // todo: better error mapping
-    std::io::Error::new(std::io::ErrorKind::Other, err)
+    format!("{:?}", err)
 }
 
 impl SqliteBackedHistory {
@@ -294,19 +235,19 @@ impl SqliteBackedHistory {
     ///
     /// **Side effects:** creates all nested directories to the file
     ///
-    pub fn with_file(file: PathBuf) -> std::io::Result<Self> {
+    pub fn with_file(file: PathBuf) -> Result<Self> {
         if let Some(base_dir) = file.parent() {
-            std::fs::create_dir_all(base_dir)?;
+            std::fs::create_dir_all(base_dir).map_err(|e| format!("{}", e))?;
         }
         let db = Connection::open(&file).map_err(map_sqlite_err)?;
         Self::from_connection(db)
     }
     /// Creates a new history in memory
-    pub fn in_memory() -> std::io::Result<Self> {
+    pub fn in_memory() -> Result<Self> {
         Self::from_connection(Connection::open_in_memory().map_err(map_sqlite_err)?)
     }
     /// initialize a new database / migrate an existing one
-    fn from_connection(db: Connection) -> std::io::Result<Self> {
+    fn from_connection(db: Connection) -> Result<Self> {
         // https://phiresky.github.io/blog/2020/sqlite-performance-tuning/
         db.pragma_update(None, "journal_mode", "wal")
             .map_err(map_sqlite_err)?;
@@ -319,32 +260,113 @@ impl SqliteBackedHistory {
         db.execute(
             "
         create table if not exists history (
-            id integer primary key autoincrement,
-            start_timestamp integer not null,
-            command_line: text not null,
-            session_id: integer not null,
-            hostname: text not null,
-            cwd: text not null,
-            duration_ms: integer,
-            exit_status: integer,
-            more_info: text
+            id integer primary key on conflict replace autoincrement,
+            command_line text not null,
+            start_timestamp integer,
+            session_id integer,
+            hostname text,
+            cwd text,
+            duration_ms integer,
+            exit_status integer,
+            more_info text
         ) strict;
         create index if not exists idx_history_time on history(start_timestamp);
         create index if not exists idx_history_cwd on history(hostname, cwd);
         create index if not exists idx_history_exit_status on history(exit_status);
+        create index if not exists idx_history_cmd on history(command_line);
+        create index if not exists idx_history_cmd on history(session_id);
+        -- todo: better indexes
         ",
             params![],
         )
         .map_err(map_sqlite_err)?;
-        let mut hist = SqliteBackedHistory {
-            db,
-            last_run_command: None,
-            cursor: SqliteHistoryCursor {
-                id: 0,
-                command: None,
-                query: HistoryNavigationQuery::Normal(LineBuffer::default()),
-            },
+        Ok(SqliteBackedHistory { db })
+    }
+    fn construct_query(
+        &self,
+        query: SearchQuery,
+        select_expression: &str,
+    ) -> (String, Vec<(&'static str, Box<dyn ToSql>)>) {
+        let SearchQuery {
+            start_time,
+            start_id,
+            direction,
+            end_time,
+            end_id,
+            limit,
+            filter,
+        } = query;
+        let (op, asc) = match direction {
+            SearchDirection::Forward => (">", "asc"),
+            SearchDirection::Backward => ("<", "desc"),
         };
-        Ok(hist)
+        let mut wheres: Vec<String> = vec![];
+        let mut params: Vec<(&str, Box<dyn ToSql>)> = vec![];
+        if let Some(start) = start_time {
+            wheres.push(format!("timestamp_start {op} :start_time"));
+            params.push((":start_time", Box::new(start.timestamp_millis())))
+        }
+        if let Some(end) = end_time {
+            wheres.push(format!("where :end_time {op}= timestamp_start"));
+            params.push((":end_time", Box::new(end.timestamp_millis())));
+        }
+        if let Some(start) = start_id {
+            wheres.push(format!("id {op} :start_id"));
+            params.push((":start_id", Box::new(start.0)))
+        }
+        if let Some(end) = end_id {
+            wheres.push(format!("where :end_id {op}= id"));
+            params.push((":end_id", Box::new(end.0)));
+        }
+        let limit = match limit {
+            Some(l) => {
+                params.push((":limit", Box::new(l)));
+                format!("limit :limit")
+            }
+            None => format!(""),
+        };
+
+        if let Some(command_line) = &filter.command_line {
+            // todo: escape %
+            let command_line_like = match command_line {
+                CommandLineSearch::Exact(e) => format!("{e}"),
+                CommandLineSearch::Prefix(prefix) => format!("{prefix}%"),
+                CommandLineSearch::Substring(cont) => format!("%{cont}%"),
+            };
+            wheres.push("command_line like :command_line".to_string());
+            params.push((":command_line", Box::new(command_line_like)));
+        }
+        if let Some(hostname) = filter.hostname {
+            wheres.push("hostname = :hostname".to_string());
+            params.push((":hostname", Box::new(hostname)));
+        }
+        if let Some(cwd_exact) = filter.cwd_exact {
+            wheres.push("cwd = :cwd".to_string());
+            params.push((":cwd", Box::new(cwd_exact)));
+        }
+        if let Some(cwd_prefix) = filter.cwd_prefix {
+            wheres.push("cwd like :cwd_like".to_string());
+            let cwd_like = format!("{cwd_prefix}%");
+            params.push((":cwd_like", Box::new(cwd_like)));
+        }
+        if let Some(exit_successful) = filter.exit_successful {
+            if exit_successful {
+                wheres.push("exit_status = 0".to_string());
+            } else {
+                wheres.push("exit_status != 0".to_string());
+            }
+        }
+        let mut wheres = wheres.join(" and ");
+        if wheres.is_empty() {
+            wheres = "true".to_string();
+        }
+        let query = format!(
+            "select {select_expression} from history
+        where
+        {wheres}
+        order by id {asc} {limit}"
+        );
+        // println!("query={query}");
+        (query, params)
     }
 }

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -1,0 +1,621 @@
+use rusqlite::{named_params, params, Connection};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use super::{base::HistoryNavigationQuery, History};
+use crate::core_editor::LineBuffer;
+use std::{
+    collections::{vec_deque::Iter, VecDeque},
+    fs::OpenOptions,
+    io::{BufRead, BufReader, BufWriter, Seek, SeekFrom, Write},
+    ops::{Deref, DerefMut},
+    path::PathBuf,
+    sync::{Arc, Mutex, RwLock},
+};
+
+pub trait HistoryEntryContext: Serialize + DeserializeOwned + Default + Send {}
+impl<T> HistoryEntryContext for T where T: Serialize + DeserializeOwned + Default + Send {}
+
+/// A history that stores the values to an SQLite database.
+/// In addition to storing the command, the history can store an additional arbitrary HistoryEntryContext,
+/// to add information such as a timestamp, running directory, result...
+#[derive(Clone)]
+pub struct SqliteBackedHistory<ContextType>
+where
+    ContextType: HistoryEntryContext,
+{
+    inner: Arc<Mutex<SqliteBackedHistoryInner<ContextType>>>,
+    dummy: VecDeque<String>,
+}
+struct SqliteBackedHistoryInner<ContextType> {
+    db: rusqlite::Connection,
+    last_command_id: Option<i64>,
+    last_command_context: Option<ContextType>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct CommandSqlite<'a> {
+    id: i64,
+    command: &'a str,
+}
+impl<ContextType: HistoryEntryContext> History for SqliteBackedHistory<ContextType> {
+    /// Appends an entry if non-empty and not repetition of the previous entry.
+    /// Resets the browsing cursor to the default state in front of the most recent entry.
+    ///
+    fn append(&mut self, entry: &str) {
+        let mut inner = self.inner.lock().expect("lock poisoned");
+        let ctx = ContextType::default();
+        let ret: i64 = inner
+            .db
+            .prepare(
+                "insert into history (command, context) values (:command, :context) returning id",
+            )
+            .unwrap()
+            .query_row(
+                named_params! {
+                    ":command": entry,
+                    ":context": serde_json::to_string(&ctx).unwrap()
+                },
+                |row| row.get(0),
+            )
+            .unwrap();
+        inner.last_command_id = Some(ret);
+        inner.last_command_context = Some(ctx);
+    }
+
+    fn iter_chronologic(&self) -> Iter<'_, String> {
+        self.dummy.iter()
+        // self.entries.iter()
+    }
+
+    fn back(&mut self) {
+        todo!()
+    }
+
+    fn forward(&mut self) {
+        todo!()
+    }
+
+    fn string_at_cursor(&self) -> Option<String> {
+        todo!()
+    }
+
+    fn set_navigation(&mut self, navigation: HistoryNavigationQuery) {
+        todo!()
+    }
+
+    fn get_navigation(&self) -> HistoryNavigationQuery {
+        todo!()
+    }
+
+    fn query_entries(&self, search: &str) -> Vec<String> {
+        self.iter_chronologic()
+            .rev()
+            .filter(|entry| entry.contains(search))
+            .cloned()
+            .collect::<Vec<String>>()
+    }
+
+    fn max_values(&self) -> usize {
+        todo!()
+    }
+
+    /// Writes unwritten history contents to disk.
+    ///
+    /// If file would exceed `capacity` truncates the oldest entries.
+    fn sync(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    /// Reset the internal browsing cursor
+    fn reset_cursor(&mut self) {
+        todo!()
+    }
+}
+fn map_sqlite_err(err: rusqlite::Error) -> std::io::Error {
+    // todo: better error mapping
+    std::io::Error::new(std::io::ErrorKind::Other, err)
+}
+
+impl<ContextType: HistoryEntryContext> SqliteBackedHistory<ContextType> {
+    /*pub fn new() -> Self {
+        SqliteBackedHistory::with_file(":memory:")
+    }*/
+
+    /// Creates a new history with an associated history file.
+    ///
+    /// History file format: commands separated by new lines.
+    /// If file exists file will be read otherwise empty file will be created.
+    ///
+    ///
+    /// **Side effects:** creates all nested directories to the file
+    ///
+    pub fn with_file(file: PathBuf) -> std::io::Result<Self> {
+        let db = Connection::open(&file).map_err(map_sqlite_err)?;
+        db.pragma_update(None, "journal_mode", "wal").map_err(map_sqlite_err)?;
+        db.execute(
+            "
+        create table if not exists history (
+            id integer primary key autoincrement,
+            command text not null,
+            context text not null
+        ) strict
+        ",
+            params![],
+        ).map_err(map_sqlite_err)?;
+        Ok(SqliteBackedHistory {
+            dummy: VecDeque::new(),
+            inner: Arc::new(Mutex::new(SqliteBackedHistoryInner {
+                db,
+                last_command_id: None,
+                last_command_context: None,
+            })),
+        })
+    }
+
+    // todo: better error type (which one?)
+    /// updates the context stored for the last saved command
+    pub fn update_context<F>(&self, callback: F) -> Result<(), String>
+    where
+        F: FnOnce(ContextType) -> ContextType,
+    {
+        let mut inner = self.inner.lock().expect("lock poisoned");
+        if let (Some(id), Some(ctx)) = (inner.last_command_id, inner.last_command_context.take()) {
+            let mapped_ctx = callback(ctx);
+            inner
+                .db
+                .execute(
+                    "update history set context = :context where id = :id",
+                    named_params! {
+                        ":context": serde_json::to_string(&mapped_ctx).map_err(|e| format!("{e}"))?,
+                        ":id": id
+                    },
+                )
+                .map_err(|e| format!("{e}"))?;
+            inner.last_command_context.replace(mapped_ctx);
+            Ok(())
+        } else {
+            Err(format!("No command has been executed yet"))
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn accessing_empty_history_returns_nothing() {
+        let hist = FileBackedHistory::default();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn going_forward_in_empty_history_does_not_error_out() {
+        let mut hist = FileBackedHistory::default();
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn going_backwards_in_empty_history_does_not_error_out() {
+        let mut hist = FileBackedHistory::default();
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn going_backwards_bottoms_out() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("command1");
+        hist.append("command2");
+        hist.back();
+        hist.back();
+        hist.back();
+        hist.back();
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("command1".to_string()));
+    }
+
+    #[test]
+    fn going_forwards_bottoms_out() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("command1");
+        hist.append("command2");
+        hist.forward();
+        hist.forward();
+        hist.forward();
+        hist.forward();
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn appends_only_unique() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("unique_old");
+        hist.append("test");
+        hist.append("test");
+        hist.append("unique");
+        assert_eq!(hist.entries.len(), 3);
+    }
+    #[test]
+    fn appends_no_empties() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("");
+        assert_eq!(hist.entries.len(), 0);
+    }
+
+    #[test]
+    fn prefix_search_works() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("find me as well");
+        hist.append("test");
+        hist.append("find me");
+
+        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+    }
+
+    #[test]
+    fn prefix_search_bottoms_out() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("find me as well");
+        hist.append("test");
+        hist.append("find me");
+
+        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+        hist.back();
+        hist.back();
+        hist.back();
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+    }
+    #[test]
+    fn prefix_search_returns_to_none() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("find me as well");
+        hist.append("test");
+        hist.append("find me");
+
+        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), None);
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn prefix_search_ignores_consecutive_equivalent_entries_going_backwards() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("find me as well");
+        hist.append("find me once");
+        hist.append("test");
+        hist.append("find me once");
+
+        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me once".to_string()));
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+    }
+
+    #[test]
+    fn prefix_search_ignores_consecutive_equivalent_entries_going_forwards() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("find me once");
+        hist.append("test");
+        hist.append("find me once");
+        hist.append("find me as well");
+
+        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
+        hist.back();
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("find me once".to_string()));
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
+        hist.forward();
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn substring_search_works() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("substring");
+        hist.append("don't find me either");
+        hist.append("prefix substring");
+        hist.append("don't find me");
+        hist.append("prefix substring suffix");
+
+        hist.set_navigation(HistoryNavigationQuery::SubstringSearch(
+            "substring".to_string(),
+        ));
+        hist.back();
+        assert_eq!(
+            hist.string_at_cursor(),
+            Some("prefix substring suffix".to_string())
+        );
+        hist.back();
+        assert_eq!(
+            hist.string_at_cursor(),
+            Some("prefix substring".to_string())
+        );
+        hist.back();
+        assert_eq!(hist.string_at_cursor(), Some("substring".to_string()));
+    }
+
+    #[test]
+    fn substring_search_with_empty_value_returns_none() {
+        let mut hist = FileBackedHistory::default();
+        hist.append("substring");
+
+        hist.set_navigation(HistoryNavigationQuery::SubstringSearch("".to_string()));
+
+        assert_eq!(hist.string_at_cursor(), None);
+    }
+
+    #[test]
+    fn writes_to_new_file() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        // check that it also works for a path where the directory has not been created yet
+        let histfile = tmp.path().join("nested_path").join(".history");
+
+        let entries = vec!["test", "text", "more test text"];
+
+        {
+            let mut hist = FileBackedHistory::with_file(5, histfile.clone()).unwrap();
+
+            entries.iter().for_each(|e| hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let reading_hist = FileBackedHistory::with_file(5, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+        assert_eq!(entries, actual);
+
+        tmp.close().unwrap();
+    }
+
+    #[test]
+    fn persists_newlines_in_entries() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let histfile = tmp.path().join(".history");
+
+        let entries = vec![
+            "test",
+            "multiline\nentry\nunix",
+            "multiline\r\nentry\r\nwindows",
+            "more test text",
+        ];
+
+        {
+            let mut writing_hist = FileBackedHistory::with_file(5, histfile.clone()).unwrap();
+
+            entries.iter().for_each(|e| writing_hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let reading_hist = FileBackedHistory::with_file(5, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+        assert_eq!(entries, actual);
+
+        tmp.close().unwrap();
+    }
+
+    #[test]
+    fn truncates_file_to_capacity() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let histfile = tmp.path().join(".history");
+
+        let capacity = 5;
+        let initial_entries = vec!["test 1", "test 2"];
+        let appending_entries = vec!["test 3", "test 4"];
+        let expected_appended_entries = vec!["test 1", "test 2", "test 3", "test 4"];
+        let truncating_entries = vec!["test 5", "test 6", "test 7", "test 8"];
+        let expected_truncated_entries = vec!["test 4", "test 5", "test 6", "test 7", "test 8"];
+
+        {
+            let mut writing_hist =
+                FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            initial_entries.iter().for_each(|e| writing_hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        {
+            let mut appending_hist =
+                FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            appending_entries
+                .iter()
+                .for_each(|e| appending_hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+            let actual: Vec<_> = appending_hist.iter_chronologic().collect();
+            assert_eq!(expected_appended_entries, actual);
+        }
+
+        {
+            let mut truncating_hist =
+                FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            truncating_entries
+                .iter()
+                .for_each(|e| truncating_hist.append(e));
+
+            let actual: Vec<_> = truncating_hist.iter_chronologic().collect();
+            assert_eq!(expected_truncated_entries, actual);
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let reading_hist = FileBackedHistory::with_file(capacity, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+        assert_eq!(expected_truncated_entries, actual);
+
+        tmp.close().unwrap();
+    }
+
+    #[test]
+    fn truncates_too_large_file() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let histfile = tmp.path().join(".history");
+
+        let overly_large_previous_entries = vec![
+            "test 1", "test 2", "test 3", "test 4", "test 5", "test 6", "test 7", "test 8",
+        ];
+        let expected_truncated_entries = vec!["test 4", "test 5", "test 6", "test 7", "test 8"];
+
+        {
+            let mut writing_hist = FileBackedHistory::with_file(10, histfile.clone()).unwrap();
+
+            overly_large_previous_entries
+                .iter()
+                .for_each(|e| writing_hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        {
+            let truncating_hist = FileBackedHistory::with_file(5, histfile.clone()).unwrap();
+
+            let actual: Vec<_> = truncating_hist.iter_chronologic().collect();
+            assert_eq!(expected_truncated_entries, actual);
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let reading_hist = FileBackedHistory::with_file(5, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+        assert_eq!(expected_truncated_entries, actual);
+
+        tmp.close().unwrap();
+    }
+
+    #[test]
+    fn concurrent_histories_dont_erase_eachother() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let histfile = tmp.path().join(".history");
+
+        let capacity = 7;
+        let initial_entries = vec!["test 1", "test 2", "test 3", "test 4", "test 5"];
+        let entries_a = vec!["A1", "A2", "A3"];
+        let entries_b = vec!["B1", "B2", "B3"];
+        let expected_entries = vec!["test 5", "B1", "B2", "B3", "A1", "A2", "A3"];
+
+        {
+            let mut writing_hist =
+                FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            initial_entries.iter().for_each(|e| writing_hist.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        {
+            let mut hist_a = FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            {
+                let mut hist_b = FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+                entries_b.iter().for_each(|e| hist_b.append(e));
+
+                // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+            }
+            entries_a.iter().for_each(|e| hist_a.append(e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let reading_hist = FileBackedHistory::with_file(capacity, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+        assert_eq!(expected_entries, actual);
+
+        tmp.close().unwrap();
+    }
+
+    #[test]
+    fn concurrent_histories_are_threadsafe() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let histfile = tmp.path().join(".history");
+
+        let num_threads = 16;
+        let capacity = 2 * num_threads + 1;
+
+        let initial_entries = (0..capacity).map(|i| format!("initial {i}"));
+
+        {
+            let mut writing_hist =
+                FileBackedHistory::with_file(capacity, histfile.clone()).unwrap();
+
+            initial_entries.for_each(|e| writing_hist.append(&e));
+
+            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+        }
+
+        let threads = (0..num_threads)
+            .map(|i| {
+                let cap = capacity;
+                let hfile = histfile.clone();
+                std::thread::spawn(move || {
+                    let mut hist = FileBackedHistory::with_file(cap, hfile).unwrap();
+                    hist.append(&format!("A{}", i));
+                    hist.sync().unwrap();
+                    hist.append(&format!("B{}", i));
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for t in threads {
+            t.join().unwrap();
+        }
+
+        let reading_hist = FileBackedHistory::with_file(capacity, histfile).unwrap();
+
+        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
+
+        assert!(
+            actual.contains(&&format!("initial {}", capacity - 1)),
+            "Overwrote entry from before threading test"
+        );
+
+        for i in 0..num_threads {
+            assert!(actual.contains(&&format!("A{}", i)),);
+            assert!(actual.contains(&&format!("B{}", i)),);
+        }
+
+        tmp.close().unwrap();
+    }
+}

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -1,25 +1,22 @@
-use rusqlite::{named_params, params, Connection, MappedRows, OptionalExtension, Row};
+use chrono::{TimeZone, Utc};
+use rusqlite::{named_params, params, Connection, OptionalExtension, ToSql};
 use serde::{de::DeserializeOwned, Serialize};
 
-use super::{base::HistoryNavigationQuery, History};
+use super::{base::{HistoryNavigationQuery, SearchDirection, SearchFilter, CommandLineSearch}, HistoryItem, HistoryItemId, History, Result};
 use crate::core_editor::LineBuffer;
 use std::{
+    fmt::Display,
     path::PathBuf,
     sync::{Arc, Mutex},
+    time::Duration,
 };
-
-/// This trait represents additional context to be added to a history (see [SqliteBackedHistory])
-pub trait HistoryEntryContext: Serialize + DeserializeOwned + Default + Send {}
-
-impl<T> HistoryEntryContext for T where T: Serialize + DeserializeOwned + Default + Send {}
 
 /// A history that stores the values to an SQLite database.
 /// In addition to storing the command, the history can store an additional arbitrary HistoryEntryContext,
 /// to add information such as a timestamp, running directory, result...
-pub struct SqliteBackedHistory<ContextType> {
+pub struct SqliteBackedHistory {
     db: rusqlite::Connection,
-    last_run_command_id: Option<i64>,
-    last_run_command_context: Option<ContextType>,
+    last_run_command: Option<HistoryItem>,
     cursor: SqliteHistoryCursor,
 }
 
@@ -30,100 +27,194 @@ struct SqliteHistoryCursor {
     query: HistoryNavigationQuery,
 }
 
-/// Allow wrapping any history in Arc<Mutex<_>> so the creator of a Reedline can keep a reference to the history.
-/// That way the library user can call history-specific methods ([`SqliteBackedHistory::update_last_command_context`])
-/// The alternative would be that Reedline would have to be generic over the history type.
-impl<H: History> History for Arc<Mutex<H>> {
-    fn append(&mut self, entry: &str) {
-        self.lock().expect("lock poisoned").append(entry)
-    }
+    /*fn append(&mut self, entry: &str) {
+        let item = HistoryItem::default();
+        let item = self.save(item).unwrap();
+        self.last_run_command = Some(item);
+        self.reset_cursor();
+    }*/
 
-    fn iter_chronologic(&self) -> Box<(dyn DoubleEndedIterator<Item = std::string::String> + '_)> {
-        let inner = self.lock().expect("lock poisoned");
-        // TODO: performance :)
-        Box::new(inner.iter_chronologic().collect::<Vec<_>>().into_iter())
-    }
-
-    fn back(&mut self) {
-        self.lock().expect("lock poisoned").back()
-    }
-
-    fn forward(&mut self) {
-        self.lock().expect("lock poisoned").forward()
-    }
-
-    fn string_at_cursor(&self) -> Option<String> {
-        self.lock().expect("lock poisoned").string_at_cursor()
-    }
-
-    fn set_navigation(&mut self, navigation: HistoryNavigationQuery) {
-        self.lock()
-            .expect("lock poisoned")
-            .set_navigation(navigation)
-    }
-
-    fn get_navigation(&self) -> HistoryNavigationQuery {
-        self.lock().expect("lock poisoned").get_navigation()
-    }
-
-    fn query_entries(&self, search: &str) -> Vec<String> {
-        self.lock().expect("lock poisoned").query_entries(search)
-    }
-
-    fn max_values(&self) -> usize {
-        self.lock().expect("lock poisoned").max_values()
-    }
-
-    fn sync(&mut self) -> std::io::Result<()> {
-        self.lock().expect("lock poisoned").sync()
-    }
-
-    fn reset_cursor(&mut self) {
-        self.lock().expect("lock poisoned").reset_cursor()
-    }
+fn deserialize_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem> {
+    let x: String = row.get("more_info")?;
+    Ok(HistoryItem {
+        id: Some(HistoryItemId::new(row.get("id")?)),
+        start_timestamp: Utc.timestamp_millis(row.get("start_timestamp")?),
+        command_line: row.get("command_line")?,
+        session_id: row.get("session_id")?,
+        hostname: row.get("hostname")?,
+        cwd: row.get("cwd")?,
+        duration: row
+            .get::<&str, Option<i64>>("duration")?
+            .map(|e| Duration::from_millis(e as u64)),
+        exit_status: row.get("exit_status")?,
+        more_info: serde_json::from_str(&x).unwrap(),
+    })
 }
 
-impl<ContextType: HistoryEntryContext> History for SqliteBackedHistory<ContextType> {
-    /// Appends an entry if non-empty and not repetition of the previous entry.
-    /// Resets the browsing cursor to the default state in front of the most recent entry.
-    ///
-    fn append(&mut self, entry: &str) {
-        let ctx = ContextType::default();
+impl History for SqliteBackedHistory {
+    fn save(&mut self, mut entry: HistoryItem) -> Result<HistoryItem> {
+        /*if entry.id.is_some() {
+            return Err("ID must be empty".to_string());
+        }*/
         let ret: i64 = self
             .db
             .prepare(
-                "insert into history (command, context) values (:command, :context) returning id",
+                "insert into history
+                               (id,  start_timestamp,  command_line,  session_id,  hostname,  cwd,  duration,  exit_status,  more_info)
+                        values (:id, :start_timestamp, :command_line, :session_id, :hostname, :cwd, :duration, :exit_status, :more_info)
+                    returning id",
             )
-            .unwrap()
+            .map_err(|e|e.to_string())?
             .query_row(
                 named_params! {
-                    ":command": entry,
-                    ":context": serde_json::to_string(&ctx).unwrap()
+                    "id": entry.id.map(|id| id.0),
+                    "start_timestamp": entry.start_timestamp.timestamp_millis(),
+                    "command_line": entry.command_line,
+                    "session_id": entry.session_id,
+                    "hostname": entry.hostname,
+                    "cwd": entry.cwd,
+                    "duration": entry.duration.map(|e| e.as_millis() as i64),
+                    "exit_status": entry.exit_status,
+                    "more_info": &serde_json::to_string(&entry.more_info).unwrap()
                 },
                 |row| row.get(0),
             )
-            .unwrap();
-        self.last_run_command_id = Some(ret);
-        self.last_run_command_context = Some(ctx);
-        self.reset_cursor();
+            .map_err(|e| e.to_string())?;
+        entry.id = Some(HistoryItemId::new(ret));
+        Ok(entry)
     }
 
-    fn iter_chronologic(&self) -> Box<(dyn DoubleEndedIterator<Item = std::string::String> + '_)> {
-        /*let mapper = |r: &Row| Ok((r.get(0)?, r.get(1)?));
-        let fwd = inner
+    fn load(&mut self, id: HistoryItemId) -> Result<HistoryItem> {
+        let entry = self
             .db
-            .prepare("select id, command from history order by id asc").unwrap()
-            .query_map(params![], mapper)
-            .unwrap();
-        let bwd = inner
+            .prepare("select * from history where id = :id")
+            .map_err(|e| e.to_string())?
+            .query_row(named_params! { ":id": id.0 }, deserialize_history_item)
+            .map_err(|e| e.to_string())?;
+        Ok(entry)
+    }
+
+    fn search(
+        &self,
+        start: chrono::DateTime<Utc>,
+        direction: SearchDirection,
+        end: Option<chrono::DateTime<Utc>>,
+        limit: Option<i64>,
+        filter: SearchFilter,
+    ) -> Result<Vec<HistoryItem>> {
+        let (op, asc) = match direction {
+            SearchDirection::Forward => (">", "asc"),
+            SearchDirection::Backward => ("<", "desc"),
+        };
+        let mut wheres: Vec<String> = vec!["timestamp_start {op} :start".to_string()];
+        let mut params: Vec<(&str, Box<dyn ToSql>)> = vec![];
+        if let Some(end) = end {
+            wheres.push(format!("where :end {op}= timestamp_start"));
+            params.push((":end", Box::new(end.timestamp_millis())));
+        }
+        let limit = match limit {
+            Some(l) => {
+                params.push((":limit", Box::new(l)));
+                format!("limit :limit")
+            }
+            None => format!(""),
+        };
+
+        if let Some(command_line) = &filter.command_line {
+            // todo: escape %
+            let command_line_like = match command_line {
+                CommandLineSearch::Exact(e) => format!("{e}"),
+                CommandLineSearch::Prefix(prefix) => format!("{prefix}%"),
+                CommandLineSearch::Substring(cont) => format!("%{cont}%"),
+            };
+            wheres.push("command_line like :command_line".to_string());
+            params.push((":command_line", Box::new(command_line_like)));
+        }
+        if let Some(hostname) = filter.hostname {
+            wheres.push("hostname = :hostname".to_string());
+            params.push((":hostname", Box::new(hostname)));
+        }
+        if let Some(cwd_exact) = filter.cwd_exact {
+            wheres.push("cwd = :cwd".to_string());
+            params.push((":cwd", Box::new(cwd_exact)));
+        }
+        if let Some(cwd_prefix) = filter.cwd_prefix {
+            wheres.push("cwd like :cwd_like".to_string());
+            let cwd_like = format!("{cwd_prefix}%");
+            params.push((":cwd_like", Box::new(cwd_like)));
+        }
+        if let Some(exit_successful) = filter.exit_successful {
+            if exit_successful {
+                wheres.push("exit_status = 0".to_string());
+            } else {
+                wheres.push("exit_status != 0".to_string());
+            }
+        }
+        let wheres = wheres.join(" and ");
+        let query = format!(
+            "select * from history
+            where 
+            {wheres}
+            order by id {asc} {limit}"
+        );
+        let params_borrow: Vec<(&str, &dyn ToSql)> = params.iter().map(|e| (e.0, &*e.1)).collect();
+        let results: Vec<HistoryItem> = self
             .db
-            .prepare("select id, command from history order by id desc").unwrap()
-            .query_map(params![], mapper)
-            .unwrap();
-        let de = SqliteDoubleEnded {
-                fwd,
-                bwd
-            };*/
+            .prepare(&query)
+            .unwrap()
+            .query_map(&params_borrow[..], deserialize_history_item)
+            .map_err(|e| e.to_string())?
+            .collect::<rusqlite::Result<Vec<HistoryItem>>>()
+            .map_err(|e| e.to_string())?;
+        Ok(results)
+        /* if let Some((next_id, next_command)) = next_id {
+            self.cursor.id = next_id;
+            self.cursor.command = Some(next_command);
+        } else {
+            if !backward {
+                // forward search resets to none, backwards search doesn't
+                self.cursor.command = None;
+            }
+        }*/
+    }
+
+    fn update(
+        &mut self,
+        id: HistoryItemId,
+        updater: Box<dyn FnOnce(HistoryItem) -> HistoryItem>,
+    ) -> Result<()> {
+        let item = self.load(id)?;
+        self.save(updater(item))?;
+        Ok(())
+    }
+
+    fn entry_count(&self) -> Result<i64> {
+        self.db
+            .query_row(
+                "select coalesce(count(*), 0) from history",
+                params![],
+                |r| r.get::<usize, i64>(0),
+            )
+            .map_err(|e| e.to_string())
+    }
+
+    fn delete(&mut self, h: HistoryItemId) -> Result<()> {
+        let changed = self
+            .db
+            .execute("delete from history where id = ?", params![h.0])
+            .map_err(|e| e.to_string())?;
+        if changed == 0 {
+            return Err("Could not find item".to_string());
+        }
+        Ok(())
+    }
+
+    fn sync(&mut self) -> Result<()> {
+        // no-op
+        Ok(())
+    }
+
+    /*fn iter_chronologic(&self) -> Box<(dyn DoubleEndedIterator<Item = std::string::String> + '_)> {
         // todo: read in chunks or dynamically (?)
         let fwd = self
             .db
@@ -190,14 +281,14 @@ impl<ContextType: HistoryEntryContext> History for SqliteBackedHistory<ContextTy
         }
         self.cursor.id = self.last_run_command_id.unwrap_or(0) + 1;
         self.cursor.command = None;
-    }
+    }*/
 }
 fn map_sqlite_err(err: rusqlite::Error) -> std::io::Error {
     // todo: better error mapping
     std::io::Error::new(std::io::ErrorKind::Other, err)
 }
 
-impl<ContextType: HistoryEntryContext> SqliteBackedHistory<ContextType> {
+impl SqliteBackedHistory {
     /// Creates a new history with an associated history file.
     ///
     ///
@@ -229,443 +320,31 @@ impl<ContextType: HistoryEntryContext> SqliteBackedHistory<ContextType> {
             "
         create table if not exists history (
             id integer primary key autoincrement,
-            command text not null,
-            context text not null
+            start_timestamp integer not null,
+            command_line: text not null,
+            session_id: integer not null,
+            hostname: text not null,
+            cwd: text not null,
+            duration_ms: integer,
+            exit_status: integer,
+            more_info: text
         ) strict;
+        create index if not exists idx_history_time on history(start_timestamp);
+        create index if not exists idx_history_cwd on history(hostname, cwd);
+        create index if not exists idx_history_exit_status on history(exit_status);
         ",
             params![],
         )
         .map_err(map_sqlite_err)?;
         let mut hist = SqliteBackedHistory {
             db,
-            last_run_command_id: None,
-            last_run_command_context: None,
+            last_run_command: None,
             cursor: SqliteHistoryCursor {
                 id: 0,
                 command: None,
                 query: HistoryNavigationQuery::Normal(LineBuffer::default()),
             },
         };
-        hist.reset_cursor();
         Ok(hist)
-    }
-
-    // todo: better error type (which one?)
-    /// updates the context stored for the last ran command
-    pub fn update_last_command_context<F>(&mut self, callback: F) -> Result<(), String>
-    where
-        F: FnOnce(ContextType) -> ContextType,
-    {
-        if let (Some(id), Some(ctx)) = (
-            self.last_run_command_id,
-            self.last_run_command_context.take(),
-        ) {
-            let mapped_ctx = callback(ctx);
-            self.db
-                .execute(
-                    "update history set context = :context where id = :id",
-                    named_params! {
-                        ":context": serde_json::to_string(&mapped_ctx).map_err(|e| format!("{e}"))?,
-                        ":id": id
-                    },
-                )
-                .map_err(|e| format!("{e}"))?;
-            self.last_run_command_context.replace(mapped_ctx);
-            Ok(())
-        } else {
-            Err(format!("No command has been executed yet"))
-        }
-    }
-
-    fn navigate_in_direction(&mut self, backward: bool) {
-        let like_str = match &self.cursor.query {
-            HistoryNavigationQuery::Normal(_) => format!("%"),
-            HistoryNavigationQuery::PrefixSearch(prefix) => format!("{prefix}%"),
-            HistoryNavigationQuery::SubstringSearch(cont) => format!("%{cont}%"),
-        };
-        let query = if backward {
-            "select id, command from history where id < :id and command like :like and command != :prev_result order by id desc limit 1"
-        } else {
-            "select id, command from history where id > :id and command like :like and command != :prev_result order by id asc limit 1"
-        };
-        let next_id: Option<(i64, String)> = self
-            .db
-            .prepare(query)
-            .unwrap()
-            .query_row(
-                named_params! {
-                    ":id": self.cursor.id,
-                    ":like": like_str,
-                    ":prev_result": self.cursor.command.clone().unwrap_or(String::new())
-                },
-                |e| Ok((e.get(0)?, e.get(1)?)),
-            )
-            .optional()
-            .unwrap();
-        if let Some((next_id, next_command)) = next_id {
-            self.cursor.id = next_id;
-            self.cursor.command = Some(next_command);
-        } else {
-            if !backward {
-                // forward search resets to none, backwards search doesn't
-                self.cursor.command = None;
-            }
-        }
-    }
-}
-#[cfg(test)]
-mod tests {
-    use pretty_assertions::assert_eq;
-
-    use super::*;
-
-    fn in_memory_for_test() -> SqliteBackedHistory<()> {
-        SqliteBackedHistory::in_memory().unwrap()
-    }
-    fn with_file_for_test(
-        capacity: i32,
-        file: PathBuf,
-    ) -> std::io::Result<SqliteBackedHistory<()>> {
-        SqliteBackedHistory::with_file(file)
-    }
-
-    #[test]
-    fn accessing_empty_history_returns_nothing() {
-        let hist = in_memory_for_test();
-        assert_eq!(hist.string_at_cursor(), None);
-    }
-
-    #[test]
-    fn going_forward_in_empty_history_does_not_error_out() {
-        let mut hist = in_memory_for_test();
-        hist.forward();
-        assert_eq!(hist.string_at_cursor(), None);
-    }
-
-    #[test]
-    fn going_backwards_in_empty_history_does_not_error_out() {
-        let mut hist = in_memory_for_test();
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), None);
-    }
-
-    #[test]
-    fn going_backwards_bottoms_out() {
-        let mut hist = in_memory_for_test();
-        hist.append("command1");
-        hist.append("command2");
-        hist.back();
-        hist.back();
-        hist.back();
-        hist.back();
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("command1".to_string()));
-    }
-
-    #[test]
-    fn going_forwards_bottoms_out() {
-        let mut hist = in_memory_for_test();
-        hist.append("command1");
-        hist.append("command2");
-        hist.forward();
-        hist.forward();
-        hist.forward();
-        hist.forward();
-        hist.forward();
-        assert_eq!(hist.string_at_cursor(), None);
-    }
-
-    /*#[test]
-    fn appends_only_unique() {
-        let mut hist = in_memory_for_test();
-        hist.append("unique_old");
-        hist.append("test");
-        hist.append("test");
-        hist.append("unique");
-        assert_eq!(hist.entries.len(), 3);
-    }
-    #[test]
-    fn appends_no_empties() {
-        let mut hist = in_memory_for_test();
-        hist.append("");
-        assert_eq!(hist.entries.len(), 0);
-    }*/
-
-    #[test]
-    fn prefix_search_works() {
-        let mut hist = in_memory_for_test();
-        hist.append("find me as well");
-        hist.append("test");
-        hist.append("find me");
-
-        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
-
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
-    }
-
-    #[test]
-    fn prefix_search_bottoms_out() {
-        let mut hist = in_memory_for_test();
-        hist.append("find me as well");
-        hist.append("test");
-        hist.append("find me");
-
-        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
-        hist.back();
-        hist.back();
-        hist.back();
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
-    }
-    #[test]
-    fn prefix_search_returns_to_none() {
-        let mut hist = in_memory_for_test();
-        hist.append("find me as well");
-        hist.append("test");
-        hist.append("find me");
-
-        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
-        hist.forward();
-        assert_eq!(hist.string_at_cursor(), Some("find me".to_string()));
-        hist.forward();
-        assert_eq!(hist.string_at_cursor(), None);
-        hist.forward();
-        assert_eq!(hist.string_at_cursor(), None);
-    }
-
-    #[test]
-    fn prefix_search_ignores_consecutive_equivalent_entries_going_backwards() {
-        let mut hist = in_memory_for_test();
-        hist.append("find me as well");
-        hist.append("find me once");
-        hist.append("test");
-        hist.append("find me once");
-
-        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("find me once".to_string()));
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
-    }
-
-    #[test]
-    fn prefix_search_ignores_consecutive_equivalent_entries_going_forwards() {
-        let mut hist = in_memory_for_test();
-        hist.append("find me once");
-        hist.append("test");
-        hist.append("find me once");
-        hist.append("find me as well");
-
-        hist.set_navigation(HistoryNavigationQuery::PrefixSearch("find".to_string()));
-        hist.back();
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("find me once".to_string()));
-        hist.forward();
-        assert_eq!(hist.string_at_cursor(), Some("find me as well".to_string()));
-        hist.forward();
-        assert_eq!(hist.string_at_cursor(), None);
-    }
-
-    #[test]
-    fn substring_search_works() {
-        let mut hist = in_memory_for_test();
-        hist.append("substring");
-        hist.append("don't find me either");
-        hist.append("prefix substring");
-        hist.append("don't find me");
-        hist.append("prefix substring suffix");
-
-        hist.set_navigation(HistoryNavigationQuery::SubstringSearch(
-            "substring".to_string(),
-        ));
-        hist.back();
-        assert_eq!(
-            hist.string_at_cursor(),
-            Some("prefix substring suffix".to_string())
-        );
-        hist.back();
-        assert_eq!(
-            hist.string_at_cursor(),
-            Some("prefix substring".to_string())
-        );
-        hist.back();
-        assert_eq!(hist.string_at_cursor(), Some("substring".to_string()));
-    }
-
-    #[test]
-    fn substring_search_with_empty_value_returns_none() {
-        let mut hist = in_memory_for_test();
-        hist.append("substring");
-
-        hist.set_navigation(HistoryNavigationQuery::SubstringSearch("".to_string()));
-
-        assert_eq!(hist.string_at_cursor(), None);
-    }
-
-    #[test]
-    fn writes_to_new_file() {
-        use tempfile::tempdir;
-
-        let tmp = tempdir().unwrap();
-        // check that it also works for a path where the directory has not been created yet
-        let histfile = tmp.path().join("nested_path").join(".history");
-
-        let entries = vec!["test", "text", "more test text"];
-
-        {
-            let mut hist = with_file_for_test(5, histfile.clone()).unwrap();
-
-            entries.iter().for_each(|e| hist.append(e));
-
-            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
-        }
-
-        let reading_hist = with_file_for_test(5, histfile).unwrap();
-
-        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
-        assert_eq!(entries, actual);
-
-        tmp.close().unwrap();
-    }
-
-    #[test]
-    fn persists_newlines_in_entries() {
-        use tempfile::tempdir;
-
-        let tmp = tempdir().unwrap();
-        let histfile = tmp.path().join(".history");
-
-        let entries = vec![
-            "test",
-            "multiline\nentry\nunix",
-            "multiline\r\nentry\r\nwindows",
-            "more test text",
-        ];
-
-        {
-            let mut writing_hist = with_file_for_test(5, histfile.clone()).unwrap();
-
-            entries.iter().for_each(|e| writing_hist.append(e));
-
-            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
-        }
-
-        let reading_hist = with_file_for_test(5, histfile).unwrap();
-
-        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
-        assert_eq!(entries, actual);
-
-        tmp.close().unwrap();
-    }
-
-    #[test]
-    fn concurrent_histories_dont_erase_eachother() {
-        use tempfile::tempdir;
-
-        let tmp = tempdir().unwrap();
-        let histfile = tmp.path().join(".history");
-
-        let capacity = 7;
-        let initial_entries = vec!["test 1", "test 2", "test 3", "test 4", "test 5"];
-        let entries_a = vec!["A1", "A2", "A3"];
-        let entries_b = vec!["B1", "B2", "B3"];
-        let expected_entries = vec![
-            "test 1", "test 2", "test 3", "test 4", "test 5", "B1", "B2", "B3", "A1", "A2", "A3",
-        ];
-
-        {
-            let mut writing_hist = SqliteBackedHistory::<()>::with_file(histfile.clone()).unwrap();
-
-            initial_entries.iter().for_each(|e| writing_hist.append(e));
-
-            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
-        }
-
-        {
-            let mut hist_a = with_file_for_test(capacity, histfile.clone()).unwrap();
-
-            {
-                let mut hist_b = with_file_for_test(capacity, histfile.clone()).unwrap();
-
-                entries_b.iter().for_each(|e| hist_b.append(e));
-
-                // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
-            }
-            entries_a.iter().for_each(|e| hist_a.append(e));
-
-            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
-        }
-
-        let reading_hist = with_file_for_test(capacity, histfile).unwrap();
-
-        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
-        assert_eq!(expected_entries, actual);
-
-        tmp.close().unwrap();
-    }
-
-    #[test]
-    fn concurrent_histories_are_threadsafe() {
-        use tempfile::tempdir;
-
-        let tmp = tempdir().unwrap();
-        let histfile = tmp.path().join(".history");
-
-        let num_threads = 16;
-        let capacity = 2 * num_threads + 1;
-
-        let initial_entries = (0..capacity).map(|i| format!("initial {i}"));
-
-        {
-            let mut writing_hist = with_file_for_test(capacity, histfile.clone()).unwrap();
-
-            initial_entries.for_each(|e| writing_hist.append(&e));
-
-            // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
-        }
-
-        let threads = (0..num_threads)
-            .map(|i| {
-                let cap = capacity;
-                let hfile = histfile.clone();
-                std::thread::spawn(move || {
-                    let mut hist = with_file_for_test(cap, hfile).unwrap();
-                    hist.append(&format!("A{}", i));
-                    hist.sync().unwrap();
-                    hist.append(&format!("B{}", i));
-                })
-            })
-            .collect::<Vec<_>>();
-
-        for t in threads {
-            t.join().unwrap();
-        }
-
-        let reading_hist = with_file_for_test(capacity, histfile).unwrap();
-
-        let actual: Vec<_> = reading_hist.iter_chronologic().collect();
-
-        assert!(
-            actual.contains(&&format!("initial {}", capacity - 1)),
-            "Overwrote entry from before threading test"
-        );
-
-        for i in 0..num_threads {
-            assert!(actual.contains(&&format!("A{}", i)),);
-            assert!(actual.contains(&&format!("B{}", i)),);
-        }
-
-        tmp.close().unwrap();
     }
 }

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -55,9 +55,6 @@ fn deserialize_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem
 
 impl History for SqliteBackedHistory {
     fn save(&mut self, mut entry: HistoryItem) -> Result<HistoryItem> {
-        /*if entry.id.is_some() {
-            return Err("ID must be empty".to_string());
-        }*/
         let ret: i64 = self
             .db
             .prepare(
@@ -129,15 +126,6 @@ impl History for SqliteBackedHistory {
             .collect::<rusqlite::Result<Vec<HistoryItem>>>()
             .map_err(map_sqlite_err)?;
         Ok(results)
-        /* if let Some((next_id, next_command)) = next_id {
-            self.cursor.id = next_id;
-            self.cursor.command = Some(next_command);
-        } else {
-            if !backward {
-                // forward search resets to none, backwards search doesn't
-                self.cursor.command = None;
-            }
-        }*/
     }
 
     fn update(
@@ -180,78 +168,9 @@ impl History for SqliteBackedHistory {
                 .map_err(map_sqlite_err)?,
         ))
     }
-
-    /*fn iter_chronologic(&self) -> Box<(dyn DoubleEndedIterator<Item = std::string::String> + '_)> {
-        // todo: read in chunks or dynamically (?)
-        let fwd = self
-            .db
-            .prepare("select command from history order by id asc")
-            .unwrap()
-            .query_map(params![], |row| row.get(0))
-            .unwrap()
-            .collect::<rusqlite::Result<Vec<String>>>()
-            .unwrap();
-        return Box::new(fwd.into_iter());
-    }
-
-    fn back(&mut self) {
-        self.navigate_in_direction(true)
-        // self.cursor.id
-    }
-
-    fn forward(&mut self) {
-        self.navigate_in_direction(false)
-    }
-
-    fn string_at_cursor(&self) -> Option<String> {
-        self.cursor.command.clone()
-    }
-
-    fn set_navigation(&mut self, navigation: HistoryNavigationQuery) {
-        self.cursor.query = navigation;
-        self.reset_cursor();
-    }
-
-    fn get_navigation(&self) -> HistoryNavigationQuery {
-        self.cursor.query.clone()
-    }
-
-    fn query_entries(&self, search: &str) -> Vec<String> {
-        self.iter_chronologic()
-            .rev()
-            .filter(|entry| entry.contains(search))
-            .collect::<Vec<String>>()
-    }
-
-    fn max_values(&self) -> usize {
-        self.last_run_command_id.unwrap_or(0) as usize
-    }
-
-    /// Writes unwritten history contents to disk.
-    ///
-    /// If file would exceed `capacity` truncates the oldest entries.
-    fn sync(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-
-    /// Reset the internal browsing cursor
-    fn reset_cursor(&mut self) {
-        // if no command run yet, fetch last id from db
-        if self.last_run_command_id == None {
-            self.last_run_command_id = self
-                .db
-                .prepare("select coalesce(max(id), 0) from history")
-                .unwrap()
-                .query_row(params![], |e| e.get(0))
-                .optional()
-                .unwrap();
-        }
-        self.cursor.id = self.last_run_command_id.unwrap_or(0) + 1;
-        self.cursor.command = None;
-    }*/
 }
 fn map_sqlite_err(err: rusqlite::Error) -> ReedlineError {
-    // todo: better error mapping
+    // TODO: better error mapping
     ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(format!(
         "{:?}",
         err
@@ -336,7 +255,7 @@ impl SqliteBackedHistory {
         query: &'a SearchQuery,
         select_expression: &str,
     ) -> (String, BoxedNamedParams<'a>) {
-        // todo: this whole function could be done with less allocs
+        // TODO: this whole function could be done with less allocs
         let (is_asc, asc) = match query.direction {
             SearchDirection::Forward => (true, "asc"),
             SearchDirection::Backward => (false, "desc"),
@@ -383,7 +302,7 @@ impl SqliteBackedHistory {
             None => "",
         };
         if let Some(command_line) = &query.filter.command_line {
-            // todo: escape %
+            // TODO: escape %
             let command_line_like = match command_line {
                 CommandLineSearch::Exact(e) => e.to_string(),
                 CommandLineSearch::Prefix(prefix) => format!("{prefix}%"),
@@ -427,7 +346,6 @@ impl SqliteBackedHistory {
         {wheres}
         order by id {asc} {limit}"
         );
-        // aprintln!("query={query}");
         (query, params)
     }
 }

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -277,7 +277,7 @@ impl SqliteBackedHistory {
             .map_err(map_sqlite_err)?;
         db.pragma_update(None, "foreign_keys", "on")
             .map_err(map_sqlite_err)?;
-        db.execute(
+        db.execute_batch(
             "
         create table if not exists history (
             id integer primary key autoincrement,
@@ -297,7 +297,6 @@ impl SqliteBackedHistory {
         create index if not exists idx_history_cmd on history(session_id);
         -- todo: better indexes
         ",
-            params![],
         )
         .map_err(map_sqlite_err)?;
         Ok(SqliteBackedHistory { db })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,9 +192,9 @@ mod engine;
 pub use engine::Reedline;
 
 mod history;
+#[cfg(feature = "sqlite")]
+pub use history::SqliteBackedHistory;
 pub use history::{FileBackedHistory, History, HistoryItem, HistoryNavigationQuery, HISTORY_SIZE};
-#[cfg(feature="sqlite")]
-pub use history::{SqliteBackedHistory};
 
 mod prompt;
 pub use prompt::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ mod engine;
 pub use engine::Reedline;
 
 mod history;
-pub use history::{FileBackedHistory, History, HistoryNavigationQuery, HISTORY_SIZE};
+pub use history::{FileBackedHistory, History, HistoryItem, HistoryNavigationQuery, HISTORY_SIZE};
 #[cfg(feature="sqlite")]
 pub use history::{SqliteBackedHistory};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,8 @@ pub use engine::Reedline;
 
 mod history;
 pub use history::{FileBackedHistory, History, HistoryNavigationQuery, HISTORY_SIZE};
+#[cfg(feature="sqlite")]
+pub use history::{SqliteBackedHistory};
 
 mod prompt;
 pub use prompt::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,9 @@ pub use painting::{Painter, StyledText};
 mod engine;
 pub use engine::Reedline;
 
+mod result;
+pub(crate) use result::Result;
+
 mod history;
 #[cfg(feature = "sqlite")]
 pub use history::SqliteBackedHistory;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,12 +43,7 @@ fn main() -> Result<()> {
     }
 
     #[cfg(feature = "sqlite")]
-    let (history, history_clone) = {
-        let history = Box::new(std::sync::Arc::new(std::sync::Mutex::new(
-            reedline::SqliteBackedHistory::<TestContext>::with_file("history.sqlite3".into())?,
-        )));
-        (history.clone(), history)
-    };
+    let history = Box::new(reedline::SqliteBackedHistory::with_file("history.sqlite3".into())?);
     #[cfg(not(feature = "sqlite"))]
     let history = Box::new(FileBackedHistory::with_file(50, "history.txt".into())?);
     let commands = vec![
@@ -133,10 +128,7 @@ fn main() -> Result<()> {
                 #[cfg(feature = "sqlite")]
                 {
                     // save timestamp to history
-                    history_clone
-                        .lock()
-                        .expect("lock poisoned")
-                        .update_last_command_context(|mut c| {
+                    line_editor.update_last_command_context(|mut c| {
                             c.timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
                             c
                         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,6 @@ use {
     },
 };
 
-#[derive(serde::Serialize, serde::Deserialize, Default, Debug, Clone)]
-struct TestContext {
-    timestamp: u64,
-}
 fn main() -> Result<()> {
     // quick command like parameter handling
     let vi_mode = matches!(std::env::args().nth(1), Some(x) if x == "--vi");
@@ -121,11 +117,6 @@ fn main() -> Result<()> {
 
     let prompt = DefaultPrompt::new();
 
-    #[cfg(feature = "sqlite")]
-    let session_id = line_editor
-        .history_mut()
-        .new_session_id()
-        .expect("todo: error handling");
     loop {
         let sig = line_editor.read_line(&prompt);
 
@@ -145,7 +136,6 @@ fn main() -> Result<()> {
                         c.cwd = std::env::current_dir()
                             .ok()
                             .map(|e| e.to_string_lossy().to_string());
-                        c.session_id = Some(session_id);
                         c
                     })
                     .expect("todo: error handling");

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,10 @@ use {
     },
 };
 
+#[derive(serde::Serialize, serde::Deserialize, Default, Debug, Clone)]
+struct TestContext {
+    timestamp: String,
+}
 fn main() -> Result<()> {
     // quick command like parameter handling
     let vi_mode = matches!(std::env::args().nth(1), Some(x) if x == "--vi");
@@ -37,6 +41,14 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    #[cfg(feature = "sqlite")]
+    let history = {
+        let history = Box::new(reedline::SqliteBackedHistory::<TestContext>::with_file(
+            "history.sqlite3".into(),
+        )?);
+        history
+    };
+    #[cfg(not(feature = "sqlite"))]
     let history = Box::new(FileBackedHistory::with_file(50, "history.txt".into())?);
     let commands = vec![
         "test".into(),
@@ -70,7 +82,7 @@ fn main() -> Result<()> {
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 
     let mut line_editor = Reedline::create()
-        .with_history(history)
+        .with_history(history.clone())
         .with_completer(completer)
         .with_quick_completions(true)
         .with_partial_completions(true)
@@ -117,6 +129,10 @@ fn main() -> Result<()> {
                 break;
             }
             Ok(Signal::Success(buffer)) => {
+                history.update_context(|mut c| {
+                    c.timestamp = "foo".to_string();
+                    c
+                });
                 if (buffer.trim() == "exit") || (buffer.trim() == "logout") {
                     break;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-
 #[cfg(not(feature = "sqlite"))]
 use reedline::FileBackedHistory;
 use reedline::{DefaultValidator, ReedlineMenu};
@@ -14,8 +13,8 @@ use {
         get_reedline_default_keybindings, get_reedline_edit_commands,
         get_reedline_keybinding_modifiers, get_reedline_keycodes, get_reedline_prompt_edit_modes,
         get_reedline_reedline_events, ColumnarMenu, DefaultCompleter, DefaultHinter, DefaultPrompt,
-        EditMode, Emacs, ExampleHighlighter, Keybindings, ListMenu, Reedline,
-        ReedlineEvent, Signal, Vi,
+        EditMode, Emacs, ExampleHighlighter, Keybindings, ListMenu, Reedline, ReedlineEvent,
+        Signal, Vi,
     },
     std::{
         io::{stdout, Write},

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ fn main() -> Result<()> {
                 history.update_context(|mut c| {
                     c.timestamp = "foo".to_string();
                     c
-                });
+                }).unwrap();
                 if (buffer.trim() == "exit") || (buffer.trim() == "logout") {
                     break;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
-use chrono::Utc;
-use reedline::{DefaultValidator, ReedlineMenu};
-use std::time::{Instant};
+
 #[cfg(not(feature = "sqlite"))]
 use reedline::FileBackedHistory;
+use reedline::{DefaultValidator, ReedlineMenu};
 
 use {
     crossterm::{
@@ -15,8 +14,8 @@ use {
         get_reedline_default_keybindings, get_reedline_edit_commands,
         get_reedline_keybinding_modifiers, get_reedline_keycodes, get_reedline_prompt_edit_modes,
         get_reedline_reedline_events, ColumnarMenu, DefaultCompleter, DefaultHinter, DefaultPrompt,
-        EditMode, Emacs, ExampleHighlighter, HistoryItem, Keybindings, ListMenu,
-        Reedline, ReedlineEvent, Signal, Vi,
+        EditMode, Emacs, ExampleHighlighter, Keybindings, ListMenu, Reedline,
+        ReedlineEvent, Signal, Vi,
     },
     std::{
         io::{stdout, Write},
@@ -124,7 +123,10 @@ fn main() -> Result<()> {
     let prompt = DefaultPrompt::new();
 
     #[cfg(feature = "sqlite")]
-    let session_id = line_editor.history_mut().new_session_id().expect("todo: error handling");
+    let session_id = line_editor
+        .history_mut()
+        .new_session_id()
+        .expect("todo: error handling");
     loop {
         let sig = line_editor.read_line(&prompt);
 
@@ -133,14 +135,17 @@ fn main() -> Result<()> {
                 break;
             }
             Ok(Signal::Success(buffer)) => {
-                let start = Instant::now();
+                #[cfg(feature = "sqlite")]
+                let start = std::time::Instant::now();
                 // save timestamp, cwd, hostname to history
                 #[cfg(feature = "sqlite")]
                 line_editor
-                    .update_last_command_context(&|mut c: HistoryItem| {
-                        c.start_timestamp = Some(Utc::now());
+                    .update_last_command_context(&|mut c: reedline::HistoryItem| {
+                        c.start_timestamp = Some(chrono::Utc::now());
                         c.hostname = Some(gethostname::gethostname().to_string_lossy().to_string());
-                        c.cwd = std::env::current_dir().ok().map(|e| e.to_string_lossy().to_string());
+                        c.cwd = std::env::current_dir()
+                            .ok()
+                            .map(|e| e.to_string_lossy().to_string());
                         c.session_id = Some(session_id);
                         c
                     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,16 +129,19 @@ fn main() -> Result<()> {
                 let start = std::time::Instant::now();
                 // save timestamp, cwd, hostname to history
                 #[cfg(feature = "sqlite")]
-                line_editor
-                    .update_last_command_context(&|mut c: reedline::HistoryItem| {
-                        c.start_timestamp = Some(chrono::Utc::now());
-                        c.hostname = Some(gethostname::gethostname().to_string_lossy().to_string());
-                        c.cwd = std::env::current_dir()
-                            .ok()
-                            .map(|e| e.to_string_lossy().to_string());
-                        c
-                    })
-                    .expect("todo: error handling");
+                if !buffer.is_empty() {
+                    line_editor
+                        .update_last_command_context(&|mut c: reedline::HistoryItem| {
+                            c.start_timestamp = Some(chrono::Utc::now());
+                            c.hostname =
+                                Some(gethostname::gethostname().to_string_lossy().to_string());
+                            c.cwd = std::env::current_dir()
+                                .ok()
+                                .map(|e| e.to_string_lossy().to_string());
+                            c
+                        })
+                        .expect("todo: error handling");
+                }
                 if (buffer.trim() == "exit") || (buffer.trim() == "logout") {
                     break;
                 }
@@ -152,13 +155,15 @@ fn main() -> Result<()> {
                 }
                 println!("Our buffer: {}", buffer);
                 #[cfg(feature = "sqlite")]
-                line_editor
-                    .update_last_command_context(&|mut c| {
-                        c.duration = Some(start.elapsed());
-                        c.exit_status = Some(0);
-                        c
-                    })
-                    .expect("todo: error handling");
+                if !buffer.is_empty() {
+                    line_editor
+                        .update_last_command_context(&|mut c| {
+                            c.duration = Some(start.elapsed());
+                            c.exit_status = Some(0);
+                            c
+                        })
+                        .expect("todo: error handling");
+                }
             }
             Ok(Signal::CtrlC) => {
                 // Prompt has been cleared and should start on the next line

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ fn main() -> Result<()> {
                     history_clone
                         .lock()
                         .expect("lock poisoned")
-                        .update_context(|mut c| {
+                        .update_last_command_context(|mut c| {
                             c.timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
                             c
                         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use reedline::{DefaultValidator, ReedlineMenu};
+use std::time::SystemTime;
 
 use {
     crossterm::{
@@ -22,7 +23,7 @@ use {
 
 #[derive(serde::Serialize, serde::Deserialize, Default, Debug, Clone)]
 struct TestContext {
-    timestamp: String,
+    timestamp: u64,
 }
 fn main() -> Result<()> {
     // quick command like parameter handling
@@ -42,11 +43,11 @@ fn main() -> Result<()> {
     }
 
     #[cfg(feature = "sqlite")]
-    let history = {
-        let history = Box::new(reedline::SqliteBackedHistory::<TestContext>::with_file(
-            "history.sqlite3".into(),
-        )?);
-        history
+    let (history, history_clone) = {
+        let history = Box::new(std::sync::Arc::new(std::sync::Mutex::new(
+            reedline::SqliteBackedHistory::<TestContext>::with_file("history.sqlite3".into())?,
+        )));
+        (history.clone(), history)
     };
     #[cfg(not(feature = "sqlite"))]
     let history = Box::new(FileBackedHistory::with_file(50, "history.txt".into())?);
@@ -82,7 +83,7 @@ fn main() -> Result<()> {
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 
     let mut line_editor = Reedline::create()
-        .with_history(history.clone())
+        .with_history(history)
         .with_completer(completer)
         .with_quick_completions(true)
         .with_partial_completions(true)
@@ -129,10 +130,18 @@ fn main() -> Result<()> {
                 break;
             }
             Ok(Signal::Success(buffer)) => {
-                history.update_context(|mut c| {
-                    c.timestamp = "foo".to_string();
-                    c
-                }).unwrap();
+                #[cfg(feature = "sqlite")]
+                {
+                    // save timestamp to history
+                    history_clone
+                        .lock()
+                        .expect("lock poisoned")
+                        .update_context(|mut c| {
+                            c.timestamp = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64;
+                            c
+                        })
+                        .unwrap();
+                }
                 if (buffer.trim() == "exit") || (buffer.trim() == "logout") {
                     break;
                 }

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -2,13 +2,12 @@ mod columnar_menu;
 mod list_menu;
 pub mod menu_functions;
 
+use crate::History;
 use crate::{
-    completion::history::HistoryCompleter, painting::Painter, Completer, LineBuffer,
-    Suggestion,
+    completion::history::HistoryCompleter, painting::Painter, Completer, LineBuffer, Suggestion,
 };
 pub use columnar_menu::ColumnarMenu;
 pub use list_menu::ListMenu;
-use crate::History;
 use nu_ansi_term::{Color, Style};
 
 /// Struct to store the menu style

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -3,11 +3,12 @@ mod list_menu;
 pub mod menu_functions;
 
 use crate::{
-    completion::history::HistoryCompleter, painting::Painter, Completer, History, LineBuffer,
+    completion::history::HistoryCompleter, painting::Painter, Completer, LineBuffer,
     Suggestion,
 };
 pub use columnar_menu::ColumnarMenu;
 pub use list_menu::ListMenu;
+use crate::History;
 use nu_ansi_term::{Color, Style};
 
 /// Struct to store the menu style

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,5 +1,4 @@
 use std::fmt::Display;
-
 use thiserror::Error;
 
 /// non-public (for now)

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub(crate) enum ReedlineErrorVariants {
     // todo: we should probably be more specific here
+    #[cfg(feature = "sqlite")]
     #[error("error within history database: {0}")]
     HistoryDatabaseError(String),
     #[error("error within history: {0}")]

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use thiserror::Error;
 
 /// non-public (for now)
@@ -18,6 +20,13 @@ pub(crate) enum ReedlineErrorVariants {
 /// separate struct to not expose anything to the public (for now)
 #[derive(Debug)]
 pub struct ReedlineError(pub(crate) ReedlineErrorVariants);
+
+impl Display for ReedlineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+impl std::error::Error for ReedlineError {}
 
 // for now don't expose the above error type to the public
 pub type Result<T> = std::result::Result<T, ReedlineError>;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+
+/// non-public (for now)
+#[derive(Error, Debug)]
+pub(crate) enum ReedlineErrorVariants {
+    // todo: we should probably be more specific here
+    #[error("error within history database: {0}")]
+    HistoryDatabaseError(String),
+    #[error("error within history: {0}")]
+    OtherHistoryError(&'static str),
+    #[error("the history {history} does not support feature {feature}")]
+    HistoryFeatureUnsupported {
+        history: &'static str,
+        feature: &'static str,
+    }
+}
+
+
+/// separate struct to not expose anything to the public (for now)
+#[derive(Debug)]
+pub struct ReedlineError(pub(crate) ReedlineErrorVariants);
+
+// for now don't expose the above error type to the public
+pub type Result<T> = std::result::Result<T, ReedlineError>;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,6 +1,5 @@
 use thiserror::Error;
 
-
 /// non-public (for now)
 #[derive(Error, Debug)]
 pub(crate) enum ReedlineErrorVariants {
@@ -13,9 +12,8 @@ pub(crate) enum ReedlineErrorVariants {
     HistoryFeatureUnsupported {
         history: &'static str,
         feature: &'static str,
-    }
+    },
 }
-
 
 /// separate struct to not expose anything to the public (for now)
 #[derive(Debug)]


### PR DESCRIPTION
This is the third version of a history database for reedline, based on the previous discussions on Github and Discord.



- The history trait is modified to be more flexible and support all the interesting metadata:

    https://github.com/nushell/reedline/blob/5fc904e0750f54a065720c1b74acecc6d208f890/src/history/base.rs#L116-L153

    The FileBackedHistory was rewritten to be based on this new trait, returning errors if the user tries to filter by things it doesn't support.
    
    Each history item stores the command line plus some additional info:

    https://github.com/nushell/reedline/blob/5fc904e0750f54a065720c1b74acecc6d208f890/src/history/item.rs#L44-L64

- All the stateful cursor functionality (back, forward) is removed from the History trait and moved to a separate `HistoryCursor` struct that works with any history. I also moved all the history tests in there because they use the cursor.

- The historical metadata is stored is used by using the new `update_last_command_context` function so as to not make this a breaking change:
    
    ```rust
            Ok(Signal::Success(buffer)) => {
                line_editor
                    .update_last_command_context(&|mut c: reedline::HistoryItem| {
                        c.start_timestamp = Some(chrono::Utc::now());
                        c.hostname = Some(gethostname::gethostname().to_string_lossy().to_string());
                        c.cwd = std::env::current_dir()
                            .ok()
                            .map(|e| e.to_string_lossy().to_string());
                        c.session_id = Some(session_id);
                        c
                    })?;
   ```

    This can be called multiple times to set values that are only known after the command has run (e.g. duration, exit_status)

Stuff that should be considered (later):

- *Errors*: Most methods of the history trait are fallible and IMO should stay that way. Right now the Error type is String because I don't know how you want to handle errors. Right now it seems like only std::io::Error is used in other places, but there's no specific Error struct. Errors from the history are handled as `.except("todo: error handling")` right now because I didn't want to change the signature of any public reedline methods.
- Right now there's no UI or anything to use the additional features. Also the history is instantly merged across all shells for SQLite. These should be changed later.

References:

- https://github.com/nushell/reedline/issues/66
- https://github.com/nushell/reedline/pull/376
- https://github.com/nushell/reedline/pull/131