### PR TITLE
Fix panic when using sqlite as history backend

### DIFF
--- a/src/hinter/default.rs
+++ b/src/hinter/default.rs
@@ -24,7 +24,11 @@ impl Hinter for DefaultHinter {
                 .expect("todo: error handling")
                 .get(0)
                 .map_or_else(String::new, |entry| {
-                    entry.command_line[line.len()..].to_string()
+                    entry
+                        .command_line
+                        .get(line.len()..)
+                        .unwrap_or_default()
+                        .to_string()
                 })
         } else {
             String::new()


### PR DESCRIPTION
This PR fixes panic when using sqlite as history backend.

Fixes nushell/nushell#6251

We can reproduce the panic with the following steps:
1. `echo %` <kbd>enter</kbd>
2. `echo %%` :boom: 

[![asciicast](https://asciinema.org/a/yY3B6vWGhYptvj7j3PUkAIKTU.svg)](https://asciinema.org/a/yY3B6vWGhYptvj7j3PUkAIKTU)