### PR TITLE
show right prompt on indicator line in last line mode

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -196,8 +196,7 @@ impl Painter {
 
         let mut row = self.prompt_start_row;
         if lines.right_prompt_on_last_line {
-            let required_lines = lines.required_lines(screen_width, None);
-            row += required_lines.saturating_sub(1);
+            row += lines.prompt_lines_with_wrap(screen_width);
         }
 
         if input_width <= start_position {


### PR DESCRIPTION
When enable last line mode, the right prompt may be rendered incorrectly if we have multiline input or hint.
This PR makes right prompt show on the indicator line when last line mode enabled.

* before
![Screenshot from 2022-10-23 06-51-07](https://user-images.githubusercontent.com/15247421/197365110-f1b76f11-0305-467b-af9b-e2c66ca294d1.png)
![Screenshot from 2022-10-23 06-50-57](https://user-images.githubusercontent.com/15247421/197365112-12b2594b-6aaa-414c-80fd-5b59fe5d2d11.png)

* after
![Screenshot from 2022-10-23 06-54-45](https://user-images.githubusercontent.com/15247421/197365209-a02c5995-777c-4c2a-89cc-aebccb7b0937.png)
![Screenshot from 2022-10-23 06-54-59](https://user-images.githubusercontent.com/15247421/197365204-7feec3a5-a458-4d13-ad0a-a83bd73a0af6.png)


