### PR TITLE
Attempt fix of `ClearScrollback`

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -429,8 +429,8 @@ impl Painter {
 
     pub(crate) fn clear_scrollback(&mut self) -> Result<()> {
         self.stdout
-            .queue(crossterm::terminal::Clear(ClearType::Purge))?
             .queue(crossterm::terminal::Clear(ClearType::All))?
+            .queue(crossterm::terminal::Clear(ClearType::Purge))?
             .queue(cursor::MoveTo(0, 0))?
             .flush()?;
         self.initialize_prompt_position()


### PR DESCRIPTION
Clearing the scrollback did not work on most terminal emulators.
By reordering two ANSI control sequences, this seems to work on Linux
with most terminal emulators.
Due to a missing implementation of the exact details this will probably
not clear the scrollback under the old Windows API.

Related to the discussion in #120 and nushell/nushell#5089
