### PR TITLE
Add shared emacs-mode bindings to vi-mode

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -41,38 +41,8 @@ pub fn default_emacs_keybindings() -> Keybindings {
     // Undo/Redo
     kb.add_binding(KM::CONTROL, KC::Char('g'), edit_bind(EC::Redo));
     kb.add_binding(KM::CONTROL, KC::Char('z'), edit_bind(EC::Undo));
-    // Cutting
-    kb.add_binding(
-        KM::CONTROL,
-        KC::Char('y'),
-        edit_bind(EC::PasteCutBufferBefore),
-    );
-    kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
-    kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToEnd));
-    kb.add_binding(KM::CONTROL, KC::Char('u'), edit_bind(EC::CutFromStart));
-    // Edits
-    kb.add_binding(KM::CONTROL, KC::Char('t'), edit_bind(EC::SwapGraphemes));
 
     // *** ALT ***
-    // Moves
-    kb.add_binding(KM::ALT, KC::Left, edit_bind(EC::MoveWordLeft));
-    kb.add_binding(
-        KM::ALT,
-        KC::Right,
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::HistoryHintWordComplete,
-            edit_bind(EC::MoveWordRight),
-        ]),
-    );
-    kb.add_binding(KM::ALT, KC::Char('b'), edit_bind(EC::MoveWordLeft));
-    kb.add_binding(
-        KM::ALT,
-        KC::Char('f'),
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::HistoryHintWordComplete,
-            edit_bind(EC::MoveWordRight),
-        ]),
-    );
     // Edits
     kb.add_binding(KM::ALT, KC::Delete, edit_bind(EC::DeleteWord));
     kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -178,6 +178,25 @@ pub fn add_common_navigation_bindings(kb: &mut Keybindings) {
         KC::Char('n'),
         ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuDown, ReedlineEvent::Down]),
     );
+    // EMACS word moves
+    kb.add_binding(KM::ALT, KC::Left, edit_bind(EC::MoveWordLeft));
+    kb.add_binding(
+        KM::ALT,
+        KC::Right,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::HistoryHintWordComplete,
+            edit_bind(EC::MoveWordRight),
+        ]),
+    );
+    kb.add_binding(KM::ALT, KC::Char('b'), edit_bind(EC::MoveWordLeft));
+    kb.add_binding(
+        KM::ALT,
+        KC::Char('f'),
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::HistoryHintWordComplete,
+            edit_bind(EC::MoveWordRight),
+        ]),
+    );
 }
 
 /// Add basic functionality to edit
@@ -194,4 +213,16 @@ pub fn add_common_edit_bindings(kb: &mut Keybindings) {
     // Base commands should not affect cut buffer
     kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
     kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::BackspaceWord));
+
+    // Cutting
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Char('y'),
+        edit_bind(EC::PasteCutBufferBefore),
+    );
+    kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
+    kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToEnd));
+    kb.add_binding(KM::CONTROL, KC::Char('u'), edit_bind(EC::CutFromStart));
+    // Edits
+    kb.add_binding(KM::CONTROL, KC::Char('t'), edit_bind(EC::SwapGraphemes));
 }

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -20,9 +20,11 @@ pub fn default_vi_normal_keybindings() -> Keybindings {
 
     add_common_control_bindings(&mut kb);
     add_common_navigation_bindings(&mut kb);
-    // Replicate vi's default behavior for Backspace and delete
+    add_common_edit_bindings(&mut kb);
+
+    // Replicate vi's default behavior for Backspace
     kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::MoveLeft));
-    kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
+    kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::MoveLeft));
 
     kb
 }
@@ -30,10 +32,15 @@ pub fn default_vi_normal_keybindings() -> Keybindings {
 /// Default Vi insert keybindings
 pub fn default_vi_insert_keybindings() -> Keybindings {
     let mut kb = Keybindings::new();
+    use KeyCode as KC;
+    use KeyModifiers as KM;
 
     add_common_control_bindings(&mut kb);
     add_common_navigation_bindings(&mut kb);
     add_common_edit_bindings(&mut kb);
+
+    // Remove bindings inapplicable to vi edit mode
+    kb.remove_binding(KM::CONTROL, KC::Char('k'));
 
     kb
 }


### PR DESCRIPTION
GNU Readline has several emacs bindings that are active in vi mode.
Previously some of these were only active in insert mode when GNU
readline has them always active, and some were never activated.
The only deviation from GNU readline behavior here is that I've added
Alt-f and Alt-Right for symmetry -- for some reason these two don't
work in my computer's copy of GNU readline.
Newly active in all modes:
- Alt-Left / Alt-b (word left)
- Alt-Right / Alt-f (word rignt)
- Ctrl-y (paste)
- Ctrl-u (cut from start)
- Ctrl-t (swap graphemes)

Newly active in normal mode:
- Ctrl-h (move left/same as backspace)
- Ctrl-w (backspace word)
- Ctrl-k (cut to end) [not active in insert mode]