### PR TITLE
Fix README and lib.rs code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ fn main() -> io::Result<()> {
 
 ### Integrate with custom keybindings
 
-```rust,no_run
+```rust
 // Configure reedline with custom keybindings
 
 //Cargo.toml
@@ -98,7 +98,7 @@ let mut line_editor = Reedline::create()
 
 ### Integrate with custom syntax `Highlighter`
 
-```rust,no_run
+```rust
 // Create a reedline object with highlighter support
 
 use reedline::{ExampleHighlighter, Reedline};
@@ -115,7 +115,7 @@ Reedline::create().with_highlighter(Box::new(ExampleHighlighter::new(commands)))
 
 ### Integrate with custom tab completion
 
-```rust,no_run
+```rust
 // Create a reedline object with tab completions support
 
 use reedline::{ColumnarMenu, DefaultCompleter, Reedline, ReedlineMenu};
@@ -136,7 +136,7 @@ Reedline::create().with_completer(completer).with_menu(ReedlineMenu::EngineCompl
 
 ### Integrate with `Hinter` for fish-style history autosuggestions
 
-```rust,no_run
+```rust
 // Create a reedline object with in-line hint support
 
 //Cargo.toml
@@ -156,7 +156,7 @@ let mut line_editor = Reedline::create().with_hinter(Box::new(
 
 ### Integrate with custom line completion `Validator`
 
-```rust,no_run
+```rust
 // Create a reedline object with line completion validation support
 
 use reedline::{DefaultValidator, Reedline};
@@ -168,7 +168,7 @@ let mut line_editor = Reedline::create().with_validator(validator);
 
 ### Use custom `EditMode`
 
-```rust,no_run
+```rust
 // Create a reedline object with custom edit mode
 // This can define a keybinding setting or enable vi-emulation
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Reedline::create().with_highlighter(Box::new(ExampleHighlighter::new(commands)))
 ```rust,no_run
 // Create a reedline object with tab completions support
 
-use reedline::{DefaultCompleter, Reedline, CompletionMenu};
+use reedline::{ColumnarMenu, DefaultCompleter, Reedline, ReedlineMenu};
 
 let commands = vec![
   "test".into(),
@@ -128,9 +128,10 @@ let commands = vec![
 ];
 let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 // Use the interactive menu to select options from the completer
-let completion_menu = Box::new(CompletionMenu::default());
+let completion_menu = Box::new(ColumnarMenu::default().with_name("completion_menu"));
 
-let mut line_editor = Reedline::create().with_completer(completer).with_menu(completion_menu);
+let mut line_editor =
+Reedline::create().with_completer(completer).with_menu(ReedlineMenu::EngineCompleter(completion_menu));
 ```
 
 ### Integrate with `Hinter` for fish-style history autosuggestions
@@ -165,16 +166,20 @@ let validator = Box::new(DefaultValidator);
 let mut line_editor = Reedline::create().with_validator(validator);
 ```
 
-### Integrate with custom Edit Mode
+### Use custom `EditMode`
 
 ```rust,no_run
 // Create a reedline object with custom edit mode
+// This can define a keybinding setting or enable vi-emulation
 
-use reedline::{EditMode, Reedline};
+use reedline::{
+    default_vi_insert_keybindings, default_vi_normal_keybindings, EditMode, Reedline, Vi,
+};
 
-let mut line_editor = Reedline::create().with_edit_mode(
-  EditMode::ViNormal, // or EditMode::Emacs or EditMode::ViInsert
-);
+let mut line_editor = Reedline::create().with_edit_mode(Box::new(Vi::new(
+    default_vi_insert_keybindings(),
+    default_vi_normal_keybindings(),
+)));
 ```
 
 ## Are we prompt yet? (Development status)

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -9,7 +9,7 @@ use std::{
 ///
 /// # Example
 ///
-/// ```rust, no_run
+/// ```rust
 /// use reedline::{DefaultCompleter, Reedline};
 ///
 /// let commands = vec![

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -166,7 +166,7 @@ impl Reedline {
 
     /// A builder to include a [`Hinter`] in your instance of the Reedline engine
     /// # Example
-    /// ```rust,no_run
+    /// ```rust
     /// //Cargo.toml
     /// //[dependencies]
     /// //nu-ansi-term = "*"
@@ -195,7 +195,7 @@ impl Reedline {
 
     /// A builder to configure the tab completion
     /// # Example
-    /// ```rust,no_run
+    /// ```rust
     /// // Create a reedline object with tab completions support
     ///
     /// use reedline::{DefaultCompleter, Reedline};
@@ -250,7 +250,7 @@ impl Reedline {
 
     /// A builder that configures the highlighter for your instance of the Reedline engine
     /// # Example
-    /// ```rust,no_run
+    /// ```rust
     /// // Create a reedline object with highlighter support
     ///
     /// use reedline::{ExampleHighlighter, Reedline};
@@ -292,7 +292,7 @@ impl Reedline {
 
     /// A builder that configures the validator for your instance of the Reedline engine
     /// # Example
-    /// ```rust,no_run
+    /// ```rust
     /// // Create a reedline object with validator support
     ///
     /// use reedline::{DefaultValidator, Reedline};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! ```
 //! ## Integrate with custom keybindings
 //!
-//! ```rust,no_run
+//! ```rust
 //! // Configure reedline with custom keybindings
 //!
 //! //Cargo.toml
@@ -76,7 +76,7 @@
 //!
 //! ## Integrate with custom syntax [`Highlighter`]
 //!
-//! ```rust,no_run
+//! ```rust
 //! // Create a reedline object with highlighter support
 //!
 //! use reedline::{ExampleHighlighter, Reedline};
@@ -93,7 +93,7 @@
 //!
 //! ## Integrate with custom tab completion
 //!
-//! ```rust,no_run
+//! ```rust
 //! // Create a reedline object with tab completions support
 //!
 //! use reedline::{ColumnarMenu, DefaultCompleter, Reedline, ReedlineMenu};
@@ -114,7 +114,7 @@
 //!
 //! ## Integrate with [`Hinter`] for fish-style history autosuggestions
 //!
-//! ```rust,no_run
+//! ```rust
 //! // Create a reedline object with in-line hint support
 //!
 //! //Cargo.toml
@@ -136,7 +136,7 @@
 //!
 //! ## Integrate with custom line completion [`Validator`]
 //!
-//! ```rust,no_run
+//! ```rust
 //! // Create a reedline object with line completion validation support
 //!
 //! use reedline::{DefaultValidator, Reedline};
@@ -148,7 +148,7 @@
 //!
 //! ## Use custom [`EditMode`]
 //!
-//! ```rust,no_run
+//! ```rust
 //! // Create a reedline object with custom edit mode
 //! // This can define a keybinding setting or enable vi-emulation
 //! use reedline::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,34 @@
 //! ));
 //! ```
 //!
+//!
+//! ## Integrate with custom line completion [`Validator`]
+//!
+//! ```rust,no_run
+//! // Create a reedline object with line completion validation support
+//!
+//! use reedline::{DefaultValidator, Reedline};
+//!
+//! let validator = Box::new(DefaultValidator);
+//!
+//! let mut line_editor = Reedline::create().with_validator(validator);
+//! ```
+//!
+//! ## Use custom [`EditMode`]
+//!
+//! ```rust,no_run
+//! // Create a reedline object with custom edit mode
+//! // This can define a keybinding setting or enable vi-emulation
+//! use reedline::{
+//!     default_vi_insert_keybindings, default_vi_normal_keybindings, EditMode, Reedline, Vi,
+//! };
+//!
+//! let mut line_editor = Reedline::create().with_edit_mode(Box::new(Vi::new(
+//!     default_vi_insert_keybindings(),
+//!     default_vi_normal_keybindings(),
+//! )));
+//! ```
+//!
 //! ## Are we prompt yet? (Development status)
 //!
 //! Nushell has now all the basic features to become the primary line editor for [nushell](https://github.com/nushell/nushell


### PR DESCRIPTION
- Fix README and lib.rs code examples
  - Add missing doctests
  - Fix the completion example in README
  - Fix the edit mode example
- Try to run more of the doctests
  - They should not block with the IO loop or do file IO as this was failing the CI
