### PR TITLE
Remove flicker on external print

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,12 @@ jobs:
         rust:
           - stable
         # Define the feature sets that will be built here (for caching you define a separate name)
-        style: [bashisms, default, sqlite, basqlite]
+        style: [bashisms, default, sqlite, basqlite, external_printer]
         include:
           - style: bashisms
             flags: "--features bashisms"
+          - style: external_printer
+            flags: "--features external_printer"
           - style: default
             flags: ""
           - style: sqlite

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -3,16 +3,18 @@ use {
     crate::{
         menu::{Menu, ReedlineMenu},
         painting::PromptLines,
-        LineBuffer, Prompt,
+        Prompt,
     },
     crossterm::{
-        cursor::{self, MoveTo, MoveUp, RestorePosition, SavePosition},
+        cursor::{self, MoveTo, RestorePosition, SavePosition},
         style::{Attribute, Print, ResetColor, SetAttribute, SetForegroundColor},
         terminal::{self, Clear, ClearType, ScrollUp},
         QueueableCommand, Result,
     },
     std::io::Write,
 };
+#[cfg(feature = "external_printer")]
+use {crate::LineBuffer, crossterm::cursor::MoveUp};
 
 // Returns a string that skips N number of lines with the next offset of lines
 // An offset of 0 would return only one line after skipping the required lines
@@ -457,6 +459,7 @@ impl Painter {
     ///
     /// This function doesn't flush the buffer. So buffer should be flushed
     /// afterwards perhaps by repainting the prompt via `repaint_buffer()`.
+    #[cfg(feature = "external_printer")]
     pub(crate) fn print_external_message(
         &mut self,
         messages: Vec<String>,

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -457,7 +457,7 @@ impl Painter {
     ///
     /// This function doesn't flush the buffer. So buffer should be flushed
     /// afterwards perhaps by repainting the prompt via `repaint_buffer()`.
-    pub fn print_external_message(
+    pub(crate) fn print_external_message(
         &mut self,
         messages: Vec<String>,
         line_buffer: &LineBuffer,


### PR DESCRIPTION
Just tested external print and noticed this issue. It's not super important, but nice to have.

Previously each external print was causing a visible flicker on at least two terminal emulators I've tested (alacritty, xfce4-terminal).

I'm not sure this is the best solution. I've looked into just removing `.flush()` in the `print_line`. The latter is used in just two places here and in printing history. It would be fine to also optimize out flush on every line when printing history, however that would likely break abstraction and make painter somewhat more stateful (i.e. needs exposing `.painter.stdout.flush()` in a some way).

Current approach also makes painter a bit stateful and works just because `self.paint()` is called right after `print_external_message` (https://github.com/nushell/reedline/blob/f994cc9/src/engine.rs#L492-L497), but at least scope of that dependency is a local enough. Feel free to suggest a better way.