### PR TITLE
line buffer editor

### DIFF
--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -170,4 +170,5 @@ pub fn add_common_keybindings(kb: &mut Keybindings) {
         KC::Char('n'),
         ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuDown, ReedlineEvent::Down]),
     );
+    kb.add_binding(KM::CONTROL, KC::Char('e'), ReedlineEvent::OpenEditor);
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -113,7 +113,7 @@ pub struct Reedline {
 
     // Engine Menus
     menus: Vec<ReedlineMenu>,
-    
+
     // Text editor used to open the line buffer for editing
     text_editor: String,
 }
@@ -300,11 +300,11 @@ impl Reedline {
         self.validator = Some(validator);
         self
     }
-    
-    /// A builder that configures the text editor used to edit the line buffer 
+
+    /// A builder that configures the text editor used to edit the line buffer
     /// # Example
     /// ```rust,no_run
-    /// // Create a reedline object with vim as editor 
+    /// // Create a reedline object with vim as editor
     ///
     /// use reedline::{DefaultValidator, Reedline};
     ///
@@ -313,7 +313,7 @@ impl Reedline {
     /// ```
     #[must_use]
     pub fn with_text_editor(mut self, editor: String) -> Self {
-        self.text_editor = editor; 
+        self.text_editor = editor;
         self
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -309,7 +309,7 @@ impl Reedline {
     /// use reedline::{DefaultValidator, Reedline};
     ///
     /// let mut line_editor =
-    /// Reedline::create().with_editor("vim".into());
+    /// Reedline::create().with_text_editor("vim".into());
     /// ```
     #[must_use]
     pub fn with_text_editor(mut self, editor: String) -> Self {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -388,6 +388,9 @@ pub enum ReedlineEvent {
 
     /// Way to bind the execution of a whole command (directly returning from [`crate::Reedline::read_line()`]) to a keybinding
     ExecuteHostCommand(String),
+
+    /// Open text editor
+    OpenEditor,
 }
 
 impl Display for ReedlineEvent {
@@ -429,6 +432,7 @@ impl Display for ReedlineEvent {
             ReedlineEvent::MenuPageNext => write!(f, "MenuPageNext"),
             ReedlineEvent::MenuPagePrevious => write!(f, "MenuPagePrevious"),
             ReedlineEvent::ExecuteHostCommand(_) => write!(f, "ExecuteHostCommand"),
+            ReedlineEvent::OpenEditor => write!(f, "OpenEditor"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use reedline::{DefaultValidator, EditCommand, ReedlineMenu};
-
 use {
     crossterm::{
         event::{poll, Event, KeyCode, KeyEvent, KeyModifiers},
@@ -11,8 +9,8 @@ use {
         get_reedline_default_keybindings, get_reedline_edit_commands,
         get_reedline_keybinding_modifiers, get_reedline_keycodes, get_reedline_prompt_edit_modes,
         get_reedline_reedline_events, ColumnarMenu, DefaultCompleter, DefaultHinter, DefaultPrompt,
-        EditMode, Emacs, ExampleHighlighter, FileBackedHistory, Keybindings, ListMenu, Reedline,
-        ReedlineEvent, Signal, Vi,
+        DefaultValidator, EditCommand, EditMode, Emacs, ExampleHighlighter, FileBackedHistory,
+        Keybindings, ListMenu, Reedline, ReedlineEvent, ReedlineMenu, Signal, Vi,
     },
     std::{
         io::{stdout, Write},
@@ -111,7 +109,7 @@ fn main() -> Result<()> {
     line_editor = line_editor.with_edit_mode(edit_mode);
 
     // Adding vi as text editor
-    line_editor = line_editor.with_text_editor("emacs".into());
+    line_editor = line_editor.with_buffer_editor("hx".into(), "nu".into());
 
     let prompt = DefaultPrompt::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn main() -> Result<()> {
     line_editor = line_editor.with_edit_mode(edit_mode);
 
     // Adding vi as text editor
-    line_editor = line_editor.with_buffer_editor("hx".into(), "nu".into());
+    line_editor = line_editor.with_buffer_editor("vi".into(), "nu".into());
 
     let prompt = DefaultPrompt::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,9 @@ fn main() -> Result<()> {
 
     line_editor = line_editor.with_edit_mode(edit_mode);
 
+    // Adding vi as text editor
+    line_editor = line_editor.with_text_editor("emacs".into());
+
     let prompt = DefaultPrompt::new();
 
     loop {


### PR DESCRIPTION
Introduces a new event to open a line editor to edit the line buffer

Note. There is an issue that I cannot figure out. After you open the line buffer (ctr + e), edit your line and save the result, if you press `ctr+c` there is a panic in reedline. I've been looking everywhere but I cannot find where it is coming from.  Any suggestions on where that error could come from?

closes #409