### PR TITLE
introduce LastCommand variant for parse bang result

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1180,6 +1180,26 @@ impl Reedline {
             .index
             .zip(parsed.marker)
             .and_then(|(index, indicator)| match parsed.action {
+                ParseAction::LastCommand => self
+                    .history
+                    .search(SearchQuery {
+                        direction: SearchDirection::Backward,
+                        start_time: None,
+                        end_time: None,
+                        start_id: None,
+                        end_id: None,
+                        limit: Some(1), // fetch the latest one entries
+                        filter: SearchFilter::anything(),
+                    })
+                    .unwrap_or_else(|_| Vec::new())
+                    .get(index.saturating_sub(1))
+                    .map(|history| {
+                        (
+                            parsed.remainder.len(),
+                            indicator.len(),
+                            history.command_line.clone(),
+                        )
+                    }),
                 ParseAction::BackwardSearch => self
                     .history
                     .search(SearchQuery {

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -28,6 +28,8 @@ pub enum ParseAction {
     BackwardSearch,
     /// Last token
     LastToken,
+    /// Last executed command.
+    LastCommand,
 }
 
 /// Splits a string that contains a marker character
@@ -70,9 +72,9 @@ pub fn parse_selection_char(buffer: &str, marker: char) -> ParseResult {
                 Some(&x) if x == marker => {
                     return ParseResult {
                         remainder: &buffer[0..index],
-                        index: Some(1),
+                        index: Some(0),
                         marker: Some(&buffer[index..index + 2]),
-                        action: ParseAction::BackwardSearch,
+                        action: ParseAction::LastCommand,
                     }
                 }
                 #[cfg(feature = "bashisms")]
@@ -269,7 +271,7 @@ mod tests {
         assert_eq!(res.remainder, "search");
         assert_eq!(res.index, Some(1));
         assert_eq!(res.marker, Some("!!"));
-        assert!(matches!(res.action, ParseAction::BackwardSearch));
+        assert!(matches!(res.action, ParseAction::LastCommand));
     }
 
     #[cfg(feature = "bashisms")]

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -269,7 +269,7 @@ mod tests {
         let res = parse_selection_char(input, '!');
 
         assert_eq!(res.remainder, "search");
-        assert_eq!(res.index, Some(1));
+        assert_eq!(res.index, Some(0));
         assert_eq!(res.marker, Some("!!"));
         assert!(matches!(res.action, ParseAction::LastCommand));
     }


### PR DESCRIPTION
Sadly find the fix in https://github.com/nushell/reedline/pull/444 breaks `!!` in history search menu... Because `!!` will select the item with index `1`.

To avoid this, introduce `ParseAction::LastCommand` for `!!`, then `reedline` can handle `!!` and `!3` better.

