### PR TITLE
Custom validator and prompt code examples

### DIFF
--- a/examples/custom_prompt.rs
+++ b/examples/custom_prompt.rs
@@ -1,0 +1,75 @@
+// Create a reedline object with a custom prompt.
+// cargo run --example custom_prompt
+//
+// Pressing keys will increase the right prompt value
+
+use reedline::{
+    Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, Reedline, Signal,
+};
+use std::{borrow::Cow, cell::Cell, io};
+
+// For custom prompt, implement the Prompt trait
+//
+// This example displays the number of keystrokes
+// or rather increments each time the prompt is rendered.
+#[derive(Clone)]
+pub struct CustomPrompt(Cell<u32>, &'static str);
+pub static DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
+impl Prompt for CustomPrompt {
+    fn render_prompt_left(&self) -> Cow<str> {
+        {
+            Cow::Owned(self.1.to_string())
+        }
+    }
+
+    fn render_prompt_right(&self) -> Cow<str> {
+        {
+            let old = self.0.get();
+            self.0.set(old + 1);
+            Cow::Owned(format!("[{}]", old))
+        }
+    }
+
+    fn render_prompt_indicator(&self, _edit_mode: PromptEditMode) -> Cow<str> {
+        Cow::Owned(">".to_string())
+    }
+
+    fn render_prompt_multiline_indicator(&self) -> Cow<str> {
+        Cow::Borrowed(DEFAULT_MULTILINE_INDICATOR)
+    }
+
+    fn render_prompt_history_search_indicator(
+        &self,
+        history_search: PromptHistorySearch,
+    ) -> Cow<str> {
+        let prefix = match history_search.status {
+            PromptHistorySearchStatus::Passing => "",
+            PromptHistorySearchStatus::Failing => "failing ",
+        };
+
+        Cow::Owned(format!(
+            "({}reverse-search: {}) ",
+            prefix, history_search.term
+        ))
+    }
+}
+
+fn main() -> io::Result<()> {
+    println!("Custom prompt demo:\nAbort with Ctrl-C or Ctrl-D");
+    let mut line_editor = Reedline::create();
+
+    let prompt = CustomPrompt(Cell::new(0), "Custom Prompt");
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {}", buffer);
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+        }
+    }
+}

--- a/examples/validator.rs
+++ b/examples/validator.rs
@@ -1,22 +1,17 @@
-// Create a reedline object with custom validator and prompt support.
+// Create a reedline object with a custom validator to break the line on unfinished input.
 // cargo run --example validator
 //
-// Pressing keys will increase the right prompt value
 // Input "complete" followed by [Enter], will accept the input line (Signal::Succeed will be called)
 // Pressing [Enter] will in other cases give you a multi-line prompt.
 
-use reedline::{
-    Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, Reedline, Signal,
-    ValidationResult, Validator,
-};
-use std::{borrow::Cow, cell::Cell, io};
+use reedline::{DefaultPrompt, Reedline, Signal, ValidationResult, Validator};
+use std::io;
 
 struct CustomValidator;
 
 // For custom validation, implement the Validator trait
 impl Validator for CustomValidator {
     fn validate(&self, line: &str) -> ValidationResult {
-        print!("-");
         if line == "complete" {
             ValidationResult::Complete
         } else {
@@ -25,56 +20,11 @@ impl Validator for CustomValidator {
     }
 }
 
-// For custom prompt, implement the Prompt trait
-//
-// This example displays the number of keystrokes
-// or rather increments each time the prompt is rendered.
-#[derive(Clone)]
-pub struct CustomPrompt(Cell<u32>, &'static str);
-pub static DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
-impl Prompt for CustomPrompt {
-    fn render_prompt_left(&self) -> Cow<str> {
-        {
-            Cow::Owned(self.1.to_string())
-        }
-    }
-
-    fn render_prompt_right(&self) -> Cow<str> {
-        {
-            let old = self.0.get();
-            self.0.set(old + 1);
-            Cow::Owned(format!("[{}]", old))
-        }
-    }
-
-    fn render_prompt_indicator(&self, _edit_mode: PromptEditMode) -> Cow<str> {
-        Cow::Owned(">".to_string())
-    }
-
-    fn render_prompt_multiline_indicator(&self) -> Cow<str> {
-        Cow::Borrowed(DEFAULT_MULTILINE_INDICATOR)
-    }
-
-    fn render_prompt_history_search_indicator(
-        &self,
-        history_search: PromptHistorySearch,
-    ) -> Cow<str> {
-        let prefix = match history_search.status {
-            PromptHistorySearchStatus::Passing => "",
-            PromptHistorySearchStatus::Failing => "failing ",
-        };
-
-        Cow::Owned(format!(
-            "({}reverse-search: {}) ",
-            prefix, history_search.term
-        ))
-    }
-}
-
 fn main() -> io::Result<()> {
+    println!("Input \"complete\" followed by [Enter], will accept the input line (Signal::Succeed will be called)\nPressing [Enter] will in other cases give you a multi-line prompt.\nAbort with Ctrl-C or Ctrl-D");
     let mut line_editor = Reedline::create().with_validator(Box::new(CustomValidator));
 
-    let prompt = CustomPrompt(Cell::new(0), "Custom Prompt");
+    let prompt = DefaultPrompt::default();
 
     loop {
         let sig = line_editor.read_line(&prompt)?;

--- a/examples/validator.rs
+++ b/examples/validator.rs
@@ -6,10 +6,10 @@
 // Pressing [Enter] will in other cases give you a multi-line prompt.
 
 use reedline::{
-    DefaultValidator, Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus,
-    Reedline, Signal, ValidationResult, Validator,
+    Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, Reedline, Signal,
+    ValidationResult, Validator,
 };
-use std::{borrow::Cow, cell::Cell, env, io};
+use std::{borrow::Cow, cell::Cell, io};
 
 struct CustomValidator;
 
@@ -47,8 +47,8 @@ impl Prompt for CustomPrompt {
         }
     }
 
-    fn render_prompt_indicator(&self, edit_mode: PromptEditMode) -> Cow<str> {
-        format!(">").into()
+    fn render_prompt_indicator(&self, _edit_mode: PromptEditMode) -> Cow<str> {
+        Cow::Owned(">".to_string())
     }
 
     fn render_prompt_multiline_indicator(&self) -> Cow<str> {

--- a/examples/validator.rs
+++ b/examples/validator.rs
@@ -1,0 +1,91 @@
+// Create a reedline object with custom validator and prompt support.
+// cargo run --example validator
+//
+// Pressing keys will increase the right prompt value
+// Input "complete" followed by [Enter], will accept the input line (Signal::Succeed will be called)
+// Pressing [Enter] will in other cases give you a multi-line prompt.
+
+use reedline::{
+    DefaultValidator, Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus,
+    Reedline, Signal, ValidationResult, Validator,
+};
+use std::{borrow::Cow, cell::Cell, env, io};
+
+struct CustomValidator;
+
+// For custom validation, implement the Validator trait
+impl Validator for CustomValidator {
+    fn validate(&self, line: &str) -> ValidationResult {
+        print!("-");
+        if line == "complete" {
+            ValidationResult::Complete
+        } else {
+            ValidationResult::Incomplete
+        }
+    }
+}
+
+// For custom prompt, implement the Prompt trait
+//
+// This example displays the number of keystrokes
+// or rather increments each time the prompt is rendered.
+#[derive(Clone)]
+pub struct CustomPrompt(Cell<u32>, &'static str);
+pub static DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
+impl Prompt for CustomPrompt {
+    fn render_prompt_left(&self) -> Cow<str> {
+        {
+            Cow::Owned(self.1.to_string())
+        }
+    }
+
+    fn render_prompt_right(&self) -> Cow<str> {
+        {
+            let old = self.0.get();
+            self.0.set(old + 1);
+            Cow::Owned(format!("[{}]", old))
+        }
+    }
+
+    fn render_prompt_indicator(&self, edit_mode: PromptEditMode) -> Cow<str> {
+        format!(">").into()
+    }
+
+    fn render_prompt_multiline_indicator(&self) -> Cow<str> {
+        Cow::Borrowed(DEFAULT_MULTILINE_INDICATOR)
+    }
+
+    fn render_prompt_history_search_indicator(
+        &self,
+        history_search: PromptHistorySearch,
+    ) -> Cow<str> {
+        let prefix = match history_search.status {
+            PromptHistorySearchStatus::Passing => "",
+            PromptHistorySearchStatus::Failing => "failing ",
+        };
+
+        Cow::Owned(format!(
+            "({}reverse-search: {}) ",
+            prefix, history_search.term
+        ))
+    }
+}
+
+fn main() -> io::Result<()> {
+    let mut line_editor = Reedline::create().with_validator(Box::new(CustomValidator));
+
+    let prompt = CustomPrompt(Cell::new(0), "Custom Prompt");
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {}", buffer);
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+        }
+    }
+}

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -196,8 +196,7 @@ impl Painter {
 
         let mut row = self.prompt_start_row;
         if lines.right_prompt_on_last_line {
-            let required_lines = lines.required_lines(screen_width, None);
-            row += required_lines.saturating_sub(1);
+            row += lines.prompt_lines_with_wrap(screen_width);
         }
 
         if input_width <= start_position {


### PR DESCRIPTION
I made a small example how to implement a custom validator and a custom prompt.

I'm not sure if this is the right way to do it, but the example works as I anticipated.
One option is to merge as is, or rename it to `validator_prompt` (is it kind of covers both), or alternatively split them in two (as they are kind of independent).

Let me know what you think is best way forward. 