### PR TITLE
Tab inline completion

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -55,6 +55,7 @@ impl Editor {
             EditCommand::MoveWordRightEnd => self.line_buffer.move_word_right_end(),
             EditCommand::MoveBigWordRightEnd => self.line_buffer.move_big_word_right_end(),
             EditCommand::InsertChar(c) => self.line_buffer.insert_char(*c),
+            EditCommand::Complete => {}
             EditCommand::InsertString(str) => self.line_buffer.insert_str(str),
             EditCommand::InsertNewline => self.line_buffer.insert_newline(),
             EditCommand::ReplaceChar(chr) => self.replace_char(*chr),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -928,8 +928,20 @@ impl Reedline {
                                     self.completer.as_mut(),
                                     self.history.as_ref(),
                                 );
-                                if menu.get_values().len() == 1 {
-                                    return self.handle_editor_event(prompt, ReedlineEvent::Enter);
+                                if let Some(&EditCommand::Complete) = commands.first() {
+                                    if menu.get_values().len() == 1 {
+                                        return self
+                                            .handle_editor_event(prompt, ReedlineEvent::Enter);
+                                    } else if self.partial_completions
+                                        && menu.can_partially_complete(
+                                            self.quick_completions,
+                                            &mut self.editor,
+                                            self.completer.as_mut(),
+                                            self.history.as_ref(),
+                                        )
+                                    {
+                                        return Ok(EventStatus::Handled);
+                                    }
                                 }
                                 if self.editor.line_buffer().get_buffer().is_empty() {
                                     menu.menu_event(MenuEvent::Deactivate);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -943,13 +943,13 @@ impl Reedline {
                                         return Ok(EventStatus::Handled);
                                     }
                                 }
-                                if self.editor.line_buffer().get_buffer().is_empty() {
-                                    menu.menu_event(MenuEvent::Deactivate);
-                                } else {
-                                    menu.menu_event(MenuEvent::Edit(self.quick_completions));
-                                }
                             }
                         }
+                    }
+                    if self.editor.line_buffer().get_buffer().is_empty() {
+                        menu.menu_event(MenuEvent::Deactivate);
+                    } else {
+                        menu.menu_event(MenuEvent::Edit(self.quick_completions));
                     }
                 }
                 Ok(EventStatus::Handled)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -915,25 +915,31 @@ impl Reedline {
                 self.run_edit_commands(&commands);
                 if let Some(menu) = self.menus.iter_mut().find(|men| men.is_active()) {
                     if self.quick_completions && menu.can_quick_complete() {
-                        menu.menu_event(MenuEvent::Edit(self.quick_completions));
-                        menu.update_values(
-                            &mut self.editor,
-                            self.completer.as_mut(),
-                            self.history.as_ref(),
-                        );
-
-                        if menu.get_values().len() == 1 {
-                            return self.handle_editor_event(prompt, ReedlineEvent::Enter);
+                        match commands.first() {
+                            Some(&EditCommand::Backspace)
+                            | Some(&EditCommand::BackspaceWord)
+                            | Some(&EditCommand::MoveToLineStart) => {
+                                menu.menu_event(MenuEvent::Deactivate)
+                            }
+                            _ => {
+                                menu.menu_event(MenuEvent::Edit(self.quick_completions));
+                                menu.update_values(
+                                    &mut self.editor,
+                                    self.completer.as_mut(),
+                                    self.history.as_ref(),
+                                );
+                                if menu.get_values().len() == 1 {
+                                    return self.handle_editor_event(prompt, ReedlineEvent::Enter);
+                                }
+                                if self.editor.line_buffer().get_buffer().is_empty() {
+                                    menu.menu_event(MenuEvent::Deactivate);
+                                } else {
+                                    menu.menu_event(MenuEvent::Edit(self.quick_completions));
+                                }
+                            }
                         }
                     }
-
-                    if self.editor.line_buffer().get_buffer().is_empty() {
-                        menu.menu_event(MenuEvent::Deactivate);
-                    } else {
-                        menu.menu_event(MenuEvent::Edit(self.quick_completions));
-                    }
                 }
-
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::OpenEditor => self.open_editor().map(|_| EventStatus::Handled),

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -99,6 +99,9 @@ pub enum EditCommand {
     /// Clear to the end of the current line
     ClearToLineEnd,
 
+    /// Insert completion: entire completion if there is only one possibility, or else up to shared prefix.
+    Complete,
+
     /// Cut the current line
     CutCurrentLine,
 
@@ -216,6 +219,7 @@ impl Display for EditCommand {
             EditCommand::DeleteWord => write!(f, "DeleteWord"),
             EditCommand::Clear => write!(f, "Clear"),
             EditCommand::ClearToLineEnd => write!(f, "ClearToLineEnd"),
+            EditCommand::Complete => write!(f, "Complete"),
             EditCommand::CutCurrentLine => write!(f, "CutCurrentLine"),
             EditCommand::CutFromStart => write!(f, "CutFromStart"),
             EditCommand::CutFromLineStart => write!(f, "CutFromLineStart"),
@@ -287,6 +291,7 @@ impl EditCommand {
             | EditCommand::DeleteWord
             | EditCommand::Clear
             | EditCommand::ClearToLineEnd
+            | EditCommand::Complete
             | EditCommand::CutCurrentLine
             | EditCommand::CutFromStart
             | EditCommand::CutFromLineStart

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
         KeyCode::Tab,
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::Menu("completion_menu".to_string()),
-            ReedlineEvent::MenuNext,
+            ReedlineEvent::Edit(vec![EditCommand::Complete]),
         ]),
     );
 


### PR DESCRIPTION
This PR makes nushell tab completion behave more like zsh/bash. Assuming `quick_completions = true`:

- Changes Tab so that it completes instead of selecting the next menu item (arrow keys can be used for that)
- Completion is "as far as possible". So, the entire word if there's a unique completion, or else up to the shared prefix of possible completions.
- Gets rid of the quick completion behavior whereby a word was completed automatically as soon as the input came to have a unique completion.

See https://github.com/nushell/nushell/pull/6802 to use this with nushell.
