### PR TITLE
On Backspace and MoveToLineStart, deactivate menu and do not complete

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -896,25 +896,31 @@ impl Reedline {
                 self.run_edit_commands(&commands);
                 if let Some(menu) = self.menus.iter_mut().find(|men| men.is_active()) {
                     if self.quick_completions && menu.can_quick_complete() {
-                        menu.menu_event(MenuEvent::Edit(self.quick_completions));
-                        menu.update_values(
-                            &mut self.editor,
-                            self.completer.as_mut(),
-                            self.history.as_ref(),
-                        );
-
-                        if menu.get_values().len() == 1 {
-                            return self.handle_editor_event(prompt, ReedlineEvent::Enter);
+                        match commands.first() {
+                            Some(&EditCommand::Backspace)
+                            | Some(&EditCommand::BackspaceWord)
+                            | Some(&EditCommand::MoveToLineStart) => {
+                                menu.menu_event(MenuEvent::Deactivate)
+                            }
+                            _ => {
+                                menu.menu_event(MenuEvent::Edit(self.quick_completions));
+                                menu.update_values(
+                                    &mut self.editor,
+                                    self.completer.as_mut(),
+                                    self.history.as_ref(),
+                                );
+                                if menu.get_values().len() == 1 {
+                                    return self.handle_editor_event(prompt, ReedlineEvent::Enter);
+                                }
+                                if self.editor.line_buffer().get_buffer().is_empty() {
+                                    menu.menu_event(MenuEvent::Deactivate);
+                                } else {
+                                    menu.menu_event(MenuEvent::Edit(self.quick_completions));
+                                }
+                            }
                         }
                     }
-
-                    if self.editor.line_buffer().get_buffer().is_empty() {
-                        menu.menu_event(MenuEvent::Deactivate);
-                    } else {
-                        menu.menu_event(MenuEvent::Edit(self.quick_completions));
-                    }
                 }
-
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::OpenEditor => self.open_editor().map(|_| EventStatus::Handled),


### PR DESCRIPTION
Draft PR, fixes https://github.com/nushell/nushell/issues/5497

As described in https://github.com/nushell/nushell/issues/5497 and in [Discord #completions](https://discord.com/channels/601130461678272522/958067223187062834/1023220198473465996) `Backspace` is causing the completions menu to be updated when it should not (the user is simply deleting; they're not asking for completions of the shorter input). Furthermore `MoveToLineStart` does something similar, but even more obviously incorrect, and sometimes the menu is rendered incorrectly (see screenshots in [Discord #completions](https://discord.com/channels/601130461678272522/958067223187062834/1023220198473465996)).

This PR changes things so that `Backspace`, `BackspaceWord` and `MoveToLineStart` deactivate the completions menu, instead of triggering completions of the new, shorter, input.

(The diff is mostly indentation changes)
