### PR TITLE
Only partial complete suggestions when input is a prefix

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -713,8 +713,8 @@ mod tests {
     use super::*;
 
     macro_rules! partial_completion_tests {
-        (completions: $completions:expr, $($name:ident: $value:expr,)*) => {
-            mod partial_completions {
+        (name: $test_group_name:ident, completions: $completions:expr, test_cases: $($name:ident: $value:expr,)*) => {
+            mod $test_group_name {
                 use crate::{menu::Menu, ColumnarMenu, LineBuffer};
                 use super::FakeCompleter;
 
@@ -737,11 +737,23 @@ mod tests {
     }
 
     partial_completion_tests! {
+        name: partial_completion_prefix_matches,
         completions: ["build.rs", "build-all.sh"],
 
-        completes_from_empty: ("", "build"),
-        completes_from_something: ("bui", "build"),
-        completes_full_match: ("build", "build"),
+        test_cases:
+            completes_from_empty: ("", "build"),
+            completes_from_something: ("bui", "build"),
+            completes_full_match: ("build", "build"),
+    }
+
+    partial_completion_tests! {
+        name: partial_completion_fuzzy_matches,
+        completions: ["build.rs", "build-all.sh", "prepare-build.sh"],
+
+        test_cases:
+            completes_from_empty: ("", ""),
+            completes_from_something: ("bui", "bui"),
+            completes_full_match: ("build", "build"),
     }
 
     struct FakeCompleter {


### PR DESCRIPTION
This changes the partial completion mechanism so that it only replaces the entered text when the entered text is a prefix of the suggestion. This fixes problems with the fuzzy matching (see https://github.com/nushell/nushell/pull/5320#issuecomment-1110255908).

For example:

Suggestions: `build`, `all-build`
Before this PR: `build<tab>` -> ` ` (shared prefix is empty, therefore the entered input is replaced with an empty string)
After this PR: `build<tab>` -> `build` (there are suggestions which don't share a common prefix, therefore no partial completion happens)

To avoid a worse experience with file path completion I'd suggest to also consider merging https://github.com/nushell/nushell/pull/5387 in nushell.

This PR also adds some unit tests for the partial completion mechanism.