### PR TITLE
Support swtiching the case of a char with ~ in vi

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -77,6 +77,7 @@ impl Editor {
             EditCommand::PasteCutBufferAfter => self.insert_cut_buffer_after(),
             EditCommand::UppercaseWord => self.line_buffer.uppercase_word(),
             EditCommand::LowercaseWord => self.line_buffer.lowercase_word(),
+            EditCommand::SwitchcaseChar => self.line_buffer.switchcase_char(),
             EditCommand::CapitalizeChar => self.line_buffer.capitalize_char(),
             EditCommand::SwapWords => self.line_buffer.swap_words(),
             EditCommand::SwapGraphemes => self.line_buffer.swap_graphemes(),

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -162,6 +162,10 @@ where
                 .as_ref()
                 .map(|to_till| Command::ReverseToTill(to_till.clone()))
         }
+        Some('~') => {
+            let _ = input.next();
+            Some(Command::Switchcase)
+        }
         _ => None,
     }
 }
@@ -203,6 +207,7 @@ pub enum Command {
     ReplayToTill(ViToTill),
     ReverseToTill(ViToTill),
     HistorySearch,
+    Switchcase,
 }
 
 impl Command {
@@ -260,6 +265,7 @@ impl Command {
             }
             Self::SubstituteCharWithInsert => vec![ReedlineOption::Edit(EditCommand::CutChar)],
             Self::HistorySearch => vec![ReedlineOption::Event(ReedlineEvent::SearchHistory)],
+            Self::Switchcase => vec![ReedlineOption::Edit(EditCommand::SwitchcaseChar)],
             // Mark a command as incomplete whenever a motion is required to finish the command
             Self::Delete | Self::Change | Self::Incomplete => vec![ReedlineOption::Incomplete],
         }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -147,6 +147,9 @@ pub enum EditCommand {
     /// Capitalize the current character
     CapitalizeChar,
 
+    /// Switch the case of the current character
+    SwitchcaseChar,
+
     /// Swap the current word with the word to the right
     SwapWords,
 
@@ -228,6 +231,7 @@ impl Display for EditCommand {
             EditCommand::PasteCutBufferAfter => write!(f, "PasteCutBufferAfter"),
             EditCommand::UppercaseWord => write!(f, "UppercaseWord"),
             EditCommand::LowercaseWord => write!(f, "LowercaseWord"),
+            EditCommand::SwitchcaseChar => write!(f, "SwitchcaseChar"),
             EditCommand::CapitalizeChar => write!(f, "CapitalizeChar"),
             EditCommand::SwapWords => write!(f, "SwapWords"),
             EditCommand::SwapGraphemes => write!(f, "SwapGraphemes"),
@@ -300,6 +304,7 @@ impl EditCommand {
             | EditCommand::PasteCutBufferAfter
             | EditCommand::UppercaseWord
             | EditCommand::LowercaseWord
+            | EditCommand::SwitchcaseChar
             | EditCommand::CapitalizeChar
             | EditCommand::SwapWords
             | EditCommand::SwapGraphemes


### PR DESCRIPTION
> Switch case of the character under the cursor and move the cursor to the right.

vi behavior is to only swap the case of an ASCII character so this is
implementation matches that behavior