### PR TITLE
Use a default terminal size if reported terminal size is 0, 0

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -95,7 +95,16 @@ impl Painter {
     /// [`Painter::handle_resize()`] instead
     pub(crate) fn initialize_prompt_position(&mut self) -> Result<()> {
         // Update the terminal size
-        self.terminal_size = terminal::size()?;
+        self.terminal_size = {
+            let size = terminal::size()?;
+            // if reported size is 0, 0 -
+            // use a default size to avoid divide by 0 panics
+            if size == (0, 0) {
+                (80, 24)
+            } else {
+                size
+            }
+        };
         // Cursor positions are 0 based here.
         let (column, row) = cursor::position()?;
         // Assumption: if the cursor is not on the zeroth column,


### PR DESCRIPTION
I have am using reedline on an remote shell rendering on the web. The terminal size is incorrectly reported as 0, 0 (NOT due to a bug in crossterm), which leads to divide by zero panics.

Instead of panicking, I thought maybe having a default size makes sense. 
Feel free to not merge this, I can just use this as a patch. But I think any terminal size is better than pacicking.