### PR TITLE
Add duplicate column in sqlite history

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,10 +1,10 @@
 #[cfg(feature = "bashisms")]
+use crate::menu_functions::{parse_selection_char, ParseAction};
 use crate::{
-    history::SearchFilter,
-    menu_functions::{parse_selection_char, ParseAction},
+    result::{ReedlineError, ReedlineErrorVariants},
+    CommandLineSearch, SearchFilter,
 };
 
-use crate::result::{ReedlineError, ReedlineErrorVariants};
 use {
     crate::{
         completion::{Completer, DefaultCompleter},
@@ -504,7 +504,10 @@ impl Reedline {
                             last_ecs.extend(ec);
                         }
                         (ref mut a @ Some(_), other_event) => {
-                            reedline_events.push(ReedlineEvent::Edit(a.take().unwrap()));
+                            reedline_events.push(ReedlineEvent::Edit(
+                                a.take()
+                                    .expect("Cannot take out item from last edit commands"),
+                            ));
 
                             reedline_events.push(other_event);
                         }
@@ -829,6 +832,20 @@ impl Reedline {
                         let buf = self.editor.get_buffer();
                         if !buf.is_empty() {
                             let mut entry = HistoryItem::from_command_line(buf);
+
+                            // check if the command has been seen in the history
+                            if let Ok(dup) = self.history.search(SearchQuery {
+                                filter: SearchFilter::from_text_search(
+                                    CommandLineSearch::Substring(entry.command_line.clone()),
+                                ),
+                                ..SearchQuery::everything(SearchDirection::Backward)
+                            }) {
+                                if dup.is_empty() {
+                                    entry.duplicate = 0;
+                                } else {
+                                    entry.duplicate = 1;
+                                }
+                            }
                             // todo: in theory there's a race condition here because another shell might get the next session id at the same time
                             entry.session_id =
                                 Some(*self.history_session_id.get_or_insert_with(|| {

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -189,6 +189,7 @@ mod test {
             cwd: Some(cwd.to_string()),
             duration: Some(Duration::from_millis(1000)),
             exit_status: Some(exit_status),
+            duplicate: 0,
             more_info: None,
         }
     }

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -310,6 +310,7 @@ impl FileBackedHistory {
             cwd: None,
             duration: None,
             exit_status: None,
+            duplicate: 0,
             more_info: None,
         }
     }

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -79,6 +79,8 @@ pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = IgnoreAllExtraInfo> {
     pub duration: Option<Duration>,
     /// the exit status of the command
     pub exit_status: Option<i64>,
+    /// the bit flags of the duplicated command
+    pub duplicate: u8,
     /// arbitrary additional information that might be interesting
     pub more_info: Option<ExtraInfo>,
 }
@@ -95,6 +97,7 @@ impl HistoryItem {
             cwd: None,
             duration: None,
             exit_status: None,
+            duplicate: 0,
             more_info: None,
         }
     }


### PR DESCRIPTION
Fix part of https://github.com/nushell/nushell/issues/6502, specifically, address  @sholderbach's comment  

> The history menu we provide out of the box could be more helpful to have functionality to filter for success and dedup afterwards.

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/85712372/189699664-0dede654-836f-42a6-982c-e2e34fa50d78.png">
