### PR TITLE
Support vi mode ; and , motions

### DIFF
--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -152,17 +152,15 @@ where
         }
         Some(';') => {
             let _ = input.next();
-            match &vi.last_to_till {
-                Some(to_till) => Some(Command::ReplayToTill(to_till.clone())),
-                _ => None,
-            }
+            vi.last_to_till
+                .as_ref()
+                .map(|to_till| Command::ReplayToTill(to_till.clone()))
         }
         Some(',') => {
             let _ = input.next();
-            match &vi.last_to_till {
-                Some(to_till) => Some(Command::ReverseToTill(to_till.clone())),
-                _ => None,
-            }
+            vi.last_to_till
+                .as_ref()
+                .map(|to_till| Command::ReverseToTill(to_till.clone()))
         }
         _ => None,
     }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -118,7 +118,7 @@ impl EditMode for Vi {
                             c
                         });
 
-                        let res = parse(&self, &mut self.cache.iter().peekable());
+                        let res = parse(self, &mut self.cache.iter().peekable());
 
                         if res.enter_insert_mode() {
                             self.mode = ViMode::Insert;

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -21,7 +21,7 @@ enum ViMode {
 
 /// Vi left-right motions to or till a character.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) enum ViToTill {
+pub enum ViToTill {
     /// f
     ToRight(char),
     /// F
@@ -138,17 +138,16 @@ impl EditMode for Vi {
 
                         // to_reedline_event() returned Multiple or None when this was written
                         if let ReedlineEvent::Multiple(ref events) = event {
-                            let last_to_till = events.iter().rev().find_map(|e| {
-                                if let ReedlineEvent::Edit(edit) = e {
-                                    if edit.len() == 1 {
+                            let last_to_till =
+                                if events.len() == 2 && events[0] == ReedlineEvent::RecordToTill {
+                                    if let ReedlineEvent::Edit(edit) = &events[1] {
                                         edit[0].clone().into()
                                     } else {
                                         None
                                     }
                                 } else {
                                     None
-                                }
-                            });
+                                };
 
                             if last_to_till.is_some() {
                                 self.last_to_till = last_to_till;

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -19,6 +19,43 @@ enum ViMode {
     Insert,
 }
 
+/// Vi left-right motions to or till a character.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub(crate) enum ViToTill {
+    /// f
+    ToRight(char),
+    /// F
+    ToLeft(char),
+    /// t
+    TillRight(char),
+    /// T
+    TillLeft(char),
+}
+
+impl ViToTill {
+    /// Swap the direction of the to or till for ','
+    pub fn reverse(&self) -> Self {
+        match self {
+            ViToTill::ToRight(c) => ViToTill::ToLeft(*c),
+            ViToTill::ToLeft(c) => ViToTill::ToRight(*c),
+            ViToTill::TillRight(c) => ViToTill::TillLeft(*c),
+            ViToTill::TillLeft(c) => ViToTill::TillRight(*c),
+        }
+    }
+}
+
+impl From<EditCommand> for Option<ViToTill> {
+    fn from(edit: EditCommand) -> Self {
+        match edit {
+            EditCommand::MoveLeftBefore(c) => Some(ViToTill::TillLeft(c)),
+            EditCommand::MoveLeftUntil(c) => Some(ViToTill::ToLeft(c)),
+            EditCommand::MoveRightBefore(c) => Some(ViToTill::TillRight(c)),
+            EditCommand::MoveRightUntil(c) => Some(ViToTill::ToRight(c)),
+            _ => None,
+        }
+    }
+}
+
 /// This parses incoming input `Event`s like a Vi-Style editor
 pub struct Vi {
     cache: Vec<char>,
@@ -26,6 +63,8 @@ pub struct Vi {
     normal_keybindings: Keybindings,
     mode: ViMode,
     previous: Option<ReedlineEvent>,
+    // last f, F, t, T motion for ; and ,
+    last_to_till: Option<ViToTill>,
 }
 
 impl Default for Vi {
@@ -36,6 +75,7 @@ impl Default for Vi {
             cache: Vec::new(),
             mode: ViMode::Insert,
             previous: None,
+            last_to_till: None,
         }
     }
 }
@@ -46,9 +86,7 @@ impl Vi {
         Self {
             insert_keybindings,
             normal_keybindings,
-            cache: Vec::new(),
-            mode: ViMode::Insert,
-            previous: None,
+            ..Default::default()
         }
     }
 }
@@ -80,7 +118,7 @@ impl EditMode for Vi {
                             c
                         });
 
-                        let res = parse(&mut self.cache.iter().peekable());
+                        let res = parse(&self, &mut self.cache.iter().peekable());
 
                         if res.enter_insert_mode() {
                             self.mode = ViMode::Insert;
@@ -97,6 +135,25 @@ impl EditMode for Vi {
                                 self.cache.clear();
                             }
                         };
+
+                        // to_reedline_event() returned Multiple or None when this was written
+                        if let ReedlineEvent::Multiple(ref events) = event {
+                            let last_to_till = events.iter().rev().find_map(|e| {
+                                if let ReedlineEvent::Edit(edit) = e {
+                                    if edit.len() == 1 {
+                                        edit[0].clone().into()
+                                    } else {
+                                        None
+                                    }
+                                } else {
+                                    None
+                                }
+                            });
+
+                            if last_to_till.is_some() {
+                                self.last_to_till = last_to_till;
+                            }
+                        }
 
                         self.previous = Some(event.clone());
 
@@ -174,6 +231,7 @@ impl EditMode for Vi {
 mod test {
     use super::*;
     use pretty_assertions::assert_eq;
+    use rstest::rstest;
 
     #[test]
     fn esc_leads_to_normal_mode_test() {
@@ -203,9 +261,8 @@ mod test {
         let mut vi = Vi {
             insert_keybindings: default_vi_insert_keybindings(),
             normal_keybindings: keybindings,
-            cache: Vec::new(),
             mode: ViMode::Normal,
-            previous: None,
+            ..Default::default()
         };
 
         let esc = Event::Key(KeyEvent {
@@ -229,9 +286,8 @@ mod test {
         let mut vi = Vi {
             insert_keybindings: default_vi_insert_keybindings(),
             normal_keybindings: keybindings,
-            cache: Vec::new(),
             mode: ViMode::Normal,
-            previous: None,
+            ..Default::default()
         };
 
         let esc = Event::Key(KeyEvent {
@@ -249,9 +305,8 @@ mod test {
         let mut vi = Vi {
             insert_keybindings: default_vi_insert_keybindings(),
             normal_keybindings: keybindings,
-            cache: Vec::new(),
             mode: ViMode::Normal,
-            previous: None,
+            ..Default::default()
         };
 
         let esc = Event::Key(KeyEvent {
@@ -261,5 +316,33 @@ mod test {
         let result = vi.parse_event(esc);
 
         assert_eq!(result, ReedlineEvent::None);
+    }
+
+    #[rstest]
+    #[case('f', KeyModifiers::NONE, ViToTill::ToRight('X'))]
+    #[case('f', KeyModifiers::SHIFT, ViToTill::ToLeft('X'))]
+    #[case('t', KeyModifiers::NONE, ViToTill::TillRight('X'))]
+    #[case('t', KeyModifiers::SHIFT, ViToTill::TillLeft('X'))]
+    fn last_to_till(
+        #[case] code: char,
+        #[case] modifiers: KeyModifiers,
+        #[case] expected: ViToTill,
+    ) {
+        let mut vi = Vi::default();
+        vi.mode = ViMode::Normal;
+
+        let to_till = Event::Key(KeyEvent {
+            code: KeyCode::Char(code),
+            modifiers,
+        });
+        vi.parse_event(to_till);
+
+        let key_x = Event::Key(KeyEvent {
+            code: KeyCode::Char('x'),
+            modifiers: KeyModifiers::SHIFT,
+        });
+        vi.parse_event(key_x);
+
+        assert_eq!(vi.last_to_till, Some(expected));
     }
 }

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -1,6 +1,6 @@
 use super::command::{parse_command, Command};
 use super::motion::{parse_motion, Motion};
-use crate::{EditCommand, ReedlineEvent};
+use crate::{EditCommand, ReedlineEvent, Vi};
 use std::iter::Peekable;
 
 #[derive(Debug, Clone)]
@@ -113,12 +113,12 @@ where
     }
 }
 
-pub fn parse<'iter, I>(input: &mut Peekable<I>) -> ParseResult
+pub fn parse<'iter, I>(vi: &Vi, input: &mut Peekable<I>) -> ParseResult
 where
     I: Iterator<Item = &'iter char>,
 {
     let multiplier = parse_number(input);
-    let command = parse_command(input);
+    let command = parse_command(vi, input);
     let count = parse_number(input);
     let motion = parse_motion(input);
 
@@ -148,7 +148,8 @@ mod tests {
     use rstest::rstest;
 
     fn vi_parse(input: &[char]) -> ParseResult {
-        parse(&mut input.iter().peekable())
+        let vi = Vi::default();
+        parse(&vi, &mut input.iter().peekable())
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -654,7 +654,8 @@ impl Reedline {
             | ReedlineEvent::MenuLeft
             | ReedlineEvent::MenuRight
             | ReedlineEvent::MenuPageNext
-            | ReedlineEvent::MenuPagePrevious => Ok(EventStatus::Inapplicable),
+            | ReedlineEvent::MenuPagePrevious
+            | ReedlineEvent::RecordToTill => Ok(EventStatus::Inapplicable),
         }
     }
 
@@ -966,7 +967,9 @@ impl Reedline {
                 // Exhausting the event handlers is still considered handled
                 Ok(EventStatus::Inapplicable)
             }
-            ReedlineEvent::None | ReedlineEvent::Mouse => Ok(EventStatus::Inapplicable),
+            ReedlineEvent::None | ReedlineEvent::Mouse | ReedlineEvent::RecordToTill => {
+                Ok(EventStatus::Inapplicable)
+            }
         }
     }
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -446,6 +446,9 @@ pub enum ReedlineEvent {
 
     /// Open text editor
     OpenEditor,
+
+    /// Record vi to or till motion
+    RecordToTill,
 }
 
 impl Display for ReedlineEvent {
@@ -488,6 +491,7 @@ impl Display for ReedlineEvent {
             ReedlineEvent::MenuPagePrevious => write!(f, "MenuPagePrevious"),
             ReedlineEvent::ExecuteHostCommand(_) => write!(f, "ExecuteHostCommand"),
             ReedlineEvent::OpenEditor => write!(f, "OpenEditor"),
+            ReedlineEvent::RecordToTill => write!(f, "RecordToTill"),
         }
     }
 }


### PR DESCRIPTION
The f, F, t, and T left-right motions can be repeated with the ; motion, or reversed with the , motion:

> ;
> Repeat latest f, t, F or T [count] times. See cpo-;
>
> ,
> Repeat latest f, t, F or T in opposite direction [count] times. See also cpo-;

I named these "to-till" motions as the first word of the description for the f and T motions are "To" and "Till" respectively.

Add storage for the last To or Till motion on the `Vi` struct, and pass it through to `parse_command()` so `;` or `,` can re-use it.

When a to-till motion is fully parsed the new to-till motion is stored in the `Vi` struct.

I'm not the happiest with finding a new to-till motion in the parsed command. I can't think of a better way to match it due to the `Vec`, but am open to suggestions.

It's probably reasonable to make `parse_command()` a method of `Vi` if my implementation is acceptable.