### PR TITLE
render right prompt on the last line of the left prompt

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -183,16 +183,19 @@ impl Painter {
             .screen_width()
             .saturating_sub(prompt_length_right as u16);
         let input_width = lines.estimate_first_input_line_width();
-        let screen_width = self.screen_width();
-        let required_lines = lines.required_lines(screen_width, None);
+
+        let mut row = self.prompt_start_row;
+        if lines.right_prompt_on_last_line {
+            let screen_width = self.screen_width();
+            let required_lines = lines.required_lines(screen_width, None);
+
+            row += required_lines.saturating_sub(1);
+        }
 
         if input_width <= start_position {
             self.stdout
                 .queue(SavePosition)?
-                .queue(cursor::MoveTo(
-                    start_position,
-                    self.prompt_start_row + required_lines.saturating_sub(1),
-                ))?
+                .queue(cursor::MoveTo(start_position, row))?
                 .queue(Print(&coerce_crlf(&lines.prompt_str_right)))?
                 .queue(RestorePosition)?;
         }

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -182,13 +182,12 @@ impl Painter {
         let start_position = self
             .screen_width()
             .saturating_sub(prompt_length_right as u16);
-        let input_width = lines.estimate_first_input_line_width();
+        let screen_width = self.screen_width();
+        let input_width = lines.estimate_right_prompt_line_width(screen_width);
 
         let mut row = self.prompt_start_row;
         if lines.right_prompt_on_last_line {
-            let screen_width = self.screen_width();
             let required_lines = lines.required_lines(screen_width, None);
-
             row += required_lines.saturating_sub(1);
         }
 

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -183,11 +183,16 @@ impl Painter {
             .screen_width()
             .saturating_sub(prompt_length_right as u16);
         let input_width = lines.estimate_first_input_line_width();
+        let screen_width = self.screen_width();
+        let required_lines = lines.required_lines(screen_width, None);
 
         if input_width <= start_position {
             self.stdout
                 .queue(SavePosition)?
-                .queue(cursor::MoveTo(start_position, self.prompt_start_row))?
+                .queue(cursor::MoveTo(
+                    start_position,
+                    self.prompt_start_row + required_lines.saturating_sub(1),
+                ))?
                 .queue(Print(&coerce_crlf(&lines.prompt_str_right)))?
                 .queue(RestorePosition)?;
         }

--- a/src/painting/prompt_lines.rs
+++ b/src/painting/prompt_lines.rs
@@ -14,6 +14,7 @@ pub(crate) struct PromptLines<'prompt> {
     pub(crate) before_cursor: Cow<'prompt, str>,
     pub(crate) after_cursor: Cow<'prompt, str>,
     pub(crate) hint: Cow<'prompt, str>,
+    pub(crate) right_prompt_on_last_line: bool,
 }
 
 impl<'prompt> PromptLines<'prompt> {
@@ -39,6 +40,7 @@ impl<'prompt> PromptLines<'prompt> {
         let before_cursor = coerce_crlf(before_cursor);
         let after_cursor = coerce_crlf(after_cursor);
         let hint = coerce_crlf(hint);
+        let right_prompt_on_last_line = prompt.right_prompt_on_last_line();
 
         Self {
             prompt_str_left,
@@ -47,6 +49,7 @@ impl<'prompt> PromptLines<'prompt> {
             before_cursor,
             after_cursor,
             hint,
+            right_prompt_on_last_line,
         }
     }
 

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -113,4 +113,9 @@ pub trait Prompt: Send {
     fn get_prompt_right_color(&self) -> Color {
         DEFAULT_PROMPT_RIGHT_COLOR
     }
+
+    /// Whether to render right prompt on the last line
+    fn right_prompt_on_last_line(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
This PR makes nushell+starship behave like other shells (e.g. zsh).
Related: starship/starship#3982 
Closes nushell/nushell#4909

* nushell native prompt
![Screenshot from 2022-10-16 00-06-28](https://user-images.githubusercontent.com/15247421/195997220-4112fc33-054a-43c4-980a-ddf22451a3e9.png)
* nushell + starship(disable `line_break` and `add_newline`)
![Screenshot from 2022-10-16 00-07-09](https://user-images.githubusercontent.com/15247421/195997225-e56e0f16-529c-43ef-a681-908ff0627a14.png)
* nushell + starship(enable `line_break` and disable `add_newline`)
![Screenshot from 2022-10-16 00-07-51](https://user-images.githubusercontent.com/15247421/195997228-b92f76a6-25a2-4b86-9454-ee2f70635527.png)
* nushell + starship(enable `line_break` and `add_newline`)
![Screenshot from 2022-10-16 00-08-34](https://user-images.githubusercontent.com/15247421/195997237-e913478b-b15a-4eaf-b8d1-6c94445a1a0a.png)
