### PR TITLE
Change keybinding for external editor

### DIFF
--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -170,5 +170,5 @@ pub fn add_common_keybindings(kb: &mut Keybindings) {
         KC::Char('n'),
         ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuDown, ReedlineEvent::Down]),
     );
-    kb.add_binding(KM::CONTROL, KC::Char('i'), ReedlineEvent::OpenEditor);
+    kb.add_binding(KM::CONTROL, KC::Char('u'), ReedlineEvent::OpenEditor);
 }

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -170,5 +170,5 @@ pub fn add_common_keybindings(kb: &mut Keybindings) {
         KC::Char('n'),
         ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuDown, ReedlineEvent::Down]),
     );
-    kb.add_binding(KM::CONTROL, KC::Char('u'), ReedlineEvent::OpenEditor);
+    kb.add_binding(KM::CONTROL, KC::Char('o'), ReedlineEvent::OpenEditor);
 }


### PR DESCRIPTION
Current `Ctrl-I` is overloaded as `Tab` in the ASCII/ANSI world.

Don't use `Ctrl-U` (Conflict with emacs cut command)

Best candidate `Ctrl-o` (mnenomic "o"pen in editor) currently not bound to anything
