### PR TITLE
Vi mode add support for d0, d^, c0, and c^

### DIFF
--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -306,7 +306,7 @@ impl Command {
                 Motion::LeftBefore(c) => {
                     Some(vec![ReedlineOption::Edit(EditCommand::CutLeftBefore(*c))])
                 }
-                Motion::Start => Some(vec![ReedlineOption::Edit(EditCommand::CutFromStart)]),
+                Motion::Start => Some(vec![ReedlineOption::Edit(EditCommand::CutFromLineStart)]),
             },
             Self::Change => match motion {
                 Motion::End => Some(vec![

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -359,7 +359,7 @@ impl Command {
                     ReedlineOption::Event(ReedlineEvent::Repaint),
                 ]),
                 Motion::Start => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutFromStart),
+                    ReedlineOption::Edit(EditCommand::CutFromLineStart),
                     ReedlineOption::Event(ReedlineEvent::Repaint),
                 ]),
             },

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -278,7 +278,7 @@ impl Command {
     ) -> Option<Vec<ReedlineOption>> {
         let edits = match self {
             Self::Delete => match motion {
-                Motion::End => Some(vec![ReedlineOption::Edit(EditCommand::CutToEnd)]),
+                Motion::End => Some(vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)]),
                 Motion::Line => Some(vec![ReedlineOption::Edit(EditCommand::CutCurrentLine)]),
                 Motion::NextWord => {
                     Some(vec![ReedlineOption::Edit(EditCommand::CutWordRightToNext)])
@@ -306,7 +306,7 @@ impl Command {
                 Motion::LeftBefore(c) => {
                     Some(vec![ReedlineOption::Edit(EditCommand::CutLeftBefore(*c))])
                 }
-                Motion::Start => None,
+                Motion::Start => Some(vec![ReedlineOption::Edit(EditCommand::CutFromStart)]),
             },
             Self::Change => match motion {
                 Motion::End => Some(vec![
@@ -358,7 +358,10 @@ impl Command {
                     ReedlineOption::Edit(EditCommand::CutLeftBefore(*c)),
                     ReedlineOption::Event(ReedlineEvent::Repaint),
                 ]),
-                Motion::Start => None,
+                Motion::Start => Some(vec![
+                    ReedlineOption::Edit(EditCommand::CutFromStart),
+                    ReedlineOption::Event(ReedlineEvent::Repaint),
+                ]),
             },
             _ => None,
         };

--- a/src/edit_mode/vi/motion.rs
+++ b/src/edit_mode/vi/motion.rs
@@ -33,7 +33,7 @@ where
             let _ = input.next();
             Some(Motion::Line)
         }
-        Some('0') => {
+        Some('0' | '^') => {
             let _ = input.next();
             Some(Motion::Start)
         }


### PR DESCRIPTION
The main feedback question for this pull request is for the multi-line handling I've made it so `d0` and `d$` will only delete to the end of the **_line_**, but the previous behavior of `d$` deleted the end of the **_input_**, even for multi-line inputs.

I believe my change is more consistent with vi's behavior, but let me know if the prior `d$` behavior is preferable and I can edit accordingly.