### PR TITLE
fix: actually use sqlite-dynlib feature

### DIFF
--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -173,9 +173,9 @@ pub trait History: Send {
 
 #[cfg(test)]
 mod test {
-    #[cfg(feature = "sqlite")]
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
     const IS_FILE_BASED: bool = false;
-    #[cfg(not(feature = "sqlite"))]
+    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
     const IS_FILE_BASED: bool = true;
 
     use crate::HistorySessionId;
@@ -197,11 +197,11 @@ mod test {
 
     use super::*;
     fn create_filled_example_history() -> Result<Box<dyn History>> {
-        #[cfg(feature = "sqlite")]
+        #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
         let mut history = crate::SqliteBackedHistory::in_memory()?;
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
         let mut history = crate::FileBackedHistory::default();
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
         history.save(create_item(1, "/", "dummy", 0))?; // add dummy item so ids start with 1
         history.save(create_item(1, "/home/me", "cd ~/Downloads", 0))?; // 1
         history.save(create_item(1, "/home/me/Downloads", "unzp foo.zip", 1))?; // 2
@@ -219,7 +219,7 @@ mod test {
         Ok(Box::new(history))
     }
 
-    #[cfg(feature = "sqlite")]
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
     #[test]
     fn update_item() -> Result<()> {
         let mut history = create_filled_example_history()?;

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -106,9 +106,9 @@ mod tests {
     use super::*;
 
     fn create_history() -> (Box<dyn History>, HistoryCursor) {
-        #[cfg(feature = "sqlite")]
+        #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
         let hist = Box::new(SqliteBackedHistory::in_memory().unwrap());
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
         let hist = Box::new(FileBackedHistory::default());
         (
             hist,
@@ -188,7 +188,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(feature = "sqlite"))]
+    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
     #[test]
     fn appends_only_unique() -> Result<()> {
         let (mut hist, _) = create_history();
@@ -411,7 +411,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(feature = "sqlite"))]
+    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
     #[test]
     fn truncates_file_to_capacity() -> Result<()> {
         use tempfile::tempdir;

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -2,9 +2,9 @@ mod base;
 mod cursor;
 mod file_backed;
 mod item;
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
 mod sqlite_backed;
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
 pub use sqlite_backed::SqliteBackedHistory;
 
 pub use base::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ mod result;
 pub(crate) use result::Result;
 
 mod history;
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
 pub use history::SqliteBackedHistory;
 pub use history::{
     CommandLineSearch, FileBackedHistory, History, HistoryItem, HistoryItemId,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "sqlite"))]
+#[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
 use reedline::FileBackedHistory;
 
 use {
@@ -39,12 +39,12 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    #[cfg(feature = "sqlite")]
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
     let history = Box::new(
         reedline::SqliteBackedHistory::with_file("history.sqlite3".into())
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
     );
-    #[cfg(not(feature = "sqlite"))]
+    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
     let history = Box::new(FileBackedHistory::with_file(50, "history.txt".into())?);
     let commands = vec![
         "test".into(),
@@ -131,10 +131,10 @@ fn main() -> Result<()> {
                 break;
             }
             Ok(Signal::Success(buffer)) => {
-                #[cfg(feature = "sqlite")]
+                #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
                 let start = std::time::Instant::now();
                 // save timestamp, cwd, hostname to history
-                #[cfg(feature = "sqlite")]
+                #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
                 if !buffer.is_empty() {
                     line_editor
                         .update_last_command_context(&|mut c: reedline::HistoryItem| {
@@ -160,7 +160,7 @@ fn main() -> Result<()> {
                     continue;
                 }
                 println!("Our buffer: {}", buffer);
-                #[cfg(feature = "sqlite")]
+                #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
                 if !buffer.is_empty() {
                     line_editor
                         .update_last_command_context(&|mut c| {

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub(crate) enum ReedlineErrorVariants {
     // todo: we should probably be more specific here
-    #[cfg(feature = "sqlite")]
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
     #[error("error within history database: {0}")]
     HistoryDatabaseError(String),
     #[error("error within history: {0}")]


### PR DESCRIPTION
Follow-up on https://github.com/nushell/reedline/pull/474

7d721a1 introduced the sqlite-dynlib feature, but using it in places
where sqlite is currently used was not possible, because the cfg gates
weren't adjusted yet. This commit replaces each `feature = "sqlite"`
with `any(feature = "sqlite",feature = "sqlite-dynlib")`, meaning that
it doesn't matter which sqlite feature you use, reedline will expose the
same API.
