### PR TITLE
Organize the common keybindings

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -1,8 +1,11 @@
-use super::{
-    keybindings::{add_common_keybindings, edit_bind, Keybindings},
-    EditMode,
-};
 use crate::{
+    edit_mode::{
+        keybindings::{
+            add_common_control_bindings, add_common_edit_bindings, add_common_navigation_bindings,
+            edit_bind, Keybindings,
+        },
+        EditMode,
+    },
     enums::{EditCommand, ReedlineEvent},
     PromptEditMode,
 };
@@ -15,10 +18,26 @@ pub fn default_emacs_keybindings() -> Keybindings {
     use KeyModifiers as KM;
 
     let mut kb = Keybindings::new();
+    add_common_control_bindings(&mut kb);
+    add_common_navigation_bindings(&mut kb);
+    add_common_edit_bindings(&mut kb);
 
-    // CTRL
-    kb.add_binding(KM::CONTROL, KC::Char('g'), edit_bind(EC::Redo));
-    kb.add_binding(KM::CONTROL, KC::Char('z'), edit_bind(EC::Undo));
+    // *** CTRL ***
+    // Moves
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Char('b'),
+        ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuLeft, ReedlineEvent::Left]),
+    );
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Char('f'),
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::HistoryHintComplete,
+            ReedlineEvent::MenuRight,
+            ReedlineEvent::Right,
+        ]),
+    );
     kb.add_binding(KM::CONTROL, KC::Char('a'), edit_bind(EC::MoveToLineStart));
     kb.add_binding(
         KM::CONTROL,
@@ -28,20 +47,25 @@ pub fn default_emacs_keybindings() -> Keybindings {
             edit_bind(EC::MoveToLineEnd),
         ]),
     );
-    kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToEnd));
-    kb.add_binding(KM::CONTROL, KC::Char('u'), edit_bind(EC::CutFromStart));
+    // Undo/Redo
+    kb.add_binding(KM::CONTROL, KC::Char('g'), edit_bind(EC::Redo));
+    kb.add_binding(KM::CONTROL, KC::Char('z'), edit_bind(EC::Undo));
+    // Cutting
     kb.add_binding(
         KM::CONTROL,
         KC::Char('y'),
         edit_bind(EC::PasteCutBufferBefore),
     );
+    kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
+    kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToEnd));
+    kb.add_binding(KM::CONTROL, KC::Char('u'), edit_bind(EC::CutFromStart));
+    // Edits
     kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
     kb.add_binding(KM::CONTROL, KC::Char('t'), edit_bind(EC::SwapGraphemes));
 
-    // ALT
+    // *** ALT ***
+    // Moves
     kb.add_binding(KM::ALT, KC::Left, edit_bind(EC::MoveWordLeft));
-    kb.add_binding(KM::ALT, KC::Delete, edit_bind(EC::DeleteWord));
-    kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));
     kb.add_binding(
         KM::ALT,
         KC::Right,
@@ -59,17 +83,20 @@ pub fn default_emacs_keybindings() -> Keybindings {
             edit_bind(EC::MoveWordRight),
         ]),
     );
-    kb.add_binding(KM::ALT, KC::Char('d'), edit_bind(EC::CutWordRight));
-    kb.add_binding(KM::ALT, KC::Char('u'), edit_bind(EC::UppercaseWord));
-    kb.add_binding(KM::ALT, KC::Char('l'), edit_bind(EC::LowercaseWord));
-    kb.add_binding(KM::ALT, KC::Char('c'), edit_bind(EC::CapitalizeChar));
+    // Edits
+    kb.add_binding(KM::ALT, KC::Delete, edit_bind(EC::DeleteWord));
+    kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));
     kb.add_binding(
         KM::ALT,
         KC::Char('m'),
         ReedlineEvent::Edit(vec![EditCommand::BackspaceWord]),
     );
-
-    add_common_keybindings(&mut kb);
+    // Cutting
+    kb.add_binding(KM::ALT, KC::Char('d'), edit_bind(EC::CutWordRight));
+    // Case changes
+    kb.add_binding(KM::ALT, KC::Char('u'), edit_bind(EC::UppercaseWord));
+    kb.add_binding(KM::ALT, KC::Char('l'), edit_bind(EC::LowercaseWord));
+    kb.add_binding(KM::ALT, KC::Char('c'), edit_bind(EC::CapitalizeChar));
 
     kb
 }

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -87,42 +87,29 @@ pub fn edit_bind(command: EditCommand) -> ReedlineEvent {
     ReedlineEvent::Edit(vec![command])
 }
 
-pub fn add_common_keybindings(kb: &mut Keybindings) {
-    use EditCommand as EC;
+/// Add the basic special keybindings
+///
+/// `Ctrl-C`, `Ctrl-D`, `Ctrl-O`, `Ctrl-R`
+/// + `Esc`
+/// + `Ctrl-O` to open the external editor
+pub fn add_common_control_bindings(kb: &mut Keybindings) {
     use KeyCode as KC;
     use KeyModifiers as KM;
 
     kb.add_binding(KM::NONE, KC::Esc, ReedlineEvent::Esc);
-    kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::Backspace));
-    kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
-    kb.add_binding(
-        KM::NONE,
-        KC::End,
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::HistoryHintComplete,
-            edit_bind(EC::MoveToLineEnd),
-        ]),
-    );
-    kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToLineStart));
-
     kb.add_binding(KM::CONTROL, KC::Char('c'), ReedlineEvent::CtrlC);
     kb.add_binding(KM::CONTROL, KC::Char('d'), ReedlineEvent::CtrlD);
     kb.add_binding(KM::CONTROL, KC::Char('l'), ReedlineEvent::ClearScreen);
     kb.add_binding(KM::CONTROL, KC::Char('r'), ReedlineEvent::SearchHistory);
+    kb.add_binding(KM::CONTROL, KC::Char('o'), ReedlineEvent::OpenEditor);
+}
+/// Add the arrow navigation and its `Ctrl` variants
+pub fn add_common_navigation_bindings(kb: &mut Keybindings) {
+    use EditCommand as EC;
+    use KeyCode as KC;
+    use KeyModifiers as KM;
 
-    kb.add_binding(
-        KM::CONTROL,
-        KC::Right,
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::HistoryHintWordComplete,
-            edit_bind(EC::MoveWordRight),
-        ]),
-    );
-    kb.add_binding(KM::CONTROL, KC::Left, edit_bind(EC::MoveWordLeft));
-    kb.add_binding(KM::CONTROL, KC::Backspace, edit_bind(EC::BackspaceWord));
-    kb.add_binding(KM::CONTROL, KC::Delete, edit_bind(EC::DeleteWord));
-    kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
-
+    // Arrow keys without modifier
     kb.add_binding(
         KM::NONE,
         KC::Up,
@@ -148,20 +135,30 @@ pub fn add_common_keybindings(kb: &mut Keybindings) {
         ]),
     );
 
+    // Ctrl Left and Right
+    kb.add_binding(KM::CONTROL, KC::Left, edit_bind(EC::MoveWordLeft));
     kb.add_binding(
         KM::CONTROL,
-        KC::Char('b'),
-        ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuLeft, ReedlineEvent::Left]),
-    );
-    kb.add_binding(
-        KM::CONTROL,
-        KC::Char('f'),
+        KC::Right,
         ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::HistoryHintComplete,
-            ReedlineEvent::MenuRight,
-            ReedlineEvent::Right,
+            ReedlineEvent::HistoryHintWordComplete,
+            edit_bind(EC::MoveWordRight),
         ]),
     );
+    // Home/End
+    kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToLineStart));
+    kb.add_binding(
+        KM::NONE,
+        KC::End,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::HistoryHintComplete,
+            edit_bind(EC::MoveToLineEnd),
+        ]),
+    );
+    // Ctrl Home/End
+    kb.add_binding(KM::CONTROL, KC::Home, edit_bind(EC::MoveToStart));
+    kb.add_binding(KM::CONTROL, KC::End, edit_bind(EC::MoveToEnd));
+    // EMACS arrows
     kb.add_binding(
         KM::CONTROL,
         KC::Char('p'),
@@ -172,5 +169,19 @@ pub fn add_common_keybindings(kb: &mut Keybindings) {
         KC::Char('n'),
         ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuDown, ReedlineEvent::Down]),
     );
-    kb.add_binding(KM::CONTROL, KC::Char('o'), ReedlineEvent::OpenEditor);
+}
+
+/// Add basic functionality to edit
+///
+/// `Delete`, `Backspace` and the basic variants do delete words
+pub fn add_common_edit_bindings(kb: &mut Keybindings) {
+    use EditCommand as EC;
+    use KeyCode as KC;
+    use KeyModifiers as KM;
+    kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::Backspace));
+    kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
+    kb.add_binding(KM::CONTROL, KC::Backspace, edit_bind(EC::BackspaceWord));
+    kb.add_binding(KM::CONTROL, KC::Delete, edit_bind(EC::DeleteWord));
+    // Base commands should not affect cut buffer
+    kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::DeleteWord));
 }

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -1,36 +1,28 @@
-use crate::{
-    edit_mode::{keybindings::add_common_keybindings, Keybindings},
-    ReedlineEvent,
-};
+use crossterm::event::{KeyCode, KeyModifiers};
 
-use crossterm::event::{KeyCode as KC, KeyModifiers as KM};
+use crate::{
+    edit_mode::{
+        keybindings::{
+            add_common_control_bindings, add_common_edit_bindings, add_common_navigation_bindings,
+            edit_bind,
+        },
+        Keybindings,
+    },
+    EditCommand,
+};
 
 /// Default Vi normal keybindings
 pub fn default_vi_normal_keybindings() -> Keybindings {
     let mut kb = Keybindings::new();
+    use EditCommand as EC;
+    use KeyCode as KC;
+    use KeyModifiers as KM;
 
-    kb.add_binding(KM::CONTROL, KC::Char('c'), ReedlineEvent::CtrlC);
-    kb.add_binding(KM::CONTROL, KC::Char('l'), ReedlineEvent::ClearScreen);
-    kb.add_binding(
-        KM::NONE,
-        KC::Up,
-        ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuUp, ReedlineEvent::Up]),
-    );
-    kb.add_binding(
-        KM::NONE,
-        KC::Down,
-        ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuDown, ReedlineEvent::Down]),
-    );
-    kb.add_binding(
-        KM::NONE,
-        KC::Left,
-        ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuLeft, ReedlineEvent::Left]),
-    );
-    kb.add_binding(
-        KM::NONE,
-        KC::Right,
-        ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuRight, ReedlineEvent::Right]),
-    );
+    add_common_control_bindings(&mut kb);
+    add_common_navigation_bindings(&mut kb);
+    // Replicate vi's default behavior for Backspace and delete
+    kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::MoveLeft));
+    kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
 
     kb
 }
@@ -39,7 +31,9 @@ pub fn default_vi_normal_keybindings() -> Keybindings {
 pub fn default_vi_insert_keybindings() -> Keybindings {
     let mut kb = Keybindings::new();
 
-    add_common_keybindings(&mut kb);
+    add_common_control_bindings(&mut kb);
+    add_common_navigation_bindings(&mut kb);
+    add_common_edit_bindings(&mut kb);
 
     kb
 }


### PR DESCRIPTION
Group the common keybindings into three functions:
- `add_common_control_bindings`
- `add_common_navigation_bindings`
- `add_common_edit_bindings`

Vi normal uses the first two
Vi insert uses all of them

Emacs extends upon those
