### PR TITLE
Do not allocate eagerly for full history capacity

### DIFF
--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -215,7 +215,7 @@ impl FileBackedHistory {
         }
         FileBackedHistory {
             capacity,
-            entries: VecDeque::with_capacity(capacity),
+            entries: VecDeque::new(),
             cursor: 0,
             file: None,
             len_on_disk: 0,


### PR DESCRIPTION
Amortized growing of the history based on the amount read from the file
is cheap. Allocating for the capacity is expensive and can cause OOM for
large capacities.

Fix for nushell/nushell#5593
