### PR TITLE
Buffer editor keybinding

### DIFF
--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -170,5 +170,5 @@ pub fn add_common_keybindings(kb: &mut Keybindings) {
         KC::Char('n'),
         ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuDown, ReedlineEvent::Down]),
     );
-    kb.add_binding(KM::CONTROL, KC::Char('e'), ReedlineEvent::OpenEditor);
+    kb.add_binding(KM::CONTROL, KC::Char('i'), ReedlineEvent::OpenEditor);
 }


### PR DESCRIPTION
Changes the keybinding to open the buffer editor because it overrides an existing emacs keybinding