### PR TITLE
Fix vi-mode word motions

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -42,6 +42,8 @@ impl Editor {
             EditCommand::MoveRight => self.line_buffer.move_right(),
             EditCommand::MoveWordLeft => self.line_buffer.move_word_left(),
             EditCommand::MoveWordRight => self.line_buffer.move_word_right(),
+            EditCommand::MoveWordRightStart => self.line_buffer.move_word_right_start(),
+            EditCommand::MoveWordRightEnd => self.line_buffer.move_word_right_end(),
             EditCommand::InsertChar(c) => self.insert_char(*c),
             EditCommand::InsertString(str) => self.line_buffer.insert_str(str),
             EditCommand::InsertNewline => self.line_buffer.insert_newline(),
@@ -60,6 +62,7 @@ impl Editor {
             EditCommand::CutToLineEnd => self.cut_to_line_end(),
             EditCommand::CutWordLeft => self.cut_word_left(),
             EditCommand::CutWordRight => self.cut_word_right(),
+            EditCommand::CutWordRightToNext => self.cut_word_right_to_next(),
             EditCommand::PasteCutBufferBefore => self.insert_cut_buffer_before(),
             EditCommand::PasteCutBufferAfter => self.insert_cut_buffer_after(),
             EditCommand::UppercaseWord => self.line_buffer.uppercase_word(),
@@ -259,6 +262,19 @@ impl Editor {
     fn cut_word_right(&mut self) {
         let insertion_offset = self.line_buffer.insertion_point();
         let right_index = self.line_buffer.word_right_index();
+        if right_index > insertion_offset {
+            let cut_range = insertion_offset..right_index;
+            self.cut_buffer.set(
+                &self.line_buffer.get_buffer()[cut_range.clone()],
+                ClipboardMode::Normal,
+            );
+            self.clear_range(cut_range);
+        }
+    }
+
+    fn cut_word_right_to_next(&mut self) {
+        let insertion_offset = self.line_buffer.insertion_point();
+        let right_index = self.line_buffer.word_right_start_index();
         if right_index > insertion_offset {
             let cut_range = insertion_offset..right_index;
             self.cut_buffer.set(

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -179,6 +179,35 @@ impl LineBuffer {
             .unwrap_or_else(|| self.lines.len())
     }
 
+    /// Cursor position *at end of* the next word to the right
+    pub fn word_right_end_index(&self) -> usize {
+        self.lines[self.insertion_point..]
+            .split_word_bound_indices()
+            .filter_map(|(i, word)| {
+                word.grapheme_indices(true)
+                    .next_back()
+                    .map(|x| self.insertion_point + x.0 + i)
+                    .filter(|x| !is_whitespace_str(word) && *x != self.insertion_point)
+            })
+            .next()
+            .unwrap_or_else(|| {
+                self.lines
+                    .grapheme_indices(true)
+                    .last()
+                    .map(|x| x.0)
+                    .unwrap_or(0)
+            })
+    }
+
+    /// Cursor position *in front of* the next word to the right
+    pub fn word_right_start_index(&self) -> usize {
+        self.lines[self.insertion_point..]
+            .split_word_bound_indices()
+            .find(|(i, word)| *i != 0 && !is_whitespace_str(word))
+            .map(|(i, _)| self.insertion_point + i)
+            .unwrap_or_else(|| self.lines.len())
+    }
+
     /// Cursor position *in front of* the next word to the left
     pub fn word_left_index(&self) -> usize {
         self.lines[..self.insertion_point]
@@ -207,6 +236,16 @@ impl LineBuffer {
     /// Move cursor position *behind* the next word to the right
     pub fn move_word_right(&mut self) {
         self.insertion_point = self.word_right_index();
+    }
+
+    /// Move cursor position to the start of the next word
+    pub fn move_word_right_start(&mut self) {
+        self.insertion_point = self.word_right_start_index();
+    }
+
+    /// Move cursor position to the end of the next word
+    pub fn move_word_right_end(&mut self) {
+        self.insertion_point = self.word_right_end_index();
     }
 
     ///Insert a single character at the insertion point and move right

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -37,7 +37,11 @@ where
         }
         Some('w') => {
             let _ = input.next();
-            Some(Command::MoveWordRight)
+            Some(Command::MoveWordRightStart)
+        }
+        Some('e') => {
+            let _ = input.next();
+            Some(Command::MoveWordRightEnd)
         }
         Some('b') => {
             let _ = input.next();
@@ -143,7 +147,8 @@ pub enum Command {
     MoveRight,
     MoveUp,
     MoveDown,
-    MoveWordRight,
+    MoveWordRightStart,
+    MoveWordRightEnd,
     MoveWordLeft,
     MoveToLineStart,
     MoveToLineEnd,
@@ -173,7 +178,8 @@ impl Command {
             Self::MoveToLineStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],
             Self::MoveToLineEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
             Self::MoveWordLeft => vec![ReedlineOption::Edit(EditCommand::MoveWordLeft)],
-            Self::MoveWordRight => vec![ReedlineOption::Edit(EditCommand::MoveWordRight)],
+            Self::MoveWordRightStart => vec![ReedlineOption::Edit(EditCommand::MoveWordRightStart)],
+            Self::MoveWordRightEnd => vec![ReedlineOption::Edit(EditCommand::MoveWordRightEnd)],
             Self::EnterViInsert => vec![ReedlineOption::Event(ReedlineEvent::Repaint)],
             Self::EnterViAppend => vec![ReedlineOption::Edit(EditCommand::MoveRight)],
             Self::PasteAfter => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferAfter)],
@@ -207,7 +213,10 @@ impl Command {
             Self::Delete => match motion {
                 Motion::End => Some(vec![ReedlineOption::Edit(EditCommand::CutToEnd)]),
                 Motion::Line => Some(vec![ReedlineOption::Edit(EditCommand::CutCurrentLine)]),
-                Motion::Word => Some(vec![ReedlineOption::Edit(EditCommand::CutWordRight)]),
+                Motion::NextWord => {
+                    Some(vec![ReedlineOption::Edit(EditCommand::CutWordRightToNext)])
+                }
+                Motion::NextWordEnd => Some(vec![ReedlineOption::Edit(EditCommand::CutWordRight)]),
                 Motion::RightUntil(c) => {
                     Some(vec![ReedlineOption::Edit(EditCommand::CutRightUntil(*c))])
                 }
@@ -232,7 +241,11 @@ impl Command {
                     ReedlineOption::Edit(EditCommand::ClearToLineEnd),
                     ReedlineOption::Event(ReedlineEvent::Repaint),
                 ]),
-                Motion::Word => Some(vec![
+                Motion::NextWord => Some(vec![
+                    ReedlineOption::Edit(EditCommand::CutWordRightToNext),
+                    ReedlineOption::Event(ReedlineEvent::Repaint),
+                ]),
+                Motion::NextWordEnd => Some(vec![
                     ReedlineOption::Edit(EditCommand::CutWordRight),
                     ReedlineOption::Event(ReedlineEvent::Repaint),
                 ]),

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -256,7 +256,7 @@ mod test {
 
         let esc = Event::Key(KeyEvent {
             modifiers: KeyModifiers::NONE,
-            code: KeyCode::Char('e'),
+            code: KeyCode::Char('q'),
         });
         let result = vi.parse_event(esc);
 

--- a/src/edit_mode/vi/motion.rs
+++ b/src/edit_mode/vi/motion.rs
@@ -7,7 +7,11 @@ where
     match input.peek() {
         Some('w') => {
             let _ = input.next();
-            Some(Motion::Word)
+            Some(Motion::NextWord)
+        }
+        Some('e') => {
+            let _ = input.next();
+            Some(Motion::NextWordEnd)
         }
         Some('d') => {
             let _ = input.next();
@@ -43,7 +47,8 @@ where
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Motion {
-    Word,
+    NextWord,
+    NextWordEnd,
     Line,
     Start,
     End,

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -162,7 +162,7 @@ mod tests {
                 multiplier: None,
                 command: Some(Command::Delete),
                 count: None,
-                motion: Some(Motion::Word),
+                motion: Some(Motion::NextWord),
                 valid: true
             }
         );
@@ -179,7 +179,7 @@ mod tests {
                 multiplier: Some(2),
                 command: Some(Command::Delete),
                 count: None,
-                motion: Some(Motion::Word),
+                motion: Some(Motion::NextWord),
                 valid: true
             }
         );
@@ -196,7 +196,7 @@ mod tests {
                 multiplier: Some(2),
                 command: Some(Command::Delete),
                 count: Some(2),
-                motion: Some(Motion::Word),
+                motion: Some(Motion::NextWord),
                 valid: true
             }
         );
@@ -213,7 +213,7 @@ mod tests {
                 multiplier: Some(2),
                 command: Some(Command::Delete),
                 count: Some(20),
-                motion: Some(Motion::Word),
+                motion: Some(Motion::NextWord),
                 valid: true
             }
         );
@@ -300,7 +300,8 @@ mod tests {
         ]))]
     #[case(&['d', 'd'], ReedlineEvent::Multiple(vec![
         ReedlineEvent::Edit(vec![EditCommand::CutCurrentLine])]))]
-    #[case(&['d', 'w'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRight])]))]
+    #[case(&['d', 'w'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRightToNext])]))]
+    #[case(&['d', 'e'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRight])]))]
     fn test_reedline_move(#[case] input: &[char], #[case] expected: ReedlineEvent) {
         let res = vi_parse(input);
         let output = res.to_reedline_event();

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -42,6 +42,12 @@ pub enum EditCommand {
     /// Move one word to the right
     MoveWordRight,
 
+    /// Move one word to the right, stop at start of word
+    MoveWordRightStart,
+
+    /// Move one word to the right, stop at end of word
+    MoveWordRightEnd,
+
     /// Move to position
     MoveToPosition(usize),
 
@@ -101,6 +107,9 @@ pub enum EditCommand {
 
     /// Cut the word right of the insertion point
     CutWordRight,
+
+    /// Cut the word right of the insertion point and any following space
+    CutWordRightToNext,
 
     /// Paste the cut buffer in front of the insertion point (Emacs, vi `P`)
     PasteCutBufferBefore,
@@ -165,6 +174,8 @@ impl Display for EditCommand {
             EditCommand::MoveRight => write!(f, "MoveRight"),
             EditCommand::MoveWordLeft => write!(f, "MoveWordLeft"),
             EditCommand::MoveWordRight => write!(f, "MoveWordRight"),
+            EditCommand::MoveWordRightEnd => write!(f, "MoveWordRightEnd"),
+            EditCommand::MoveWordRightStart => write!(f, "MoveWordRightStart"),
             EditCommand::MoveToPosition(_) => write!(f, "MoveToPosition  Value: <int>"),
             EditCommand::InsertChar(_) => write!(f, "InsertChar  Value: <char>"),
             EditCommand::InsertString(_) => write!(f, "InsertString Value: <string>"),
@@ -184,6 +195,7 @@ impl Display for EditCommand {
             EditCommand::CutToLineEnd => write!(f, "CutToLineEnd"),
             EditCommand::CutWordLeft => write!(f, "CutWordLeft"),
             EditCommand::CutWordRight => write!(f, "CutWordRight"),
+            EditCommand::CutWordRightToNext => write!(f, "CutWordRightToNext"),
             EditCommand::PasteCutBufferBefore => write!(f, "PasteCutBufferBefore"),
             EditCommand::PasteCutBufferAfter => write!(f, "PasteCutBufferAfter"),
             EditCommand::UppercaseWord => write!(f, "UppercaseWord"),
@@ -220,6 +232,8 @@ impl EditCommand {
             | EditCommand::MoveRight
             | EditCommand::MoveWordLeft
             | EditCommand::MoveWordRight
+            | EditCommand::MoveWordRightStart
+            | EditCommand::MoveWordRightEnd
             | EditCommand::MoveRightUntil(_)
             | EditCommand::MoveRightBefore(_)
             | EditCommand::MoveLeftUntil(_)
@@ -246,6 +260,7 @@ impl EditCommand {
             | EditCommand::CutToEnd
             | EditCommand::CutWordLeft
             | EditCommand::CutWordRight
+            | EditCommand::CutWordRightToNext
             | EditCommand::PasteCutBufferBefore
             | EditCommand::PasteCutBufferAfter
             | EditCommand::UppercaseWord


### PR DESCRIPTION
The 'w' motion goes to the beginning of the next word to the right, not
the end. The 'e' motion, which is introduced here, goes to the end, but
lands on the last character, not after it.