### PR TITLE
Expose the `History` query functionality

### DIFF
--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use chrono::Utc;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
+/// Unique ID for the [`HistoryItem`]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct HistoryItemId(pub(crate) i64);
 impl HistoryItemId {
@@ -10,6 +11,8 @@ impl HistoryItemId {
         HistoryItemId(i)
     }
 }
+
+/// Unique ID for the session in which reedline was run to disambiguate different sessions
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct HistorySessionId(pub(crate) i64);
 impl HistorySessionId {

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -7,7 +7,9 @@ mod sqlite_backed;
 #[cfg(feature = "sqlite")]
 pub use sqlite_backed::SqliteBackedHistory;
 
-pub use base::{History, HistoryNavigationQuery, SearchDirection, SearchFilter, SearchQuery};
+pub use base::{
+    CommandLineSearch, History, HistoryNavigationQuery, SearchDirection, SearchFilter, SearchQuery,
+};
 pub use cursor::HistoryCursor;
 pub use item::{HistoryItem, HistoryItemId, HistorySessionId};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,11 @@ pub(crate) use result::Result;
 mod history;
 #[cfg(feature = "sqlite")]
 pub use history::SqliteBackedHistory;
-pub use history::{FileBackedHistory, History, HistoryItem, HistoryNavigationQuery, HISTORY_SIZE};
+pub use history::{
+    CommandLineSearch, FileBackedHistory, History, HistoryItem, HistoryItemId,
+    HistoryNavigationQuery, HistorySessionId, SearchDirection, SearchFilter, SearchQuery,
+    HISTORY_SIZE,
+};
 
 mod prompt;
 pub use prompt::{


### PR DESCRIPTION
Makes the history querying structs and enums pub as it seems reasonable
for now. Useful to create nushells `history` command.

Might make sense to change that API to something simpler cleaner later.

Relevant to nushell/nushell#5721
