### PR TITLE
Ctrl+h edit binding moved from emacs to common

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -51,7 +51,6 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToEnd));
     kb.add_binding(KM::CONTROL, KC::Char('u'), edit_bind(EC::CutFromStart));
     // Edits
-    kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
     kb.add_binding(KM::CONTROL, KC::Char('t'), edit_bind(EC::SwapGraphemes));
 
     // *** ALT ***

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -192,5 +192,6 @@ pub fn add_common_edit_bindings(kb: &mut Keybindings) {
     kb.add_binding(KM::CONTROL, KC::Backspace, edit_bind(EC::BackspaceWord));
     kb.add_binding(KM::CONTROL, KC::Delete, edit_bind(EC::DeleteWord));
     // Base commands should not affect cut buffer
+    kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
     kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::BackspaceWord));
 }


### PR DESCRIPTION
Moving the edit binding to `add_common_edit_bindings` because `Ctrl+h` works in Vim's **Insert** mode as backspace. This behavior is also supported by _vi_ mode in bash.