### PR TITLE
Update crossterm to 0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+checksum = "ab9f7409c70a38a56216480fba371ee460207dd8926ccf5b4160591759559170"
 dependencies = [
  "bitflags",
  "crossterm_winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [dependencies]
 chrono = "0.4.19"
 clipboard = { version = "0.5.0", optional = true }
-crossterm = { version = "0.23.0", features = ["serde"] }
+crossterm = { version = "0.24.0", features = ["serde"] }
 itertools = "0.10.3"
 nu-ansi-term = "0.46.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This new crossterm version includes a breaking change to the indexing of
certain cursor move operations:

https://github.com/crossterm-rs/crossterm/releases/tag/0.24

While reedline itself might not be affected, check the code of the
consuming application that needs to match the crossterm version!