### PR TITLE
Add `Submit` and `SubmitOrNewline` editor events

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -22,6 +22,9 @@ pub fn default_emacs_keybindings() -> Keybindings {
     add_common_navigation_bindings(&mut kb);
     add_common_edit_bindings(&mut kb);
 
+    // This could be in common, but in Vi it also changes the mode
+    kb.add_binding(KM::NONE, KC::Enter, ReedlineEvent::Enter);
+
     // *** CTRL ***
     // Moves
     kb.add_binding(
@@ -141,7 +144,6 @@ impl EditMode for Emacs {
                             .unwrap_or(ReedlineEvent::None)
                     }
                 }
-                (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,
                 _ => self
                     .keybindings
                     .find_binding(modifiers, code)

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -422,6 +422,12 @@ pub enum ReedlineEvent {
     /// Handle enter event
     Enter,
 
+    /// Handle unconditional submit event
+    Submit,
+
+    /// Submit at the end of the *complete* text, otherwise newline
+    SubmitOrNewline,
+
     /// Esc event
     Esc,
 
@@ -510,6 +516,8 @@ impl Display for ReedlineEvent {
             ReedlineEvent::ClearScreen => write!(f, "ClearScreen"),
             ReedlineEvent::ClearScrollback => write!(f, "ClearScrollback"),
             ReedlineEvent::Enter => write!(f, "Enter"),
+            ReedlineEvent::Submit => write!(f, "Submit"),
+            ReedlineEvent::SubmitOrNewline => write!(f, "SubmitOrNewline"),
             ReedlineEvent::Esc => write!(f, "Esc"),
             ReedlineEvent::Mouse => write!(f, "Mouse"),
             ReedlineEvent::Resize(_, _) => write!(f, "Resize <int> <int>"),


### PR DESCRIPTION
* `Submit` is used to return data unconditionally. This is useful for example if you want compiler to show you where the unclosed paren that doesn't pass validation actually is.
* `SubmitOrNewline` is similar to `Enter` but inserts a new line if the cursor is not at the end of the buffer. It's useful to insert newlines in the middle of the text when editing.

This also removes unconditional `KeyCode::Enter` to `ReedlineEvent::Enter` event mapping and sets it in the keybindings normally (so you can rebind to `Submit` or `SubmitOrNewline`)