### PR TITLE
Add doctests back to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,9 @@ jobs:
         with:
           command: nextest
           args: run --all ${{ matrix.flags }}
+
+      - name: Doctests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --doc ${{ matrix.flags }}


### PR DESCRIPTION
`cargo nextest` currently doesn't support running the doctests.

Thus, add an additional step for them with cargo's default test runner.
