### PR TITLE
change cursor shape depending on edit mode

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1354,8 +1354,13 @@ impl Reedline {
                 "",
             );
 
-            self.painter
-                .repaint_buffer(prompt, &lines, None, self.use_ansi_coloring)?;
+            self.painter.repaint_buffer(
+                prompt,
+                &lines,
+                self.prompt_edit_mode(),
+                None,
+                self.use_ansi_coloring,
+            )?;
         }
 
         Ok(())
@@ -1416,8 +1421,13 @@ impl Reedline {
 
         let menu = self.menus.iter().find(|menu| menu.is_active());
 
-        self.painter
-            .repaint_buffer(prompt, &lines, menu, self.use_ansi_coloring)
+        self.painter.repaint_buffer(
+            prompt,
+            &lines,
+            self.prompt_edit_mode(),
+            menu,
+            self.use_ansi_coloring,
+        )
     }
 
     /// Adds an external printer

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1,3 +1,5 @@
+use crate::PromptEditMode;
+
 use {
     super::utils::{coerce_crlf, line_width},
     crate::{
@@ -132,6 +134,7 @@ impl Painter {
         &mut self,
         prompt: &dyn Prompt,
         lines: &PromptLines,
+        prompt_mode: PromptEditMode,
         menu: Option<&ReedlineMenu>,
         use_ansi_coloring: bool,
     ) -> Result<()> {
@@ -172,7 +175,13 @@ impl Painter {
         // can print without overwriting the things written during the painting
         self.last_required_lines = required_lines;
 
-        self.stdout.queue(RestorePosition)?.queue(cursor::Show)?;
+        self.stdout
+            .queue(RestorePosition)?
+            .queue(cursor::SetCursorShape(match prompt_mode {
+                PromptEditMode::Vi(crate::PromptViMode::Insert) => cursor::CursorShape::Line,
+                _ => cursor::CursorShape::Block,
+            }))?
+            .queue(cursor::Show)?;
 
         self.stdout.flush()
     }


### PR DESCRIPTION
Modal editors such as vim/neovim/etc. often use different cursors for different edit modes.
In it's current state, this pr changes the cursor to a line if the user is in insert mode, and uses a block cursor for all other modes (including custom and emacs). 

Unfortunately, there is no way to retrieve the current cursor shape in crossterm that I know of, so restoring the previous cursor when exiting reedline could prove to be quite difficult. I currently can think of two solutions for this:

1. Use the block or a configurable cursor as "standard" and set that whenever reedline exits
2. Somehow retrieve the cursor upon starting reedline. This could also be quite useful as it would allow to use that as the default cursor for modes which don't need an indicator, I'm specifically thinking of custom modes. I believe there are ways to retrieve the cursor shape, but I will have to research those before either submitting an upstream pr to crossterm or adding them to this pr.

Regarding configurability, I think it should be possible to configure the cursor depending on the mode, this would be quite useful for nushell as it would allow customizing the behaviour in the config record. Depending on how the implementation ends up looking, it might also be a good idea to hide this behind a `with_custom_cursors()` function. 

Once I've resolved all those problems, I might also look into enabling/disabling cursor blinking. Uni is starting next week so it could take a while until this is in a polished state, but I will try to come back to this regularly.