### PR TITLE
Don't panic when parent directory does not exist

### DIFF
--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -137,6 +137,11 @@ impl History for FileBackedHistory {
             // The unwritten entries
             let own_entries = self.entries.range(self.len_on_disk..);
 
+            let parent = fname.parent().expect("history path shouldn't be '/'");
+            if !parent.exists() {
+                std::fs::create_dir_all(parent)?;
+            }
+
             let mut f_lock = fd_lock::RwLock::new(
                 OpenOptions::new()
                     .create(true)

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -137,9 +137,8 @@ impl History for FileBackedHistory {
             // The unwritten entries
             let own_entries = self.entries.range(self.len_on_disk..);
 
-            let parent = fname.parent().expect("history path shouldn't be '/'");
-            if !parent.exists() {
-                std::fs::create_dir_all(parent)?;
+            if let Some(base_dir) = fname.parent() {
+                std::fs::create_dir_all(base_dir)?;
             }
 
             let mut f_lock = fd_lock::RwLock::new(


### PR DESCRIPTION
Relative: https://github.com/nushell/nushell/issues/5203

After investigate, I think `nu` will crash is because history file's parent is deleted, and it leads to file sync operation failed.

Refer to the expected behavior in that issue:

> I expected nu to ask to recreate the missing config files, like it did on first start.

I think that's too complicated to implement such feature, instead, we can make `nu` work as normal (because config is loaded to memory), we just need to create that missing directory.