### PR TITLE
Add vi r (replace)

### DIFF
--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -87,6 +87,13 @@ where
             let _ = input.next();
             Some(Command::DeleteChar)
         }
+        Some('r') => {
+            let _ = input.next();
+            match input.peek() {
+                Some(c) => Some(Command::ReplaceChar(**c)),
+                None => Some(Command::Incomplete),
+            }
+        }
         Some('s') => {
             let _ = input.next();
             Some(Command::SubstituteCharWithInsert)
@@ -152,6 +159,7 @@ pub enum Command {
     Incomplete,
     Delete,
     DeleteChar,
+    ReplaceChar(char),
     SubstituteCharWithInsert,
     PasteAfter,
     PasteBefore,
@@ -219,6 +227,9 @@ impl Command {
             Self::MoveLeftUntil(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftUntil(*c))],
             Self::MoveLeftBefore(c) => vec![ReedlineOption::Edit(EditCommand::MoveLeftBefore(*c))],
             Self::DeleteChar => vec![ReedlineOption::Edit(EditCommand::CutChar)],
+            Self::ReplaceChar(c) => {
+                vec![ReedlineOption::Edit(EditCommand::ReplaceChar(*c))]
+            }
             Self::SubstituteCharWithInsert => vec![ReedlineOption::Edit(EditCommand::CutChar)],
             Self::HistorySearch => vec![ReedlineOption::Event(ReedlineEvent::SearchHistory)],
             // Mark a command as incomplete whenever a motion is required to finish the command

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -72,7 +72,10 @@ pub enum EditCommand {
     /// - On Windows CRLF (`"\r\n"`)
     InsertNewline,
 
-    /// Repace characters with string
+    /// Replace a character
+    ReplaceChar(char),
+
+    /// Replace characters with string
     ReplaceChars(usize, String),
 
     /// Backspace delete from the current insertion point
@@ -201,6 +204,7 @@ impl Display for EditCommand {
             EditCommand::InsertChar(_) => write!(f, "InsertChar  Value: <char>"),
             EditCommand::InsertString(_) => write!(f, "InsertString Value: <string>"),
             EditCommand::InsertNewline => write!(f, "InsertNewline"),
+            EditCommand::ReplaceChar(_) => write!(f, "ReplaceChar <char>"),
             EditCommand::ReplaceChars(_, _) => write!(f, "ReplaceChars <int> <string>"),
             EditCommand::Backspace => write!(f, "Backspace"),
             EditCommand::Delete => write!(f, "Delete"),
@@ -275,6 +279,7 @@ impl EditCommand {
             | EditCommand::CutChar
             | EditCommand::InsertString(_)
             | EditCommand::InsertNewline
+            | EditCommand::ReplaceChar(_)
             | EditCommand::ReplaceChars(_, _)
             | EditCommand::BackspaceWord
             | EditCommand::DeleteWord


### PR DESCRIPTION
This is an incomplete implementation as it omits the behaviors for CTRL-V, CTRL-E, and CTRL-Y:

> Replace the character under the cursor with {char}. If {char} is a <CR> or <NL>, a line break replaces the character.  To replace with a real <CR>, use CTRL-V <CR>.  CTRL-V <NL> replaces with a <Nul>.
>
> If {char} is CTRL-E or CTRL-Y the character from the line below or above is used, just like with |i_CTRL-E| and |i_CTRL-Y|.  This also works with a count, thus `10r<C-E>` copies 10 characters from the line below.

The similarly-named ReplaceChars is used for history substitution and
is more complicated than we need (n_chars will always be 1, string will
always be a single character string), but could be used if the extra
replace_char() function is too much.