### PR TITLE
change history session_id to a systematically generated number

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -195,9 +195,9 @@ impl Reedline {
         let nanoseconds_since_first_commit =
             duration_since_first_commit.num_nanoseconds().unwrap_or(0);
 
-        eprintln!(
-            "nanoseconds_since_first_commit: {}",
-            nanoseconds_since_first_commit
+        std::env::set_var(
+            "REEDLINE_SESSION_ID",
+            nanoseconds_since_first_commit.to_string(),
         );
 
         Some(HistorySessionId::new(nanoseconds_since_first_commit))

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -156,7 +156,7 @@ impl Reedline {
         let hinter = None;
         let validator = None;
         let edit_mode = Box::new(Emacs::default());
-        let hist_session_id = Self::get_history_session_id();
+        let hist_session_id = Self::create_history_session_id();
 
         Reedline {
             editor: Editor::default(),
@@ -185,7 +185,7 @@ impl Reedline {
     }
 
     /// Get a new history session id based on the current time and the first commit datetime of reedline
-    fn get_history_session_id() -> Option<HistorySessionId> {
+    fn create_history_session_id() -> Option<HistorySessionId> {
         //Sun Feb 28 22:42:07 2021 +1300
         let first_commit_date_time_naive = NaiveDate::from_ymd(2021, 2, 28).and_hms(22, 42, 7);
         let first_commit_date_time_utc =
@@ -195,12 +195,12 @@ impl Reedline {
         let nanoseconds_since_first_commit =
             duration_since_first_commit.num_nanoseconds().unwrap_or(0);
 
-        std::env::set_var(
-            "REEDLINE_SESSION_ID",
-            nanoseconds_since_first_commit.to_string(),
-        );
-
         Some(HistorySessionId::new(nanoseconds_since_first_commit))
+    }
+
+    /// Return the previously generated history session id
+    pub fn get_history_session_id(&self) -> Option<HistorySessionId> {
+        self.history_session_id
     }
 
     /// A builder to include a [`Hinter`] in your instance of the Reedline engine

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -178,6 +178,8 @@ mod test {
     #[cfg(not(feature = "sqlite"))]
     const IS_FILE_BASED: bool = true;
 
+    use crate::HistorySessionId;
+
     fn create_item(session: i64, cwd: &str, cmd: &str, exit_status: i64) -> HistoryItem {
         HistoryItem {
             id: None,

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 
 use crate::{core_editor::LineBuffer, HistoryItem, Result};
 
-use super::{HistoryItemId, HistorySessionId};
+use super::HistoryItemId;
 
 /// Browsing modes for a [`History`]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -149,7 +149,6 @@ pub trait History: Send {
     fn load(&self, id: HistoryItemId) -> Result<HistoryItem>;
 
     /// retrieves the next unused session id
-    fn next_session_id(&mut self) -> Result<HistorySessionId>;
 
     /// count the results of a query
     fn count(&self, query: SearchQuery) -> Result<i64>;

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -1,6 +1,5 @@
 use super::{
-    base::CommandLineSearch, History, HistoryItem, HistoryItemId, HistorySessionId,
-    SearchDirection, SearchQuery,
+    base::CommandLineSearch, History, HistoryItem, HistoryItemId, SearchDirection, SearchQuery,
 };
 use crate::{
     result::{ReedlineError, ReedlineErrorVariants},
@@ -255,11 +254,6 @@ impl History for FileBackedHistory {
             self.len_on_disk = self.entries.len();
         }
         Ok(())
-    }
-
-    fn next_session_id(&mut self) -> Result<HistorySessionId> {
-        // doesn't support separating out different sessions
-        Ok(HistorySessionId::new(0))
     }
 }
 

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -1,6 +1,3 @@
-use chrono::{TimeZone, Utc};
-use rusqlite::{named_params, params, Connection, ToSql};
-
 use super::{
     base::{CommandLineSearch, SearchDirection, SearchQuery},
     History, HistoryItem, HistoryItemId, HistorySessionId,
@@ -9,10 +6,10 @@ use crate::{
     result::{ReedlineError, ReedlineErrorVariants},
     Result,
 };
-
-const SQLITE_APPLICATION_ID: i32 = 1151497937;
-
+use chrono::{TimeZone, Utc};
+use rusqlite::{named_params, params, Connection, ToSql};
 use std::{path::PathBuf, time::Duration};
+const SQLITE_APPLICATION_ID: i32 = 1151497937;
 
 /// A history that stores the values to an SQLite database.
 /// In addition to storing the command, the history can store an additional arbitrary HistoryEntryContext,
@@ -155,18 +152,6 @@ impl History for SqliteBackedHistory {
     fn sync(&mut self) -> std::io::Result<()> {
         // no-op (todo?)
         Ok(())
-    }
-
-    fn next_session_id(&mut self) -> Result<HistorySessionId> {
-        Ok(HistorySessionId::new(
-            self.db
-                .query_row(
-                    "select coalesce(max(session_id), 0) + 1 from history",
-                    params![],
-                    |r| r.get(0),
-                )
-                .map_err(map_sqlite_err)?,
-        ))
     }
 }
 fn map_sqlite_err(err: rusqlite::Error) -> ReedlineError {


### PR DESCRIPTION
This PR changes the `history_session_id` from a regular number like 1,2,3,4,5 to a systematically generated number based on the date of reedline's first commit and is expressed in nanoseconds. 

I submit this change in order to be able to generate a `history_session_id` without the need of looking anything up in the history database. This number should be pretty unique although not precisely unique. Each time you start up reedline you get a new time and therefore you get a new `history_session_id`.

I also changed the trait so that `next_session_id()` no longer exists.

I created a public function in the Reedline impl to `get_history_session_id()`. Hopefully that is enough to return it so that we can use it in nushell in order to filter on each session id which will be unique to each terminal window running reedline/nushell.

