### PR TITLE
Vi additions and fixes by @zim0369

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -48,6 +48,7 @@ impl Editor {
             EditCommand::ReplaceChars(n_chars, str) => self.replace_chars(*n_chars, str),
             EditCommand::Backspace => self.line_buffer.delete_left_grapheme(),
             EditCommand::Delete => self.line_buffer.delete_right_grapheme(),
+            EditCommand::CutChar => self.cut_char(),
             EditCommand::BackspaceWord => self.line_buffer.delete_word_left(),
             EditCommand::DeleteWord => self.line_buffer.delete_word_right(),
             EditCommand::Clear => self.line_buffer.clear(),
@@ -258,6 +259,19 @@ impl Editor {
     fn cut_word_right(&mut self) {
         let insertion_offset = self.line_buffer.insertion_point();
         let right_index = self.line_buffer.word_right_index();
+        if right_index > insertion_offset {
+            let cut_range = insertion_offset..right_index;
+            self.cut_buffer.set(
+                &self.line_buffer.get_buffer()[cut_range.clone()],
+                ClipboardMode::Normal,
+            );
+            self.clear_range(cut_range);
+        }
+    }
+
+    fn cut_char(&mut self) {
+        let insertion_offset = self.line_buffer.insertion_point();
+        let right_index = self.line_buffer.grapheme_right_index();
         if right_index > insertion_offset {
             let cut_range = insertion_offset..right_index;
             self.cut_buffer.set(

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -91,6 +91,10 @@ where
             let _ = input.next();
             Some(Command::AppendToEnd)
         }
+        Some('S') => {
+            let _ = input.next();
+            Some(Command::RewriteCurrentLine)
+        }
         Some('f') => {
             let _ = input.next();
             match input.peek() {
@@ -145,6 +149,7 @@ pub enum Command {
     DeleteToEnd,
     AppendToEnd,
     PrependToStart,
+    RewriteCurrentLine,
     Change,
     MoveRightUntil(char),
     MoveRightBefore(char),
@@ -173,6 +178,7 @@ impl Command {
             Self::DeleteToEnd => vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)],
             Self::AppendToEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
             Self::PrependToStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],
+            Self::RewriteCurrentLine => vec![ReedlineOption::Edit(EditCommand::CutCurrentLine)],
             Self::MoveRightUntil(c) => vec![ReedlineOption::Edit(EditCommand::MoveRightUntil(*c))],
             Self::MoveRightBefore(c) => {
                 vec![ReedlineOption::Edit(EditCommand::MoveRightBefore(*c))]

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -185,7 +185,7 @@ impl Command {
             }
             Self::MoveLeftUntil(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftUntil(*c))],
             Self::MoveLeftBefore(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftBefore(*c))],
-            Self::DeleteChar => vec![ReedlineOption::Edit(EditCommand::Delete)],
+            Self::DeleteChar => vec![ReedlineOption::Edit(EditCommand::CutChar)],
             Self::HistorySearch => vec![ReedlineOption::Event(ReedlineEvent::SearchHistory)],
             // Mark a command as incomplete whenever a motion is required to finish the command
             Self::Delete | Self::Change | Self::Incomplete => vec![ReedlineOption::Incomplete],

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -73,7 +73,7 @@ where
         }
         Some('s') => {
             let _ = input.next();
-            Some(Command::DeleteCharInsert)
+            Some(Command::SubstituteCharWithInsert)
         }
         Some('?') => {
             let _ = input.next();
@@ -136,7 +136,7 @@ pub enum Command {
     Incomplete,
     Delete,
     DeleteChar,
-    DeleteCharInsert,
+    SubstituteCharWithInsert,
     PasteAfter,
     PasteBefore,
     MoveLeft,
@@ -191,7 +191,7 @@ impl Command {
             Self::MoveLeftUntil(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftUntil(*c))],
             Self::MoveLeftBefore(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftBefore(*c))],
             Self::DeleteChar => vec![ReedlineOption::Edit(EditCommand::CutChar)],
-            Self::DeleteCharInsert => vec![ReedlineOption::Edit(EditCommand::CutChar)],
+            Self::SubstituteCharWithInsert => vec![ReedlineOption::Edit(EditCommand::CutChar)],
             Self::HistorySearch => vec![ReedlineOption::Event(ReedlineEvent::SearchHistory)],
             // Mark a command as incomplete whenever a motion is required to finish the command
             Self::Delete | Self::Change | Self::Incomplete => vec![ReedlineOption::Incomplete],

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -73,6 +73,10 @@ where
         }
         Some('s') => {
             let _ = input.next();
+            Some(Command::DeleteCharInsert)
+        }
+        Some('?') => {
+            let _ = input.next();
             Some(Command::HistorySearch)
         }
         Some('C') => {
@@ -132,6 +136,7 @@ pub enum Command {
     Incomplete,
     Delete,
     DeleteChar,
+    DeleteCharInsert,
     PasteAfter,
     PasteBefore,
     MoveLeft,
@@ -186,6 +191,7 @@ impl Command {
             Self::MoveLeftUntil(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftUntil(*c))],
             Self::MoveLeftBefore(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftBefore(*c))],
             Self::DeleteChar => vec![ReedlineOption::Edit(EditCommand::CutChar)],
+            Self::DeleteCharInsert => vec![ReedlineOption::Edit(EditCommand::CutChar)],
             Self::HistorySearch => vec![ReedlineOption::Event(ReedlineEvent::SearchHistory)],
             // Mark a command as incomplete whenever a motion is required to finish the command
             Self::Delete | Self::Change | Self::Incomplete => vec![ReedlineOption::Incomplete],

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -33,6 +33,7 @@ impl ParseResult {
                 | (Some(Command::AppendToEnd), None)
                 | (Some(Command::PrependToStart), None)
                 | (Some(Command::RewriteCurrentLine), None)
+                | (Some(Command::DeleteCharInsert), None)
                 | (Some(Command::HistorySearch), None)
                 | (Some(Command::Change), Some(_))
         )

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -33,7 +33,7 @@ impl ParseResult {
                 | (Some(Command::AppendToEnd), None)
                 | (Some(Command::PrependToStart), None)
                 | (Some(Command::RewriteCurrentLine), None)
-                | (Some(Command::DeleteCharInsert), None)
+                | (Some(Command::SubstituteCharWithInsert), None)
                 | (Some(Command::HistorySearch), None)
                 | (Some(Command::Change), Some(_))
         )

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -32,6 +32,7 @@ impl ParseResult {
                 | (Some(Command::ChangeToLineEnd), None)
                 | (Some(Command::AppendToEnd), None)
                 | (Some(Command::PrependToStart), None)
+                | (Some(Command::RewriteCurrentLine), None)
                 | (Some(Command::HistorySearch), None)
                 | (Some(Command::Change), Some(_))
         )

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -66,7 +66,7 @@ pub enum EditCommand {
     /// Delete in-place from the current insertion point
     Delete,
 
-    /// Delete in-place from the current insertion point
+    /// Cut the grapheme right from the current insertion point
     CutChar,
 
     /// Backspace delete a word from the current insertion point
@@ -78,7 +78,7 @@ pub enum EditCommand {
     /// Clear the current buffer
     Clear,
 
-    /// Clear the current buffer
+    /// Clear to the end of the current line
     ClearToLineEnd,
 
     /// Cut the current line

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -66,6 +66,9 @@ pub enum EditCommand {
     /// Delete in-place from the current insertion point
     Delete,
 
+    /// Delete in-place from the current insertion point
+    CutChar,
+
     /// Backspace delete a word from the current insertion point
     BackspaceWord,
 
@@ -169,6 +172,7 @@ impl Display for EditCommand {
             EditCommand::ReplaceChars(_, _) => write!(f, "ReplaceChars <int> <string>"),
             EditCommand::Backspace => write!(f, "Backspace"),
             EditCommand::Delete => write!(f, "Delete"),
+            EditCommand::CutChar => write!(f, "CutChar"),
             EditCommand::BackspaceWord => write!(f, "BackspaceWord"),
             EditCommand::DeleteWord => write!(f, "DeleteWord"),
             EditCommand::Clear => write!(f, "Clear"),
@@ -227,6 +231,7 @@ impl EditCommand {
             // Full edits
             EditCommand::Backspace
             | EditCommand::Delete
+            | EditCommand::CutChar
             | EditCommand::InsertString(_)
             | EditCommand::InsertNewline
             | EditCommand::ReplaceChars(_, _)


### PR DESCRIPTION
Rebased the commits from #406

- vim's 'S' binding
- copy char while deleting in vi mode
  - Fixes the behavior of `x` so the removed char/grapheme can be pasted with `p`
- vim's 's' binding
- Minor clarifications
  - Fix doccomments and clarify an enum variant's name

Closes  #406
