### PR TITLE
List that space can be bound through `Char(' ')`

### DIFF
--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -9,7 +9,7 @@ use strum::IntoEnumIterator;
 struct ReedLineCrossTermKeyCode(crossterm::event::KeyCode);
 impl ReedLineCrossTermKeyCode {
     fn iterator() -> std::slice::Iter<'static, ReedLineCrossTermKeyCode> {
-        static KEYCODE: [ReedLineCrossTermKeyCode; 18] = [
+        static KEYCODE: [ReedLineCrossTermKeyCode; 19] = [
             ReedLineCrossTermKeyCode(KeyCode::Backspace),
             ReedLineCrossTermKeyCode(KeyCode::Enter),
             ReedLineCrossTermKeyCode(KeyCode::Left),
@@ -25,6 +25,7 @@ impl ReedLineCrossTermKeyCode {
             ReedLineCrossTermKeyCode(KeyCode::Delete),
             ReedLineCrossTermKeyCode(KeyCode::Insert),
             ReedLineCrossTermKeyCode(KeyCode::F(1)),
+            ReedLineCrossTermKeyCode(KeyCode::Char(' ')),
             ReedLineCrossTermKeyCode(KeyCode::Char('a')),
             ReedLineCrossTermKeyCode(KeyCode::Null),
             ReedLineCrossTermKeyCode(KeyCode::Esc),
@@ -52,6 +53,7 @@ impl Display for ReedLineCrossTermKeyCode {
                 KeyCode::Delete => write!(f, "Delete"),
                 KeyCode::Insert => write!(f, "Insert"),
                 KeyCode::F(_) => write!(f, "F<number>"),
+                KeyCode::Char(' ') => write!(f, "Space"),
                 KeyCode::Char(_) => write!(f, "Char_<letter>"),
                 KeyCode::Null => write!(f, "Null"),
                 KeyCode::Esc => write!(f, "Esc"),


### PR DESCRIPTION
Necessary to complete nushell/nushell#6590

(Comment: this whole module feels intricately linked to the nushell
implementation as we do not implement the string parsing in reedline)
