### PR TITLE
Don't bundle sqlite by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,6 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f0455f2c1bc9a7caa792907026e469c1d91761fb0ea37cbb16427c77280cf35"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f0455f2c1bc9a7caa792907026e469c1d91761fb0ea37cbb16427c77280cf35"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ strip-ansi-escapes = "0.1.1"
 strum = "0.24"
 strum_macros = "0.24"
 fd-lock = "3.0.3"
-rusqlite = { version = "0.28.0", optional = true, features = ["bundled"] }
+rusqlite = { version = "0.28.0", optional = true }
 serde_json = { version = "1.0.79", optional = true }
 gethostname = { version = "0.2.3", optional = true }
 thiserror = "1.0.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,7 @@ rstest = { version = "0.15.0", default-features = false }
 [features]
 system_clipboard = ["clipboard"]
 bashisms = []
-sqlite = ["rusqlite", "serde_json", "gethostname"]
 external_printer = ["crossbeam"]
+sqlite = ["rusqlite/bundled", "serde_json", "gethostname"]
+sqlite-dynlib = ["rusqlite", "serde_json", "gethostname"]
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It is currently primarily developed as the interactive editor for [nushell](http
   - [Integrate with `Hinter` for fish-style history autosuggestions](#integrate-with-hinter-for-fish-style-history-autosuggestions)
   - [Integrate with custom line completion `Validator`](#integrate-with-custom-line-completion-validator)
   - [Use custom `EditMode`](#use-custom-editmode)
+- [Crate features](#crate-features)
 - [Are we prompt yet? (Development status)](#are-we-prompt-yet-development-status)
 - [Contributing](./CONTRIBUTING.md)
 - [Alternatives](#alternatives)
@@ -181,6 +182,14 @@ let mut line_editor = Reedline::create().with_edit_mode(Box::new(Vi::new(
     default_vi_normal_keybindings(),
 )));
 ```
+
+## Crate features
+
+- `clipboard`: Enable support to use the `SystemClipboard`. Enabling this feature will return a `SystemClipboard` instead of a local clipboard when calling `get_default_clipboard()`.
+- `bashisms`: Enable support for special text sequences that recall components from the history. e.g. `!!` and `!$`. For use in shells like `bash` or [`nushell`](https://nushell.sh).
+- `sqlite`: Provides the `SqliteBackedHistory` to store richer information in the history. Statically links the required sqlite version.
+- `sqlite-dynlib`: Alternative to the feature `sqlite`. Will not statically link. Requires `sqlite >= 3.38` to link dynamically!
+- `external_printer`: **Experimental:** Thread-safe `ExternalPrinter` handle to print lines from concurrently running threads.
 
 ## Are we prompt yet? (Development status)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,14 @@
 //! )));
 //! ```
 //!
+//! ## Crate features
+//!
+//! - `clipboard`: Enable support to use the `SystemClipboard`. Enabling this feature will return a `SystemClipboard` instead of a local clipboard when calling `get_default_clipboard()`.
+//! - `bashisms`: Enable support for special text sequences that recall components from the history. e.g. `!!` and `!$`. For use in shells like `bash` or [`nushell`](https://nushell.sh).
+//! - `sqlite`: Provides the `SqliteBackedHistory` to store richer information in the history. Statically links the required sqlite version.
+//! - `sqlite-dynlib`: Alternative to the feature `sqlite`. Will not statically link. Requires `sqlite >= 3.38` to link dynamically!
+//! - `external_printer`: **Experimental:** Thread-safe `ExternalPrinter` handle to print lines from concurrently running threads.
+//!
 //! ## Are we prompt yet? (Development status)
 //!
 //! Nushell has now all the basic features to become the primary line editor for [nushell](https://github.com/nushell/nushell


### PR DESCRIPTION
This came up in https://github.com/void-linux/void-packages/pull/39143#issuecomment-1239582933 while talking about bundling or not bundling deps. IMO, libraries like reedline shouldn't force using a bundled version, and if that decision is to be made at all, it should happen in the application, not somewhere deep in the dependency tree. If an application wants sqlite bundled, the application itself can add a dep on rusqlite and add the `bundled` feature, and cargo will use the bundled variant for reedline as well, via feature unification. Disabling the bundling in a similar fashion isn't possible though.

Ideally, I'd like to have an override for this available in libsqlite3-sys, but that hasn't happened yet (see https://github.com/rusqlite/rusqlite/issues/769), so the quick solution for me is patching out the bundling in the deps instead.