### PR TITLE
vim's 's' & 'S' bindings

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -48,6 +48,7 @@ impl Editor {
             EditCommand::ReplaceChars(n_chars, str) => self.replace_chars(*n_chars, str),
             EditCommand::Backspace => self.line_buffer.delete_left_grapheme(),
             EditCommand::Delete => self.line_buffer.delete_right_grapheme(),
+            EditCommand::CutChar => self.cut_char(),
             EditCommand::BackspaceWord => self.line_buffer.delete_word_left(),
             EditCommand::DeleteWord => self.line_buffer.delete_word_right(),
             EditCommand::Clear => self.line_buffer.clear(),
@@ -258,6 +259,19 @@ impl Editor {
     fn cut_word_right(&mut self) {
         let insertion_offset = self.line_buffer.insertion_point();
         let right_index = self.line_buffer.word_right_index();
+        if right_index > insertion_offset {
+            let cut_range = insertion_offset..right_index;
+            self.cut_buffer.set(
+                &self.line_buffer.get_buffer()[cut_range.clone()],
+                ClipboardMode::Normal,
+            );
+            self.clear_range(cut_range);
+        }
+    }
+
+    fn cut_char(&mut self) {
+        let insertion_offset = self.line_buffer.insertion_point();
+        let right_index = self.line_buffer.grapheme_right_index();
         if right_index > insertion_offset {
             let cut_range = insertion_offset..right_index;
             self.cut_buffer.set(

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -77,7 +77,7 @@ where
         }
         Some('C') => {
             let _ = input.next();
-            Some(Command::ChangeTillEnd)
+            Some(Command::ChangeToLineEnd)
         }
         Some('D') => {
             let _ = input.next();
@@ -141,7 +141,7 @@ pub enum Command {
     EnterViAppend,
     EnterViInsert,
     Undo,
-    ChangeTillEnd,
+    ChangeToLineEnd,
     DeleteToEnd,
     AppendToEnd,
     PrependToStart,
@@ -169,7 +169,7 @@ impl Command {
             Self::PasteAfter => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferAfter)],
             Self::PasteBefore => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferBefore)],
             Self::Undo => vec![ReedlineOption::Edit(EditCommand::Undo)],
-            Self::ChangeTillEnd => vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)],
+            Self::ChangeToLineEnd => vec![ReedlineOption::Edit(EditCommand::ClearToLineEnd)],
             Self::DeleteToEnd => vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)],
             Self::AppendToEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
             Self::PrependToStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -73,6 +73,10 @@ where
         }
         Some('s') => {
             let _ = input.next();
+            Some(Command::DeleteCharInsert)
+        }
+        Some('?') => {
+            let _ = input.next();
             Some(Command::HistorySearch)
         }
         Some('C') => {
@@ -132,6 +136,7 @@ pub enum Command {
     Incomplete,
     Delete,
     DeleteChar,
+    DeleteCharInsert,
     PasteAfter,
     PasteBefore,
     MoveLeft,
@@ -186,6 +191,7 @@ impl Command {
             Self::MoveLeftUntil(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftUntil(*c))],
             Self::MoveLeftBefore(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftBefore(*c))],
             Self::DeleteChar => vec![ReedlineOption::Edit(EditCommand::Delete)],
+            Self::DeleteCharInsert => vec![ReedlineOption::Edit(EditCommand::Delete)],
             Self::HistorySearch => vec![ReedlineOption::Event(ReedlineEvent::SearchHistory)],
             // Mark a command as incomplete whenever a motion is required to finish the command
             Self::Delete | Self::Change | Self::Incomplete => vec![ReedlineOption::Incomplete],

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -190,8 +190,8 @@ impl Command {
             }
             Self::MoveLeftUntil(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftUntil(*c))],
             Self::MoveLeftBefore(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftBefore(*c))],
-            Self::DeleteChar => vec![ReedlineOption::Edit(EditCommand::Delete)],
-            Self::DeleteCharInsert => vec![ReedlineOption::Edit(EditCommand::Delete)],
+            Self::DeleteChar => vec![ReedlineOption::Edit(EditCommand::CutChar)],
+            Self::DeleteCharInsert => vec![ReedlineOption::Edit(EditCommand::CutChar)],
             Self::HistorySearch => vec![ReedlineOption::Event(ReedlineEvent::SearchHistory)],
             // Mark a command as incomplete whenever a motion is required to finish the command
             Self::Delete | Self::Change | Self::Incomplete => vec![ReedlineOption::Incomplete],

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -91,6 +91,10 @@ where
             let _ = input.next();
             Some(Command::AppendToEnd)
         }
+        Some('S') => {
+            let _ = input.next();
+            Some(Command::RewriteCurrentLine)
+        }
         Some('f') => {
             let _ = input.next();
             match input.peek() {
@@ -145,6 +149,7 @@ pub enum Command {
     DeleteToEnd,
     AppendToEnd,
     PrependToStart,
+    RewriteCurrentLine,
     Change,
     MoveRightUntil(char),
     MoveRightBefore(char),
@@ -173,6 +178,7 @@ impl Command {
             Self::DeleteToEnd => vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)],
             Self::AppendToEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
             Self::PrependToStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],
+            Self::RewriteCurrentLine => vec![ReedlineOption::Edit(EditCommand::CutCurrentLine)],
             Self::MoveRightUntil(c) => vec![ReedlineOption::Edit(EditCommand::MoveRightUntil(*c))],
             Self::MoveRightBefore(c) => {
                 vec![ReedlineOption::Edit(EditCommand::MoveRightBefore(*c))]

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -165,8 +165,8 @@ impl Command {
             Self::PasteBefore => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferBefore)],
             Self::Undo => vec![ReedlineOption::Edit(EditCommand::Undo)],
             Self::DeleteToEnd => vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)],
-            Self::AppendToEnd => vec![ReedlineOption::Edit(EditCommand::MoveToEnd)],
-            Self::PrependToStart => vec![ReedlineOption::Edit(EditCommand::MoveToStart)],
+            Self::AppendToEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
+            Self::PrependToStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],
             Self::MoveRightUntil(c) => vec![ReedlineOption::Edit(EditCommand::MoveRightUntil(*c))],
             Self::MoveRightBefore(c) => {
                 vec![ReedlineOption::Edit(EditCommand::MoveRightBefore(*c))]

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -75,6 +75,10 @@ where
             let _ = input.next();
             Some(Command::HistorySearch)
         }
+        Some('C') => {
+            let _ = input.next();
+            Some(Command::ChangeTillEnd)
+        }
         Some('D') => {
             let _ = input.next();
             Some(Command::DeleteToEnd)
@@ -137,6 +141,7 @@ pub enum Command {
     EnterViAppend,
     EnterViInsert,
     Undo,
+    ChangeTillEnd,
     DeleteToEnd,
     AppendToEnd,
     PrependToStart,
@@ -164,6 +169,7 @@ impl Command {
             Self::PasteAfter => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferAfter)],
             Self::PasteBefore => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferBefore)],
             Self::Undo => vec![ReedlineOption::Edit(EditCommand::Undo)],
+            Self::ChangeTillEnd => vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)],
             Self::DeleteToEnd => vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)],
             Self::AppendToEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
             Self::PrependToStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -79,6 +79,10 @@ where
             let _ = input.next();
             Some(Command::DeleteToEnd)
         }
+        Some('I') => {
+            let _ = input.next();
+            Some(Command::PrependToStart)
+        }
         Some('A') => {
             let _ = input.next();
             Some(Command::AppendToEnd)
@@ -135,6 +139,7 @@ pub enum Command {
     Undo,
     DeleteToEnd,
     AppendToEnd,
+    PrependToStart,
     Change,
     MoveRightUntil(char),
     MoveRightBefore(char),
@@ -161,6 +166,7 @@ impl Command {
             Self::Undo => vec![ReedlineOption::Edit(EditCommand::Undo)],
             Self::DeleteToEnd => vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)],
             Self::AppendToEnd => vec![ReedlineOption::Edit(EditCommand::MoveToEnd)],
+            Self::PrependToStart => vec![ReedlineOption::Edit(EditCommand::MoveToStart)],
             Self::MoveRightUntil(c) => vec![ReedlineOption::Edit(EditCommand::MoveRightUntil(*c))],
             Self::MoveRightBefore(c) => {
                 vec![ReedlineOption::Edit(EditCommand::MoveRightBefore(*c))]

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -29,7 +29,7 @@ impl ParseResult {
             (&self.command, &self.motion),
             (Some(Command::EnterViInsert), None)
                 | (Some(Command::EnterViAppend), None)
-                | (Some(Command::ChangeTillEnd), None)
+                | (Some(Command::ChangeToLineEnd), None)
                 | (Some(Command::AppendToEnd), None)
                 | (Some(Command::PrependToStart), None)
                 | (Some(Command::HistorySearch), None)

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -30,6 +30,7 @@ impl ParseResult {
             (Some(Command::EnterViInsert), None)
                 | (Some(Command::EnterViAppend), None)
                 | (Some(Command::AppendToEnd), None)
+                | (Some(Command::PrependToStart), None)
                 | (Some(Command::HistorySearch), None)
                 | (Some(Command::Change), Some(_))
         )

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -29,6 +29,7 @@ impl ParseResult {
             (&self.command, &self.motion),
             (Some(Command::EnterViInsert), None)
                 | (Some(Command::EnterViAppend), None)
+                | (Some(Command::ChangeTillEnd), None)
                 | (Some(Command::AppendToEnd), None)
                 | (Some(Command::PrependToStart), None)
                 | (Some(Command::HistorySearch), None)

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -33,6 +33,7 @@ impl ParseResult {
                 | (Some(Command::AppendToEnd), None)
                 | (Some(Command::PrependToStart), None)
                 | (Some(Command::RewriteCurrentLine), None)
+                | (Some(Command::DeleteCharInsert), None)
                 | (Some(Command::HistorySearch), None)
                 | (Some(Command::Change), Some(_))
         )

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -32,6 +32,7 @@ impl ParseResult {
                 | (Some(Command::ChangeToLineEnd), None)
                 | (Some(Command::AppendToEnd), None)
                 | (Some(Command::PrependToStart), None)
+                | (Some(Command::RewriteCurrentLine), None)
                 | (Some(Command::HistorySearch), None)
                 | (Some(Command::Change), Some(_))
         )

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -66,6 +66,9 @@ pub enum EditCommand {
     /// Delete in-place from the current insertion point
     Delete,
 
+    /// Delete in-place from the current insertion point
+    CutChar,
+
     /// Backspace delete a word from the current insertion point
     BackspaceWord,
 
@@ -169,6 +172,7 @@ impl Display for EditCommand {
             EditCommand::ReplaceChars(_, _) => write!(f, "ReplaceChars <int> <string>"),
             EditCommand::Backspace => write!(f, "Backspace"),
             EditCommand::Delete => write!(f, "Delete"),
+            EditCommand::CutChar => write!(f, "CutChar"),
             EditCommand::BackspaceWord => write!(f, "BackspaceWord"),
             EditCommand::DeleteWord => write!(f, "DeleteWord"),
             EditCommand::Clear => write!(f, "Clear"),
@@ -227,6 +231,7 @@ impl EditCommand {
             // Full edits
             EditCommand::Backspace
             | EditCommand::Delete
+            | EditCommand::CutChar
             | EditCommand::InsertString(_)
             | EditCommand::InsertNewline
             | EditCommand::ReplaceChars(_, _)


### PR DESCRIPTION
Can you assure me that `cut_current_line()` is the correct function for this implementation?

I'm sorry again about duplicate commits. It's concerning that it might annoy you to see so many commits again and again. If that's a problem then please tell me. I'll redo my fork.

Also, was it correct behavior to make a different PR for implementation of every binding?

Can you also confirm that `x` binding is not copying the content to the clipboard?

I'll also try to work on `r` binding.