### PR TITLE
Vi-Refactor: Properly parse motions separate from the actions

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -506,6 +506,32 @@ mod test {
     }
 
     #[rstest]
+    #[case("hello world", 0, 'l', 1, false, "lo world")]
+    #[case("hello world", 0, 'l', 1, true, "llo world")]
+    #[ignore = "Deleting two consecutives is not implemented correctly and needs the multiplier explicitly."]
+    #[case("hello world", 0, 'l', 2, false, "o world")]
+    #[case("hello world", 0, 'h', 1, false, "hello world")]
+    #[case("hello world", 0, 'l', 3, true, "ld")]
+    #[case("hello world", 4, 'o', 1, true, "hellorld")]
+    #[case("hello world", 4, 'w', 1, false, "hellorld")]
+    #[case("hello world", 4, 'o', 1, false, "hellrld")]
+    fn test_cut_right_until_char(
+        #[case] input: &str,
+        #[case] position: usize,
+        #[case] search_char: char,
+        #[case] repeat: usize,
+        #[case] before_char: bool,
+        #[case] expected: &str,
+    ) {
+        let mut editor = editor_with(input);
+        editor.line_buffer.set_insertion_point(position);
+        for _ in 0..repeat {
+            editor.cut_right_until_char(search_char, before_char, true);
+        }
+        assert_eq!(editor.get_buffer(), expected);
+    }
+
+    #[rstest]
     #[case("abc", 1, 'X', "aXc")]
     #[case("abc", 1, '🔄', "a🔄c")]
     #[case("a🔄c", 1, 'X', "aXc")]

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -1,8 +1,8 @@
-use super::{motion::Motion, motion::ViToTill, parser::ReedlineOption};
+use super::{motion::Motion, motion::ViCharSearch, parser::ReedlineOption};
 use crate::{EditCommand, ReedlineEvent, Vi};
 use std::iter::Peekable;
 
-pub fn parse_command<'iter, I>(vi: &Vi, input: &mut Peekable<I>) -> Option<Command>
+pub fn parse_command<'iter, I>(input: &mut Peekable<I>) -> Option<Command>
 where
     I: Iterator<Item = &'iter char>,
 {
@@ -19,46 +19,6 @@ where
             let _ = input.next();
             Some(Command::PasteBefore)
         }
-        Some('h') => {
-            let _ = input.next();
-            Some(Command::MoveLeft)
-        }
-        Some('l') => {
-            let _ = input.next();
-            Some(Command::MoveRight)
-        }
-        Some('j') => {
-            let _ = input.next();
-            Some(Command::MoveDown)
-        }
-        Some('k') => {
-            let _ = input.next();
-            Some(Command::MoveUp)
-        }
-        Some('w') => {
-            let _ = input.next();
-            Some(Command::MoveWordRightStart)
-        }
-        Some('W') => {
-            let _ = input.next();
-            Some(Command::MoveBigWordRightStart)
-        }
-        Some('e') => {
-            let _ = input.next();
-            Some(Command::MoveWordRightEnd)
-        }
-        Some('E') => {
-            let _ = input.next();
-            Some(Command::MoveBigWordRightEnd)
-        }
-        Some('b') => {
-            let _ = input.next();
-            Some(Command::MoveWordLeft)
-        }
-        Some('B') => {
-            let _ = input.next();
-            Some(Command::MoveBigWordLeft)
-        }
         Some('i') => {
             let _ = input.next();
             Some(Command::EnterViInsert)
@@ -66,14 +26,6 @@ where
         Some('a') => {
             let _ = input.next();
             Some(Command::EnterViAppend)
-        }
-        Some('0' | '^') => {
-            let _ = input.next();
-            Some(Command::MoveToLineStart)
-        }
-        Some('$') => {
-            let _ = input.next();
-            Some(Command::MoveToLineEnd)
         }
         Some('u') => {
             let _ = input.next();
@@ -89,8 +41,8 @@ where
         }
         Some('r') => {
             let _ = input.next();
-            match input.peek() {
-                Some(c) => Some(Command::ReplaceChar(**c)),
+            match input.next() {
+                Some(c) => Some(Command::ReplaceChar(*c)),
                 None => Some(Command::Incomplete),
             }
         }
@@ -122,61 +74,13 @@ where
             let _ = input.next();
             Some(Command::RewriteCurrentLine)
         }
-        Some('f') => {
-            let _ = input.next();
-            match input.peek() {
-                Some(&c) => {
-                    input.next();
-                    Some(Command::MoveRightUntil(*c))
-                }
-                None => Some(Command::Incomplete),
-            }
-        }
-        Some('t') => {
-            let _ = input.next();
-            match input.peek() {
-                Some(&c) => {
-                    input.next();
-                    Some(Command::MoveRightBefore(*c))
-                }
-                None => Some(Command::Incomplete),
-            }
-        }
-        Some('F') => {
-            let _ = input.next();
-            match input.peek() {
-                Some(&c) => {
-                    input.next();
-                    Some(Command::MoveLeftUntil(*c))
-                }
-                None => Some(Command::Incomplete),
-            }
-        }
-        Some('T') => {
-            let _ = input.next();
-            match input.peek() {
-                Some(&c) => {
-                    input.next();
-                    Some(Command::MoveLeftBefore(*c))
-                }
-                None => Some(Command::Incomplete),
-            }
-        }
-        Some(';') => {
-            let _ = input.next();
-            vi.last_to_till
-                .as_ref()
-                .map(|to_till| Command::ReplayToTill(to_till.clone()))
-        }
-        Some(',') => {
-            let _ = input.next();
-            vi.last_to_till
-                .as_ref()
-                .map(|to_till| Command::ReverseToTill(to_till.clone()))
-        }
         Some('~') => {
             let _ = input.next();
             Some(Command::Switchcase)
+        }
+        Some('.') => {
+            let _ = input.next();
+            Some(Command::RepeatLastAction)
         }
         _ => None,
     }
@@ -191,18 +95,6 @@ pub enum Command {
     SubstituteCharWithInsert,
     PasteAfter,
     PasteBefore,
-    MoveLeft,
-    MoveRight,
-    MoveUp,
-    MoveDown,
-    MoveWordRightStart,
-    MoveBigWordRightStart,
-    MoveWordRightEnd,
-    MoveBigWordRightEnd,
-    MoveWordLeft,
-    MoveBigWordLeft,
-    MoveToLineStart,
-    MoveToLineEnd,
     EnterViAppend,
     EnterViInsert,
     Undo,
@@ -212,35 +104,26 @@ pub enum Command {
     PrependToStart,
     RewriteCurrentLine,
     Change,
-    MoveRightUntil(char),
-    MoveRightBefore(char),
-    MoveLeftUntil(char),
-    MoveLeftBefore(char),
-    ReplayToTill(ViToTill),
-    ReverseToTill(ViToTill),
     HistorySearch,
     Switchcase,
+    RepeatLastAction,
 }
 
 impl Command {
-    pub fn to_reedline(&self) -> Vec<ReedlineOption> {
+    pub fn whole_line_char(&self) -> Option<char> {
         match self {
-            Self::MoveUp => vec![ReedlineOption::Event(ReedlineEvent::Up)],
-            Self::MoveDown => vec![ReedlineOption::Event(ReedlineEvent::Down)],
-            Self::MoveLeft => vec![ReedlineOption::Event(ReedlineEvent::Left)],
-            Self::MoveRight => vec![ReedlineOption::Event(ReedlineEvent::Right)],
-            Self::MoveToLineStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],
-            Self::MoveToLineEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
-            Self::MoveWordLeft => vec![ReedlineOption::Edit(EditCommand::MoveWordLeft)],
-            Self::MoveBigWordLeft => vec![ReedlineOption::Edit(EditCommand::MoveBigWordLeft)],
-            Self::MoveWordRightStart => vec![ReedlineOption::Edit(EditCommand::MoveWordRightStart)],
-            Self::MoveBigWordRightStart => {
-                vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightStart)]
-            }
-            Self::MoveWordRightEnd => vec![ReedlineOption::Edit(EditCommand::MoveWordRightEnd)],
-            Self::MoveBigWordRightEnd => {
-                vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightEnd)]
-            }
+            Command::Delete => Some('d'),
+            Command::Change => Some('c'),
+            _ => None,
+        }
+    }
+
+    pub fn requires_motion(&self) -> bool {
+        matches!(self, Command::Delete | Command::Change)
+    }
+
+    pub fn to_reedline(&self, vi_state: &mut Vi) -> Vec<ReedlineOption> {
+        match self {
             Self::EnterViInsert => vec![ReedlineOption::Event(ReedlineEvent::Repaint)],
             Self::EnterViAppend => vec![ReedlineOption::Edit(EditCommand::MoveRight)],
             Self::PasteAfter => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferAfter)],
@@ -251,26 +134,6 @@ impl Command {
             Self::AppendToEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
             Self::PrependToStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],
             Self::RewriteCurrentLine => vec![ReedlineOption::Edit(EditCommand::CutCurrentLine)],
-            Self::MoveRightUntil(c) => vec![
-                ReedlineOption::Event(ReedlineEvent::RecordToTill),
-                ReedlineOption::Edit(EditCommand::MoveRightUntil(*c)),
-            ],
-            Self::MoveRightBefore(c) => {
-                vec![
-                    ReedlineOption::Event(ReedlineEvent::RecordToTill),
-                    ReedlineOption::Edit(EditCommand::MoveRightBefore(*c)),
-                ]
-            }
-            Self::MoveLeftUntil(c) => vec![
-                ReedlineOption::Event(ReedlineEvent::RecordToTill),
-                ReedlineOption::Edit(EditCommand::MoveLeftUntil(*c)),
-            ],
-            Self::MoveLeftBefore(c) => vec![
-                ReedlineOption::Event(ReedlineEvent::RecordToTill),
-                ReedlineOption::Edit(EditCommand::MoveLeftBefore(*c)),
-            ],
-            Self::ReplayToTill(to_till) => vec![ReedlineOption::Edit(to_till.into())],
-            Self::ReverseToTill(to_till) => vec![ReedlineOption::Edit(to_till.reverse().into())],
             Self::DeleteChar => vec![ReedlineOption::Edit(EditCommand::CutChar)],
             Self::ReplaceChar(c) => {
                 vec![ReedlineOption::Edit(EditCommand::ReplaceChar(*c))]
@@ -280,10 +143,18 @@ impl Command {
             Self::Switchcase => vec![ReedlineOption::Edit(EditCommand::SwitchcaseChar)],
             // Mark a command as incomplete whenever a motion is required to finish the command
             Self::Delete | Self::Change | Self::Incomplete => vec![ReedlineOption::Incomplete],
+            Command::RepeatLastAction => match &vi_state.previous {
+                Some(event) => vec![ReedlineOption::Event(event.clone())],
+                None => vec![],
+            },
         }
     }
 
-    pub fn to_reedline_with_motion(&self, motion: &Motion) -> Option<Vec<ReedlineOption>> {
+    pub fn to_reedline_with_motion(
+        &self,
+        motion: &Motion,
+        vi_state: &mut Vi,
+    ) -> Option<Vec<ReedlineOption>> {
         match self {
             Self::Delete => match motion {
                 Motion::End => Some(vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)]),
@@ -303,18 +174,34 @@ impl Command {
                     Some(vec![ReedlineOption::Edit(EditCommand::CutBigWordLeft)])
                 }
                 Motion::RightUntil(c) => {
+                    vi_state.last_char_search = Some(ViCharSearch::ToRight(*c));
                     Some(vec![ReedlineOption::Edit(EditCommand::CutRightUntil(*c))])
                 }
                 Motion::RightBefore(c) => {
+                    vi_state.last_char_search = Some(ViCharSearch::TillRight(*c));
                     Some(vec![ReedlineOption::Edit(EditCommand::CutRightBefore(*c))])
                 }
                 Motion::LeftUntil(c) => {
+                    vi_state.last_char_search = Some(ViCharSearch::ToLeft(*c));
                     Some(vec![ReedlineOption::Edit(EditCommand::CutLeftUntil(*c))])
                 }
                 Motion::LeftBefore(c) => {
+                    vi_state.last_char_search = Some(ViCharSearch::TillLeft(*c));
                     Some(vec![ReedlineOption::Edit(EditCommand::CutLeftBefore(*c))])
                 }
                 Motion::Start => Some(vec![ReedlineOption::Edit(EditCommand::CutFromLineStart)]),
+                Motion::Left => Some(vec![ReedlineOption::Edit(EditCommand::Backspace)]),
+                Motion::Right => Some(vec![ReedlineOption::Edit(EditCommand::Delete)]),
+                Motion::Up => None,
+                Motion::Down => None,
+                Motion::ReplayCharSearch => vi_state
+                    .last_char_search
+                    .as_ref()
+                    .map(|char_search| vec![ReedlineOption::Edit(char_search.to_cut())]),
+                Motion::ReverseCharSearch => vi_state
+                    .last_char_search
+                    .as_ref()
+                    .map(|char_search| vec![ReedlineOption::Edit(char_search.reverse().to_cut())]),
             },
             Self::Change => {
                 let op = match motion {
@@ -342,19 +229,36 @@ impl Command {
                         Some(vec![ReedlineOption::Edit(EditCommand::CutBigWordLeft)])
                     }
                     Motion::RightUntil(c) => {
+                        vi_state.last_char_search = Some(ViCharSearch::ToRight(*c));
                         Some(vec![ReedlineOption::Edit(EditCommand::CutRightUntil(*c))])
                     }
                     Motion::RightBefore(c) => {
+                        vi_state.last_char_search = Some(ViCharSearch::TillRight(*c));
                         Some(vec![ReedlineOption::Edit(EditCommand::CutRightBefore(*c))])
                     }
                     Motion::LeftUntil(c) => {
+                        vi_state.last_char_search = Some(ViCharSearch::ToLeft(*c));
                         Some(vec![ReedlineOption::Edit(EditCommand::CutLeftUntil(*c))])
                     }
                     Motion::LeftBefore(c) => {
+                        vi_state.last_char_search = Some(ViCharSearch::TillLeft(*c));
                         Some(vec![ReedlineOption::Edit(EditCommand::CutLeftBefore(*c))])
                     }
                     Motion::Start => {
                         Some(vec![ReedlineOption::Edit(EditCommand::CutFromLineStart)])
+                    }
+                    Motion::Left => Some(vec![ReedlineOption::Edit(EditCommand::Backspace)]),
+                    Motion::Right => Some(vec![ReedlineOption::Edit(EditCommand::Delete)]),
+                    Motion::Up => None,
+                    Motion::Down => None,
+                    Motion::ReplayCharSearch => vi_state
+                        .last_char_search
+                        .as_ref()
+                        .map(|char_search| vec![ReedlineOption::Edit(char_search.to_cut())]),
+                    Motion::ReverseCharSearch => {
+                        vi_state.last_char_search.as_ref().map(|char_search| {
+                            vec![ReedlineOption::Edit(char_search.reverse().to_cut())]
+                        })
                     }
                 };
                 // Semihack: Append `Repaint` to ensure the mode change gets displayed
@@ -365,59 +269,5 @@ impl Command {
             }
             _ => None,
         }
-    }
-}
-
-impl From<ViToTill> for EditCommand {
-    fn from(val: ViToTill) -> Self {
-        EditCommand::from(&val)
-    }
-}
-
-impl From<&ViToTill> for EditCommand {
-    fn from(val: &ViToTill) -> Self {
-        match val {
-            ViToTill::TillLeft(c) => EditCommand::MoveLeftBefore(*c),
-            ViToTill::ToLeft(c) => EditCommand::MoveLeftUntil(*c),
-            ViToTill::TillRight(c) => EditCommand::MoveRightBefore(*c),
-            ViToTill::ToRight(c) => EditCommand::MoveRightUntil(*c),
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use pretty_assertions::assert_eq;
-    use rstest::rstest;
-
-    #[rstest]
-    #[case(';', None, None)]
-    #[case(',', None, None)]
-    #[case(
-        ';',
-        Some(ViToTill::ToRight('X')),
-        Some(Command::ReplayToTill(ViToTill::ToRight('X')))
-    )]
-    #[case(
-        ',',
-        Some(ViToTill::ToRight('X')),
-        Some(Command::ReverseToTill(ViToTill::ToRight('X')))
-    )]
-    fn repeat_to_till(
-        #[case] input: char,
-        #[case] last_to_till: Option<ViToTill>,
-        #[case] expected: Option<Command>,
-    ) {
-        let vi = Vi {
-            last_to_till,
-            ..Vi::default()
-        };
-
-        let input = vec![input];
-
-        let result = parse_command(&vi, &mut input.iter().peekable());
-
-        assert_eq!(result, expected);
     }
 }

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -283,12 +283,8 @@ impl Command {
         }
     }
 
-    pub fn to_reedline_with_motion(
-        &self,
-        motion: &Motion,
-        count: &Option<usize>,
-    ) -> Option<Vec<ReedlineOption>> {
-        let edits = match self {
+    pub fn to_reedline_with_motion(&self, motion: &Motion) -> Option<Vec<ReedlineOption>> {
+        match self {
             Self::Delete => match motion {
                 Motion::End => Some(vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)]),
                 Motion::Line => Some(vec![ReedlineOption::Edit(EditCommand::CutCurrentLine)]),
@@ -368,16 +364,6 @@ impl Command {
                 })
             }
             _ => None,
-        };
-
-        match count {
-            Some(count) => edits.map(|edits| {
-                std::iter::repeat(edits)
-                    .take(*count)
-                    .flatten()
-                    .collect::<Vec<ReedlineOption>>()
-            }),
-            None => edits,
         }
     }
 }

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -320,61 +320,53 @@ impl Command {
                 }
                 Motion::Start => Some(vec![ReedlineOption::Edit(EditCommand::CutFromLineStart)]),
             },
-            Self::Change => match motion {
-                Motion::End => Some(vec![
-                    ReedlineOption::Edit(EditCommand::ClearToLineEnd),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::Line => Some(vec![
-                    ReedlineOption::Edit(EditCommand::MoveToStart),
-                    ReedlineOption::Edit(EditCommand::ClearToLineEnd),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::NextWord => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutWordRightToNext),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::NextBigWord => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutBigWordRightToNext),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::NextWordEnd => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutWordRight),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::NextBigWordEnd => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutBigWordRight),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::PreviousWord => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutWordLeft),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::PreviousBigWord => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutBigWordLeft),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::RightUntil(c) => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutRightUntil(*c)),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::RightBefore(c) => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutRightBefore(*c)),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::LeftUntil(c) => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutLeftUntil(*c)),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::LeftBefore(c) => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutLeftBefore(*c)),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-                Motion::Start => Some(vec![
-                    ReedlineOption::Edit(EditCommand::CutFromLineStart),
-                    ReedlineOption::Event(ReedlineEvent::Repaint),
-                ]),
-            },
+            Self::Change => {
+                let op = match motion {
+                    Motion::End => Some(vec![ReedlineOption::Edit(EditCommand::ClearToLineEnd)]),
+                    Motion::Line => Some(vec![
+                        ReedlineOption::Edit(EditCommand::MoveToStart),
+                        ReedlineOption::Edit(EditCommand::ClearToLineEnd),
+                    ]),
+                    Motion::NextWord => {
+                        Some(vec![ReedlineOption::Edit(EditCommand::CutWordRightToNext)])
+                    }
+                    Motion::NextBigWord => Some(vec![ReedlineOption::Edit(
+                        EditCommand::CutBigWordRightToNext,
+                    )]),
+                    Motion::NextWordEnd => {
+                        Some(vec![ReedlineOption::Edit(EditCommand::CutWordRight)])
+                    }
+                    Motion::NextBigWordEnd => {
+                        Some(vec![ReedlineOption::Edit(EditCommand::CutBigWordRight)])
+                    }
+                    Motion::PreviousWord => {
+                        Some(vec![ReedlineOption::Edit(EditCommand::CutWordLeft)])
+                    }
+                    Motion::PreviousBigWord => {
+                        Some(vec![ReedlineOption::Edit(EditCommand::CutBigWordLeft)])
+                    }
+                    Motion::RightUntil(c) => {
+                        Some(vec![ReedlineOption::Edit(EditCommand::CutRightUntil(*c))])
+                    }
+                    Motion::RightBefore(c) => {
+                        Some(vec![ReedlineOption::Edit(EditCommand::CutRightBefore(*c))])
+                    }
+                    Motion::LeftUntil(c) => {
+                        Some(vec![ReedlineOption::Edit(EditCommand::CutLeftUntil(*c))])
+                    }
+                    Motion::LeftBefore(c) => {
+                        Some(vec![ReedlineOption::Edit(EditCommand::CutLeftBefore(*c))])
+                    }
+                    Motion::Start => {
+                        Some(vec![ReedlineOption::Edit(EditCommand::CutFromLineStart)])
+                    }
+                };
+                // Semihack: Append `Repaint` to ensure the mode change gets displayed
+                op.map(|mut vec| {
+                    vec.push(ReedlineOption::Event(ReedlineEvent::Repaint));
+                    vec
+                })
+            }
             _ => None,
         };
 

--- a/src/edit_mode/vi/motion.rs
+++ b/src/edit_mode/vi/motion.rs
@@ -1,56 +1,73 @@
 use std::iter::Peekable;
 
-use crate::EditCommand;
+use crate::{EditCommand, ReedlineEvent, Vi};
 
-pub fn parse_motion<'iter, I>(input: &mut Peekable<I>) -> Option<Motion>
+use super::parser::{ParseResult, ReedlineOption};
+
+pub fn parse_motion<'iter, I>(
+    input: &mut Peekable<I>,
+    command_char: Option<char>,
+) -> ParseResult<Motion>
 where
     I: Iterator<Item = &'iter char>,
 {
     match input.peek() {
+        Some('h') => {
+            let _ = input.next();
+            ParseResult::Valid(Motion::Left)
+        }
+        Some('l') => {
+            let _ = input.next();
+            ParseResult::Valid(Motion::Right)
+        }
+        Some('j') => {
+            let _ = input.next();
+            ParseResult::Valid(Motion::Down)
+        }
+        Some('k') => {
+            let _ = input.next();
+            ParseResult::Valid(Motion::Up)
+        }
         Some('b') => {
             let _ = input.next();
-            Some(Motion::PreviousWord)
+            ParseResult::Valid(Motion::PreviousWord)
         }
         Some('B') => {
             let _ = input.next();
-            Some(Motion::PreviousBigWord)
+            ParseResult::Valid(Motion::PreviousBigWord)
         }
         Some('w') => {
             let _ = input.next();
-            Some(Motion::NextWord)
+            ParseResult::Valid(Motion::NextWord)
         }
         Some('W') => {
             let _ = input.next();
-            Some(Motion::NextBigWord)
+            ParseResult::Valid(Motion::NextBigWord)
         }
         Some('e') => {
             let _ = input.next();
-            Some(Motion::NextWordEnd)
+            ParseResult::Valid(Motion::NextWordEnd)
         }
         Some('E') => {
             let _ = input.next();
-            Some(Motion::NextBigWordEnd)
-        }
-        Some('d') => {
-            let _ = input.next();
-            Some(Motion::Line)
+            ParseResult::Valid(Motion::NextBigWordEnd)
         }
         Some('0' | '^') => {
             let _ = input.next();
-            Some(Motion::Start)
+            ParseResult::Valid(Motion::Start)
         }
         Some('$') => {
             let _ = input.next();
-            Some(Motion::End)
+            ParseResult::Valid(Motion::End)
         }
         Some('f') => {
             let _ = input.next();
             match input.peek() {
                 Some(&x) => {
                     input.next();
-                    Some(Motion::RightUntil(*x))
+                    ParseResult::Valid(Motion::RightUntil(*x))
                 }
-                None => None,
+                None => ParseResult::Incomplete,
             }
         }
         Some('t') => {
@@ -58,9 +75,9 @@ where
             match input.peek() {
                 Some(&x) => {
                     input.next();
-                    Some(Motion::RightBefore(*x))
+                    ParseResult::Valid(Motion::RightBefore(*x))
                 }
-                None => None,
+                None => ParseResult::Incomplete,
             }
         }
         Some('F') => {
@@ -68,9 +85,9 @@ where
             match input.peek() {
                 Some(&x) => {
                     input.next();
-                    Some(Motion::LeftUntil(*x))
+                    ParseResult::Valid(Motion::LeftUntil(*x))
                 }
-                None => None,
+                None => ParseResult::Incomplete,
             }
         }
         Some('T') => {
@@ -78,17 +95,34 @@ where
             match input.peek() {
                 Some(&x) => {
                     input.next();
-                    Some(Motion::LeftBefore(*x))
+                    ParseResult::Valid(Motion::LeftBefore(*x))
                 }
-                None => None,
+                None => ParseResult::Incomplete,
             }
         }
-        _ => None,
+        Some(';') => {
+            let _ = input.next();
+            ParseResult::Valid(Motion::ReplayCharSearch)
+        }
+        Some(',') => {
+            let _ = input.next();
+            ParseResult::Valid(Motion::ReverseCharSearch)
+        }
+        ch if ch == command_char.as_ref().as_ref() && command_char.is_some() => {
+            let _ = input.next();
+            ParseResult::Valid(Motion::Line)
+        }
+        None => ParseResult::Incomplete,
+        _ => ParseResult::Invalid,
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Motion {
+    Left,
+    Right,
+    Up,
+    Down,
     NextWord,
     NextBigWord,
     NextWordEnd,
@@ -102,11 +136,63 @@ pub enum Motion {
     RightBefore(char),
     LeftUntil(char),
     LeftBefore(char),
+    ReplayCharSearch,
+    ReverseCharSearch,
+}
+
+impl Motion {
+    pub fn to_reedline(&self, vi_state: &mut Vi) -> Vec<ReedlineOption> {
+        match self {
+            Motion::Left => vec![ReedlineOption::Event(ReedlineEvent::Left)],
+            Motion::Right => vec![ReedlineOption::Event(ReedlineEvent::Right)],
+            Motion::Up => vec![ReedlineOption::Event(ReedlineEvent::Up)],
+            Motion::Down => vec![ReedlineOption::Event(ReedlineEvent::Down)],
+            Motion::NextWord => vec![ReedlineOption::Edit(EditCommand::MoveWordRightStart)],
+            Motion::NextBigWord => vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightStart)],
+            Motion::NextWordEnd => vec![ReedlineOption::Edit(EditCommand::MoveWordRightEnd)],
+            Motion::NextBigWordEnd => vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightEnd)],
+            Motion::PreviousWord => vec![ReedlineOption::Edit(EditCommand::MoveWordLeft)],
+            Motion::PreviousBigWord => vec![ReedlineOption::Edit(EditCommand::MoveBigWordLeft)],
+            Motion::Line => vec![], // Placeholder as unusable standalone motion
+            Motion::Start => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],
+            Motion::End => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
+            Motion::RightUntil(ch) => {
+                vi_state.last_char_search = Some(ViCharSearch::ToRight(*ch));
+                vec![ReedlineOption::Edit(EditCommand::MoveRightUntil(*ch))]
+            }
+            Motion::RightBefore(ch) => {
+                vi_state.last_char_search = Some(ViCharSearch::TillRight(*ch));
+                vec![ReedlineOption::Edit(EditCommand::MoveRightBefore(*ch))]
+            }
+            Motion::LeftUntil(ch) => {
+                vi_state.last_char_search = Some(ViCharSearch::ToLeft(*ch));
+                vec![ReedlineOption::Edit(EditCommand::MoveLeftUntil(*ch))]
+            }
+            Motion::LeftBefore(ch) => {
+                vi_state.last_char_search = Some(ViCharSearch::TillLeft(*ch));
+                vec![ReedlineOption::Edit(EditCommand::MoveLeftBefore(*ch))]
+            }
+            Motion::ReplayCharSearch => {
+                if let Some(char_search) = vi_state.last_char_search.as_ref() {
+                    vec![ReedlineOption::Edit(char_search.to_move())]
+                } else {
+                    vec![]
+                }
+            }
+            Motion::ReverseCharSearch => {
+                if let Some(char_search) = vi_state.last_char_search.as_ref() {
+                    vec![ReedlineOption::Edit(char_search.reverse().to_move())]
+                } else {
+                    vec![]
+                }
+            }
+        }
+    }
 }
 
 /// Vi left-right motions to or till a character.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum ViToTill {
+pub enum ViCharSearch {
     /// f
     ToRight(char),
     /// F
@@ -117,26 +203,32 @@ pub enum ViToTill {
     TillLeft(char),
 }
 
-impl ViToTill {
+impl ViCharSearch {
     /// Swap the direction of the to or till for ','
     pub fn reverse(&self) -> Self {
         match self {
-            ViToTill::ToRight(c) => ViToTill::ToLeft(*c),
-            ViToTill::ToLeft(c) => ViToTill::ToRight(*c),
-            ViToTill::TillRight(c) => ViToTill::TillLeft(*c),
-            ViToTill::TillLeft(c) => ViToTill::TillRight(*c),
+            ViCharSearch::ToRight(c) => ViCharSearch::ToLeft(*c),
+            ViCharSearch::ToLeft(c) => ViCharSearch::ToRight(*c),
+            ViCharSearch::TillRight(c) => ViCharSearch::TillLeft(*c),
+            ViCharSearch::TillLeft(c) => ViCharSearch::TillRight(*c),
         }
     }
-}
 
-impl From<EditCommand> for Option<ViToTill> {
-    fn from(edit: EditCommand) -> Self {
-        match edit {
-            EditCommand::MoveLeftBefore(c) => Some(ViToTill::TillLeft(c)),
-            EditCommand::MoveLeftUntil(c) => Some(ViToTill::ToLeft(c)),
-            EditCommand::MoveRightBefore(c) => Some(ViToTill::TillRight(c)),
-            EditCommand::MoveRightUntil(c) => Some(ViToTill::ToRight(c)),
-            _ => None,
+    pub fn to_move(&self) -> EditCommand {
+        match self {
+            ViCharSearch::ToRight(c) => EditCommand::MoveRightUntil(*c),
+            ViCharSearch::ToLeft(c) => EditCommand::MoveLeftUntil(*c),
+            ViCharSearch::TillRight(c) => EditCommand::MoveRightBefore(*c),
+            ViCharSearch::TillLeft(c) => EditCommand::MoveLeftBefore(*c),
+        }
+    }
+
+    pub fn to_cut(&self) -> EditCommand {
+        match self {
+            ViCharSearch::ToRight(c) => EditCommand::CutRightUntil(*c),
+            ViCharSearch::ToLeft(c) => EditCommand::CutLeftUntil(*c),
+            ViCharSearch::TillRight(c) => EditCommand::CutRightBefore(*c),
+            ViCharSearch::TillLeft(c) => EditCommand::CutLeftBefore(*c),
         }
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -692,8 +692,7 @@ impl Reedline {
             | ReedlineEvent::MenuLeft
             | ReedlineEvent::MenuRight
             | ReedlineEvent::MenuPageNext
-            | ReedlineEvent::MenuPagePrevious
-            | ReedlineEvent::RecordToTill => Ok(EventStatus::Inapplicable),
+            | ReedlineEvent::MenuPagePrevious => Ok(EventStatus::Inapplicable),
         }
     }
 
@@ -990,9 +989,7 @@ impl Reedline {
                 // Exhausting the event handlers is still considered handled
                 Ok(EventStatus::Inapplicable)
             }
-            ReedlineEvent::None | ReedlineEvent::Mouse | ReedlineEvent::RecordToTill => {
-                Ok(EventStatus::Inapplicable)
-            }
+            ReedlineEvent::None | ReedlineEvent::Mouse => Ok(EventStatus::Inapplicable),
         }
     }
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -497,9 +497,6 @@ pub enum ReedlineEvent {
 
     /// Open text editor
     OpenEditor,
-
-    /// Record vi to or till motion
-    RecordToTill,
 }
 
 impl Display for ReedlineEvent {
@@ -541,7 +538,6 @@ impl Display for ReedlineEvent {
             ReedlineEvent::MenuPagePrevious => write!(f, "MenuPagePrevious"),
             ReedlineEvent::ExecuteHostCommand(_) => write!(f, "ExecuteHostCommand"),
             ReedlineEvent::OpenEditor => write!(f, "OpenEditor"),
-            ReedlineEvent::RecordToTill => write!(f, "RecordToTill"),
         }
     }
 }


### PR DESCRIPTION
### Make the `c` action translation more explicit

Move the `Repaint` addition outside to ensure it is always added.
Currently required to detect the mode change visually.

### Simplify application of multiplier

Take into account that only the product of the `multiplier` and `count` are relevant to execute motions.

From https://github.com/vim/vim/blob/140f6d0eda7921f2f0b057ec38ed501240903fc3/runtime/doc/motion.txt#L63-L70

> If the motion includes a count and the operator also had a count before it,
> the two counts are multiplied.  For example: "2d3w" deletes six words.
> When doubling the operator it operates on a line.  When using a count, before
> or after the first character, that many lines are operated upon.  Thus `3dd`
> deletes three lines. A count before and after the first character is
> multiplied, thus `2y3y` yanks six lines.

### Add tests for `cut_right_until_char`

I discovered a limitation in how we handle character searches with a multiplier in the case the search character appears in a consecutive sequence.
Fixing this correctly probably requires performing the search with knowledge of the multiplier.

### Parse motions properly, fix #449, add combinations

This change truly separates the actions and the motions on the parsing side. Bare motions are parsed by the motion parser instead of the command parser. (This requires a separate `ParseResult` to distinguish valid but incomplete motions like `f` from invalid motions.)

Fixes https://github.com/nushell/reedline/issues/449 by making `.` its own command. Also introduces the possibility of multiplying the `.` repeat and resticts its effect to the action commands and ignores the bare moves.

Simplify and make the `;` and `,` behavior more correct:
- Place info in the `Vi` state instead of complicated in-band signal
- Support using it with `d;` and `c;`
- Store the character search when combined with an action
- Rename `ViToTill` more explictly to `ViCharSearch`
- **Missing:** the old tests were removed as they tested old quirks

The above change also leads to proper separation of concern between parsing and translation to emacs commands (and subsequent execution).

Add support for combining `d/c` with `h/l`.
**Note:** `j/k` are still omitted as they require new behavior in the linebuffer/editor. Also `dj` has to add 1 to the multiplier to achieve the correct behavior as we do not model line ex-/inclusive behavior.

Rename `ParseResult` to `ParsedViSequence`