### PR TITLE
Export the crossterm key types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,3 +263,6 @@ pub use utils::{
     get_reedline_keybinding_modifiers, get_reedline_keycodes, get_reedline_prompt_edit_modes,
     get_reedline_reedline_events,
 };
+
+// Reexport the key types to be independent from an explicit crossterm dependency.
+pub use crossterm::event::{KeyCode, KeyModifiers};


### PR DESCRIPTION
Export `crossterm::event::{KeyCode, KeyModifiers}` as our own.
This way users of the library don't have to import crossterm with the
same version explicitly to set their own keybindings.

Closes #456