### PR TITLE
Add vi WORD motions B, E, W

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +253,15 @@ name = "io-lifetimes"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9448015e586b611e5d322f6703812bbca2f1e709d5773ecd38ddb4e3bb649504"
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -479,6 +494,7 @@ dependencies = [
  "crossterm",
  "fd-lock",
  "gethostname",
+ "itertools",
  "nu-ansi-term",
  "pretty_assertions",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 chrono = "0.4.19"
 clipboard = { version = "0.5.0", optional = true }
 crossterm = { version = "0.23.0", features = ["serde"] }
+itertools = "0.10.3"
 nu-ansi-term = "0.46.0"
 serde = { version = "1.0", features = ["derive"] }
 unicode-segmentation = "1.9.0"

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -46,6 +46,7 @@ impl Editor {
             EditCommand::MoveWordLeft => self.line_buffer.move_word_left(),
             EditCommand::MoveWordRight => self.line_buffer.move_word_right(),
             EditCommand::MoveWordRightStart => self.line_buffer.move_word_right_start(),
+            EditCommand::MoveBigWordRightStart => self.line_buffer.move_big_word_right_start(),
             EditCommand::MoveWordRightEnd => self.line_buffer.move_word_right_end(),
             EditCommand::InsertChar(c) => self.insert_char(*c),
             EditCommand::InsertString(str) => self.line_buffer.insert_str(str),
@@ -66,6 +67,7 @@ impl Editor {
             EditCommand::CutWordLeft => self.cut_word_left(),
             EditCommand::CutWordRight => self.cut_word_right(),
             EditCommand::CutWordRightToNext => self.cut_word_right_to_next(),
+            EditCommand::CutBigWordRightToNext => self.cut_big_word_right_to_next(),
             EditCommand::PasteCutBufferBefore => self.insert_cut_buffer_before(),
             EditCommand::PasteCutBufferAfter => self.insert_cut_buffer_after(),
             EditCommand::UppercaseWord => self.line_buffer.uppercase_word(),
@@ -278,6 +280,19 @@ impl Editor {
     fn cut_word_right_to_next(&mut self) {
         let insertion_offset = self.line_buffer.insertion_point();
         let right_index = self.line_buffer.word_right_start_index();
+        if right_index > insertion_offset {
+            let cut_range = insertion_offset..right_index;
+            self.cut_buffer.set(
+                &self.line_buffer.get_buffer()[cut_range.clone()],
+                ClipboardMode::Normal,
+            );
+            self.clear_range(cut_range);
+        }
+    }
+
+    fn cut_big_word_right_to_next(&mut self) {
+        let insertion_offset = self.line_buffer.insertion_point();
+        let right_index = self.line_buffer.big_word_right_start_index();
         if right_index > insertion_offset {
             let cut_range = insertion_offset..right_index;
             self.cut_buffer.set(

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -49,6 +49,7 @@ impl Editor {
             EditCommand::MoveWordRightStart => self.line_buffer.move_word_right_start(),
             EditCommand::MoveBigWordRightStart => self.line_buffer.move_big_word_right_start(),
             EditCommand::MoveWordRightEnd => self.line_buffer.move_word_right_end(),
+            EditCommand::MoveBigWordRightEnd => self.line_buffer.move_big_word_right_end(),
             EditCommand::InsertChar(c) => self.insert_char(*c),
             EditCommand::InsertString(str) => self.line_buffer.insert_str(str),
             EditCommand::InsertNewline => self.line_buffer.insert_newline(),
@@ -68,6 +69,7 @@ impl Editor {
             EditCommand::CutWordLeft => self.cut_word_left(),
             EditCommand::CutBigWordLeft => self.cut_big_word_left(),
             EditCommand::CutWordRight => self.cut_word_right(),
+            EditCommand::CutBigWordRight => self.cut_big_word_right(),
             EditCommand::CutWordRightToNext => self.cut_word_right_to_next(),
             EditCommand::CutBigWordRightToNext => self.cut_big_word_right_to_next(),
             EditCommand::PasteCutBufferBefore => self.insert_cut_buffer_before(),
@@ -283,6 +285,19 @@ impl Editor {
     fn cut_word_right(&mut self) {
         let insertion_offset = self.line_buffer.insertion_point();
         let right_index = self.line_buffer.word_right_index();
+        if right_index > insertion_offset {
+            let cut_range = insertion_offset..right_index;
+            self.cut_buffer.set(
+                &self.line_buffer.get_buffer()[cut_range.clone()],
+                ClipboardMode::Normal,
+            );
+            self.clear_range(cut_range);
+        }
+    }
+
+    fn cut_big_word_right(&mut self) {
+        let insertion_offset = self.line_buffer.insertion_point();
+        let right_index = self.line_buffer.next_whitespace();
         if right_index > insertion_offset {
             let cut_range = insertion_offset..right_index;
             self.cut_buffer.set(

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -44,6 +44,7 @@ impl Editor {
             EditCommand::MoveLeft => self.line_buffer.move_left(),
             EditCommand::MoveRight => self.line_buffer.move_right(),
             EditCommand::MoveWordLeft => self.line_buffer.move_word_left(),
+            EditCommand::MoveBigWordLeft => self.line_buffer.move_big_word_left(),
             EditCommand::MoveWordRight => self.line_buffer.move_word_right(),
             EditCommand::MoveWordRightStart => self.line_buffer.move_word_right_start(),
             EditCommand::MoveBigWordRightStart => self.line_buffer.move_big_word_right_start(),
@@ -65,6 +66,7 @@ impl Editor {
             EditCommand::CutToEnd => self.cut_from_end(),
             EditCommand::CutToLineEnd => self.cut_to_line_end(),
             EditCommand::CutWordLeft => self.cut_word_left(),
+            EditCommand::CutBigWordLeft => self.cut_big_word_left(),
             EditCommand::CutWordRight => self.cut_word_right(),
             EditCommand::CutWordRightToNext => self.cut_word_right_to_next(),
             EditCommand::CutBigWordRightToNext => self.cut_big_word_right_to_next(),
@@ -264,6 +266,20 @@ impl Editor {
         }
     }
 
+    fn cut_big_word_left(&mut self) {
+        let insertion_offset = self.line_buffer.insertion_point();
+        let left_index = self.line_buffer.big_word_left_index();
+        if left_index < insertion_offset {
+            let cut_range = left_index..insertion_offset;
+            self.cut_buffer.set(
+                &self.line_buffer.get_buffer()[cut_range.clone()],
+                ClipboardMode::Normal,
+            );
+            self.clear_range(cut_range);
+            self.line_buffer.set_insertion_point(left_index);
+        }
+    }
+
     fn cut_word_right(&mut self) {
         let insertion_offset = self.line_buffer.insertion_point();
         let right_index = self.line_buffer.word_right_index();
@@ -421,11 +437,43 @@ impl Editor {
 #[cfg(test)]
 mod test {
     use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
 
     fn editor_with(buffer: &str) -> Editor {
         let mut editor = Editor::default();
         editor.line_buffer.set_buffer(buffer.to_string());
         editor
+    }
+
+    #[rstest]
+    #[case("abc def ghi", 11, "abc def ")]
+    #[case("abc def-ghi", 11, "abc def-")]
+    #[case("abc def.ghi", 11, "abc ")]
+    fn test_cut_word_left(#[case] input: &str, #[case] position: usize, #[case] expected: &str) {
+        let mut editor = editor_with(input);
+        editor.set_insertion_point(position);
+
+        editor.cut_word_left();
+
+        assert_eq!(editor.get_buffer(), expected);
+    }
+
+    #[rstest]
+    #[case("abc def ghi", 11, "abc def ")]
+    #[case("abc def-ghi", 11, "abc ")]
+    #[case("abc def.ghi", 11, "abc ")]
+    fn test_cut_big_word_left(
+        #[case] input: &str,
+        #[case] position: usize,
+        #[case] expected: &str,
+    ) {
+        let mut editor = editor_with(input);
+        editor.set_insertion_point(position);
+
+        editor.cut_big_word_left();
+
+        assert_eq!(editor.get_buffer(), expected);
     }
 
     fn str_to_edit_commands(s: &str) -> Vec<EditCommand> {

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -39,6 +39,10 @@ where
             let _ = input.next();
             Some(Command::MoveWordRightStart)
         }
+        Some('W') => {
+            let _ = input.next();
+            Some(Command::MoveBigWordRightStart)
+        }
         Some('e') => {
             let _ = input.next();
             Some(Command::MoveWordRightEnd)
@@ -148,6 +152,7 @@ pub enum Command {
     MoveUp,
     MoveDown,
     MoveWordRightStart,
+    MoveBigWordRightStart,
     MoveWordRightEnd,
     MoveWordLeft,
     MoveToLineStart,
@@ -179,6 +184,9 @@ impl Command {
             Self::MoveToLineEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
             Self::MoveWordLeft => vec![ReedlineOption::Edit(EditCommand::MoveWordLeft)],
             Self::MoveWordRightStart => vec![ReedlineOption::Edit(EditCommand::MoveWordRightStart)],
+            Self::MoveBigWordRightStart => {
+                vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightStart)]
+            }
             Self::MoveWordRightEnd => vec![ReedlineOption::Edit(EditCommand::MoveWordRightEnd)],
             Self::EnterViInsert => vec![ReedlineOption::Event(ReedlineEvent::Repaint)],
             Self::EnterViAppend => vec![ReedlineOption::Edit(EditCommand::MoveRight)],
@@ -216,6 +224,9 @@ impl Command {
                 Motion::NextWord => {
                     Some(vec![ReedlineOption::Edit(EditCommand::CutWordRightToNext)])
                 }
+                Motion::NextBigWord => Some(vec![ReedlineOption::Edit(
+                    EditCommand::CutBigWordRightToNext,
+                )]),
                 Motion::NextWordEnd => Some(vec![ReedlineOption::Edit(EditCommand::CutWordRight)]),
                 Motion::RightUntil(c) => {
                     Some(vec![ReedlineOption::Edit(EditCommand::CutRightUntil(*c))])
@@ -243,6 +254,10 @@ impl Command {
                 ]),
                 Motion::NextWord => Some(vec![
                     ReedlineOption::Edit(EditCommand::CutWordRightToNext),
+                    ReedlineOption::Event(ReedlineEvent::Repaint),
+                ]),
+                Motion::NextBigWord => Some(vec![
+                    ReedlineOption::Edit(EditCommand::CutBigWordRightToNext),
                     ReedlineOption::Event(ReedlineEvent::Repaint),
                 ]),
                 Motion::NextWordEnd => Some(vec![

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -47,6 +47,10 @@ where
             let _ = input.next();
             Some(Command::MoveWordRightEnd)
         }
+        Some('E') => {
+            let _ = input.next();
+            Some(Command::MoveBigWordRightEnd)
+        }
         Some('b') => {
             let _ = input.next();
             Some(Command::MoveWordLeft)
@@ -158,6 +162,7 @@ pub enum Command {
     MoveWordRightStart,
     MoveBigWordRightStart,
     MoveWordRightEnd,
+    MoveBigWordRightEnd,
     MoveWordLeft,
     MoveBigWordLeft,
     MoveToLineStart,
@@ -194,6 +199,9 @@ impl Command {
                 vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightStart)]
             }
             Self::MoveWordRightEnd => vec![ReedlineOption::Edit(EditCommand::MoveWordRightEnd)],
+            Self::MoveBigWordRightEnd => {
+                vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightEnd)]
+            }
             Self::EnterViInsert => vec![ReedlineOption::Event(ReedlineEvent::Repaint)],
             Self::EnterViAppend => vec![ReedlineOption::Edit(EditCommand::MoveRight)],
             Self::PasteAfter => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferAfter)],
@@ -234,6 +242,9 @@ impl Command {
                     EditCommand::CutBigWordRightToNext,
                 )]),
                 Motion::NextWordEnd => Some(vec![ReedlineOption::Edit(EditCommand::CutWordRight)]),
+                Motion::NextBigWordEnd => {
+                    Some(vec![ReedlineOption::Edit(EditCommand::CutBigWordRight)])
+                }
                 Motion::PreviousWord => Some(vec![ReedlineOption::Edit(EditCommand::CutWordLeft)]),
                 Motion::PreviousBigWord => {
                     Some(vec![ReedlineOption::Edit(EditCommand::CutBigWordLeft)])
@@ -272,6 +283,10 @@ impl Command {
                 ]),
                 Motion::NextWordEnd => Some(vec![
                     ReedlineOption::Edit(EditCommand::CutWordRight),
+                    ReedlineOption::Event(ReedlineEvent::Repaint),
+                ]),
+                Motion::NextBigWordEnd => Some(vec![
+                    ReedlineOption::Edit(EditCommand::CutBigWordRight),
                     ReedlineOption::Event(ReedlineEvent::Repaint),
                 ]),
                 Motion::PreviousWord => Some(vec![

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -51,6 +51,10 @@ where
             let _ = input.next();
             Some(Command::MoveWordLeft)
         }
+        Some('B') => {
+            let _ = input.next();
+            Some(Command::MoveBigWordLeft)
+        }
         Some('i') => {
             let _ = input.next();
             Some(Command::EnterViInsert)
@@ -155,6 +159,7 @@ pub enum Command {
     MoveBigWordRightStart,
     MoveWordRightEnd,
     MoveWordLeft,
+    MoveBigWordLeft,
     MoveToLineStart,
     MoveToLineEnd,
     EnterViAppend,
@@ -183,6 +188,7 @@ impl Command {
             Self::MoveToLineStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],
             Self::MoveToLineEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
             Self::MoveWordLeft => vec![ReedlineOption::Edit(EditCommand::MoveWordLeft)],
+            Self::MoveBigWordLeft => vec![ReedlineOption::Edit(EditCommand::MoveBigWordLeft)],
             Self::MoveWordRightStart => vec![ReedlineOption::Edit(EditCommand::MoveWordRightStart)],
             Self::MoveBigWordRightStart => {
                 vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightStart)]
@@ -228,6 +234,10 @@ impl Command {
                     EditCommand::CutBigWordRightToNext,
                 )]),
                 Motion::NextWordEnd => Some(vec![ReedlineOption::Edit(EditCommand::CutWordRight)]),
+                Motion::PreviousWord => Some(vec![ReedlineOption::Edit(EditCommand::CutWordLeft)]),
+                Motion::PreviousBigWord => {
+                    Some(vec![ReedlineOption::Edit(EditCommand::CutBigWordLeft)])
+                }
                 Motion::RightUntil(c) => {
                     Some(vec![ReedlineOption::Edit(EditCommand::CutRightUntil(*c))])
                 }
@@ -262,6 +272,14 @@ impl Command {
                 ]),
                 Motion::NextWordEnd => Some(vec![
                     ReedlineOption::Edit(EditCommand::CutWordRight),
+                    ReedlineOption::Event(ReedlineEvent::Repaint),
+                ]),
+                Motion::PreviousWord => Some(vec![
+                    ReedlineOption::Edit(EditCommand::CutWordLeft),
+                    ReedlineOption::Event(ReedlineEvent::Repaint),
+                ]),
+                Motion::PreviousBigWord => Some(vec![
+                    ReedlineOption::Edit(EditCommand::CutBigWordLeft),
                     ReedlineOption::Event(ReedlineEvent::Repaint),
                 ]),
                 Motion::RightUntil(c) => Some(vec![

--- a/src/edit_mode/vi/motion.rs
+++ b/src/edit_mode/vi/motion.rs
@@ -5,6 +5,14 @@ where
     I: Iterator<Item = &'iter char>,
 {
     match input.peek() {
+        Some('b') => {
+            let _ = input.next();
+            Some(Motion::PreviousWord)
+        }
+        Some('B') => {
+            let _ = input.next();
+            Some(Motion::PreviousBigWord)
+        }
         Some('w') => {
             let _ = input.next();
             Some(Motion::NextWord)
@@ -54,6 +62,8 @@ pub enum Motion {
     NextWord,
     NextBigWord,
     NextWordEnd,
+    PreviousWord,
+    PreviousBigWord,
     Line,
     Start,
     End,

--- a/src/edit_mode/vi/motion.rs
+++ b/src/edit_mode/vi/motion.rs
@@ -25,6 +25,10 @@ where
             let _ = input.next();
             Some(Motion::NextWordEnd)
         }
+        Some('E') => {
+            let _ = input.next();
+            Some(Motion::NextBigWordEnd)
+        }
         Some('d') => {
             let _ = input.next();
             Some(Motion::Line)
@@ -62,6 +66,7 @@ pub enum Motion {
     NextWord,
     NextBigWord,
     NextWordEnd,
+    NextBigWordEnd,
     PreviousWord,
     PreviousBigWord,
     Line,

--- a/src/edit_mode/vi/motion.rs
+++ b/src/edit_mode/vi/motion.rs
@@ -9,6 +9,10 @@ where
             let _ = input.next();
             Some(Motion::NextWord)
         }
+        Some('W') => {
+            let _ = input.next();
+            Some(Motion::NextBigWord)
+        }
         Some('e') => {
             let _ = input.next();
             Some(Motion::NextWordEnd)
@@ -48,6 +52,7 @@ where
 #[derive(Debug, PartialEq, Eq)]
 pub enum Motion {
     NextWord,
+    NextBigWord,
     NextWordEnd,
     Line,
     Start,

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -307,6 +307,8 @@ mod tests {
     #[case(&['d', 'w'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRightToNext])]))]
     #[case(&['d', 'W'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutBigWordRightToNext])]))]
     #[case(&['d', 'e'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRight])]))]
+    #[case(&['d', 'b'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordLeft])]))]
+    #[case(&['d', 'B'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutBigWordLeft])]))]
     fn test_reedline_move(#[case] input: &[char], #[case] expected: ReedlineEvent) {
         let res = vi_parse(input);
         let output = res.to_reedline_event();

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -273,6 +273,10 @@ mod tests {
     #[rstest]
     #[case(&['2', 'k'], ReedlineEvent::Multiple(vec![ReedlineEvent::Up, ReedlineEvent::Up]))]
     #[case(&['k'], ReedlineEvent::Multiple(vec![ReedlineEvent::Up]))]
+    #[case(&['w'],
+        ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveWordRightStart])]))]
+    #[case(&['W'],
+        ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveBigWordRightStart])]))]
     #[case(&['2', 'j'], ReedlineEvent::Multiple(vec![ReedlineEvent::Down, ReedlineEvent::Down]))]
     #[case(&['j'], ReedlineEvent::Multiple(vec![ReedlineEvent::Down]))]
     #[case(&['2', 'l'], ReedlineEvent::Multiple(vec![
@@ -301,6 +305,7 @@ mod tests {
     #[case(&['d', 'd'], ReedlineEvent::Multiple(vec![
         ReedlineEvent::Edit(vec![EditCommand::CutCurrentLine])]))]
     #[case(&['d', 'w'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRightToNext])]))]
+    #[case(&['d', 'W'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutBigWordRightToNext])]))]
     #[case(&['d', 'e'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRight])]))]
     fn test_reedline_move(#[case] input: &[char], #[case] expected: ReedlineEvent) {
         let res = vi_parse(input);

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -45,6 +45,9 @@ pub enum EditCommand {
     /// Move one word to the right, stop at start of word
     MoveWordRightStart,
 
+    /// Move one WORD to the right, stop at start of WORD
+    MoveBigWordRightStart,
+
     /// Move one word to the right, stop at end of word
     MoveWordRightEnd,
 
@@ -111,6 +114,9 @@ pub enum EditCommand {
     /// Cut the word right of the insertion point and any following space
     CutWordRightToNext,
 
+    /// Cut the WORD right of the insertion point and any following space
+    CutBigWordRightToNext,
+
     /// Paste the cut buffer in front of the insertion point (Emacs, vi `P`)
     PasteCutBufferBefore,
 
@@ -176,6 +182,7 @@ impl Display for EditCommand {
             EditCommand::MoveWordRight => write!(f, "MoveWordRight"),
             EditCommand::MoveWordRightEnd => write!(f, "MoveWordRightEnd"),
             EditCommand::MoveWordRightStart => write!(f, "MoveWordRightStart"),
+            EditCommand::MoveBigWordRightStart => write!(f, "MoveBigWordRightStart"),
             EditCommand::MoveToPosition(_) => write!(f, "MoveToPosition  Value: <int>"),
             EditCommand::InsertChar(_) => write!(f, "InsertChar  Value: <char>"),
             EditCommand::InsertString(_) => write!(f, "InsertString Value: <string>"),
@@ -196,6 +203,7 @@ impl Display for EditCommand {
             EditCommand::CutWordLeft => write!(f, "CutWordLeft"),
             EditCommand::CutWordRight => write!(f, "CutWordRight"),
             EditCommand::CutWordRightToNext => write!(f, "CutWordRightToNext"),
+            EditCommand::CutBigWordRightToNext => write!(f, "CutBigWordRightToNext"),
             EditCommand::PasteCutBufferBefore => write!(f, "PasteCutBufferBefore"),
             EditCommand::PasteCutBufferAfter => write!(f, "PasteCutBufferAfter"),
             EditCommand::UppercaseWord => write!(f, "UppercaseWord"),
@@ -233,6 +241,7 @@ impl EditCommand {
             | EditCommand::MoveWordLeft
             | EditCommand::MoveWordRight
             | EditCommand::MoveWordRightStart
+            | EditCommand::MoveBigWordRightStart
             | EditCommand::MoveWordRightEnd
             | EditCommand::MoveRightUntil(_)
             | EditCommand::MoveRightBefore(_)
@@ -261,6 +270,7 @@ impl EditCommand {
             | EditCommand::CutWordLeft
             | EditCommand::CutWordRight
             | EditCommand::CutWordRightToNext
+            | EditCommand::CutBigWordRightToNext
             | EditCommand::PasteCutBufferBefore
             | EditCommand::PasteCutBufferAfter
             | EditCommand::UppercaseWord

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -39,6 +39,9 @@ pub enum EditCommand {
     /// Move one word to the left
     MoveWordLeft,
 
+    /// Move one WORD to the left
+    MoveBigWordLeft,
+
     /// Move one word to the right
     MoveWordRight,
 
@@ -107,6 +110,9 @@ pub enum EditCommand {
 
     /// Cut the word left of the insertion point
     CutWordLeft,
+
+    /// Cut the WORD left of the insertion point
+    CutBigWordLeft,
 
     /// Cut the word right of the insertion point
     CutWordRight,
@@ -179,6 +185,7 @@ impl Display for EditCommand {
             EditCommand::MoveLeft => write!(f, "MoveLeft"),
             EditCommand::MoveRight => write!(f, "MoveRight"),
             EditCommand::MoveWordLeft => write!(f, "MoveWordLeft"),
+            EditCommand::MoveBigWordLeft => write!(f, "MoveBigWordLeft"),
             EditCommand::MoveWordRight => write!(f, "MoveWordRight"),
             EditCommand::MoveWordRightEnd => write!(f, "MoveWordRightEnd"),
             EditCommand::MoveWordRightStart => write!(f, "MoveWordRightStart"),
@@ -201,6 +208,7 @@ impl Display for EditCommand {
             EditCommand::CutToEnd => write!(f, "CutToEnd"),
             EditCommand::CutToLineEnd => write!(f, "CutToLineEnd"),
             EditCommand::CutWordLeft => write!(f, "CutWordLeft"),
+            EditCommand::CutBigWordLeft => write!(f, "CutBigWordLeft"),
             EditCommand::CutWordRight => write!(f, "CutWordRight"),
             EditCommand::CutWordRightToNext => write!(f, "CutWordRightToNext"),
             EditCommand::CutBigWordRightToNext => write!(f, "CutBigWordRightToNext"),
@@ -239,6 +247,7 @@ impl EditCommand {
             | EditCommand::MoveLeft
             | EditCommand::MoveRight
             | EditCommand::MoveWordLeft
+            | EditCommand::MoveBigWordLeft
             | EditCommand::MoveWordRight
             | EditCommand::MoveWordRightStart
             | EditCommand::MoveBigWordRightStart
@@ -268,6 +277,7 @@ impl EditCommand {
             | EditCommand::CutToLineEnd
             | EditCommand::CutToEnd
             | EditCommand::CutWordLeft
+            | EditCommand::CutBigWordLeft
             | EditCommand::CutWordRight
             | EditCommand::CutWordRightToNext
             | EditCommand::CutBigWordRightToNext

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -54,6 +54,9 @@ pub enum EditCommand {
     /// Move one word to the right, stop at end of word
     MoveWordRightEnd,
 
+    /// Move one WORD to the right, stop at end of WORD
+    MoveBigWordRightEnd,
+
     /// Move to position
     MoveToPosition(usize),
 
@@ -116,6 +119,9 @@ pub enum EditCommand {
 
     /// Cut the word right of the insertion point
     CutWordRight,
+
+    /// Cut the word right of the insertion point
+    CutBigWordRight,
 
     /// Cut the word right of the insertion point and any following space
     CutWordRightToNext,
@@ -188,6 +194,7 @@ impl Display for EditCommand {
             EditCommand::MoveBigWordLeft => write!(f, "MoveBigWordLeft"),
             EditCommand::MoveWordRight => write!(f, "MoveWordRight"),
             EditCommand::MoveWordRightEnd => write!(f, "MoveWordRightEnd"),
+            EditCommand::MoveBigWordRightEnd => write!(f, "MoveBigWordRightEnd"),
             EditCommand::MoveWordRightStart => write!(f, "MoveWordRightStart"),
             EditCommand::MoveBigWordRightStart => write!(f, "MoveBigWordRightStart"),
             EditCommand::MoveToPosition(_) => write!(f, "MoveToPosition  Value: <int>"),
@@ -210,6 +217,7 @@ impl Display for EditCommand {
             EditCommand::CutWordLeft => write!(f, "CutWordLeft"),
             EditCommand::CutBigWordLeft => write!(f, "CutBigWordLeft"),
             EditCommand::CutWordRight => write!(f, "CutWordRight"),
+            EditCommand::CutBigWordRight => write!(f, "CutBigWordRight"),
             EditCommand::CutWordRightToNext => write!(f, "CutWordRightToNext"),
             EditCommand::CutBigWordRightToNext => write!(f, "CutBigWordRightToNext"),
             EditCommand::PasteCutBufferBefore => write!(f, "PasteCutBufferBefore"),
@@ -252,6 +260,7 @@ impl EditCommand {
             | EditCommand::MoveWordRightStart
             | EditCommand::MoveBigWordRightStart
             | EditCommand::MoveWordRightEnd
+            | EditCommand::MoveBigWordRightEnd
             | EditCommand::MoveRightUntil(_)
             | EditCommand::MoveRightBefore(_)
             | EditCommand::MoveLeftUntil(_)
@@ -279,6 +288,7 @@ impl EditCommand {
             | EditCommand::CutWordLeft
             | EditCommand::CutBigWordLeft
             | EditCommand::CutWordRight
+            | EditCommand::CutBigWordRight
             | EditCommand::CutWordRightToNext
             | EditCommand::CutBigWordRightToNext
             | EditCommand::PasteCutBufferBefore


### PR DESCRIPTION
Vim has motion commands over a [*word*](https://vimhelp.org/motion.txt.html#word):
> A word consists of a sequence of letters, digits and underscores, or a sequence of other non-blank characters, separated with white space (spaces, tabs, <EOL>).  This can be changed with the 'iskeyword' option.  An empty line is also considered to be a word.

And a [*WORD*](https://vimhelp.org/motion.txt.html#WORD):

> A WORD consists of a sequence of non-blank characters, separated with white space.  An empty line is also considered to be a WORD.

reedline only supported motions for *word* so if you wanted to move through hyphenated text like `git merge --no-edit main` it takes 8 *w* motions to reach the end, but only 4 *W* motions.

readline-compatible line editors support these motions 

Movement, delete, and change are added for [*B*](https://vimhelp.org/motion.txt.html#B), [*E*](https://vimhelp.org/motion.txt.html#E), and [*W*](https://vimhelp.org/motion.txt.html#W)