### PR TITLE
Update workflow to new actions (alternative)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,48 +31,35 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
+        uses: actions-rust-lang/setup-rust-toolchain@v1.3.4
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-          key: ${{ matrix.style }}v1 # increment this to bust the cache if needed
+      - name: Setup nextest
+        uses: taiki-e/install-action@nextest
 
       - name: Rustfmt
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1.0.1
         with:
           command: fmt
           args: --all -- --check
 
-      - name: Build reedline
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: ${{ matrix.flags }}
-
       - name: Clippy
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1.0.1
         with:
           command: clippy
-          args: ${{ matrix.flags }} -- -D warnings
+          args: ${{ matrix.flags }} --all -- -D warnings
 
-      - uses: taiki-e/install-action@nextest
 
       - name: Tests
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1.0.1
         with:
           command: nextest
           args: run --all ${{ matrix.flags }}
 
       - name: Doctests
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1.0.1
         with:
           command: test
           args: --doc ${{ matrix.flags }}


### PR DESCRIPTION
Alternative to #503

Using `actions-rust-lang` instead of `actions-rs` for setup. (nushell uses them for setup with integrated caching)

Remove build stage as this should also be covered by test.
clippy --all to see if this checks the examples as well.
