### PR TITLE
Split the main example binary into examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,6 @@ repository = "https://github.com/nushell/reedline"
 [lib]
 doctest = true
 
-[[bin]]
-name = "reedline"
-path = "src/main.rs"
-
 [dependencies]
 chrono = "0.4.19"
 clipboard = { version = "0.5.0", optional = true }
@@ -30,7 +26,6 @@ strum_macros = "0.24"
 fd-lock = "3.0.3"
 rusqlite = { version = "0.28.0", optional = true }
 serde_json = { version = "1.0.79", optional = true }
-gethostname = { version = "0.2.3", optional = true }
 thiserror = "1.0.31"
 crossbeam = { version = "0.8.2", optional = true }
 
@@ -38,11 +33,13 @@ crossbeam = { version = "0.8.2", optional = true }
 tempfile = "3.3.0"
 pretty_assertions = "1.1.0"
 rstest = { version = "0.15.0", default-features = false }
+# For examples/demo.rs
+gethostname = "0.2.3"
 
 [features]
 system_clipboard = ["clipboard"]
 bashisms = []
 external_printer = ["crossbeam"]
-sqlite = ["rusqlite/bundled", "serde_json", "gethostname"]
-sqlite-dynlib = ["rusqlite", "serde_json", "gethostname"]
+sqlite = ["rusqlite/bundled", "serde_json"]
+sqlite-dynlib = ["rusqlite", "serde_json"]
 

--- a/examples/event_listener.rs
+++ b/examples/event_listener.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
     println!("Ready to print events (Abort with ESC):");
     print_events()?;
     println!();
-    return Ok(());
+    Ok(())
 }
 
 /// **For debugging purposes only:** Track the terminal events observed by [`Reedline`] and print them.

--- a/examples/event_listener.rs
+++ b/examples/event_listener.rs
@@ -1,0 +1,74 @@
+use {
+    crossterm::{
+        event::{poll, Event, KeyCode, KeyEvent},
+        terminal, Result,
+    },
+    std::{
+        io::{stdout, Write},
+        time::Duration,
+    },
+};
+
+fn main() -> Result<()> {
+    println!("Ready to print events (Abort with ESC):");
+    print_events()?;
+    println!();
+    return Ok(());
+}
+
+/// **For debugging purposes only:** Track the terminal events observed by [`Reedline`] and print them.
+pub fn print_events() -> Result<()> {
+    stdout().flush()?;
+    terminal::enable_raw_mode()?;
+    let result = print_events_helper();
+    terminal::disable_raw_mode()?;
+
+    result
+}
+
+// this fn is totally ripped off from crossterm's examples
+// it's really a diagnostic routine to see if crossterm is
+// even seeing the events. if you press a key and no events
+// are printed, it's a good chance your terminal is eating
+// those events.
+fn print_events_helper() -> Result<()> {
+    loop {
+        // Wait up to 5s for another event
+        if poll(Duration::from_millis(5_000))? {
+            // It's guaranteed that read() wont block if `poll` returns `Ok(true)`
+            let event = crossterm::event::read()?;
+
+            if let Event::Key(KeyEvent { code, modifiers }) = event {
+                match code {
+                    KeyCode::Char(c) => {
+                        println!(
+                            "Char: {} code: {:#08x}; Modifier {:?}; Flags {:#08b}\r",
+                            c,
+                            u32::from(c),
+                            modifiers,
+                            modifiers
+                        );
+                    }
+                    _ => {
+                        println!(
+                            "Keycode: {:?}; Modifier {:?}; Flags {:#08b}\r",
+                            code, modifiers, modifiers
+                        );
+                    }
+                }
+            } else {
+                println!("Event::{:?}\r", event);
+            }
+
+            // hit the esc key to git out
+            if event == Event::Key(KeyCode::Esc.into()) {
+                break;
+            }
+        } else {
+            // Timeout expired, no event for 5s
+            println!("Waiting for you to type...\r");
+        }
+    }
+
+    Ok(())
+}

--- a/examples/list_bindings.rs
+++ b/examples/list_bindings.rs
@@ -10,7 +10,7 @@ use {
 fn main() -> Result<()> {
     get_all_keybinding_info();
     println!();
-    return Ok(());
+    Ok(())
 }
 
 /// List all keybinding information

--- a/examples/list_bindings.rs
+++ b/examples/list_bindings.rs
@@ -1,0 +1,50 @@
+use {
+    crossterm::Result,
+    reedline::{
+        get_reedline_default_keybindings, get_reedline_edit_commands,
+        get_reedline_keybinding_modifiers, get_reedline_keycodes, get_reedline_prompt_edit_modes,
+        get_reedline_reedline_events,
+    },
+};
+
+fn main() -> Result<()> {
+    get_all_keybinding_info();
+    println!();
+    return Ok(());
+}
+
+/// List all keybinding information
+fn get_all_keybinding_info() {
+    println!("--Key Modifiers--");
+    for mods in get_reedline_keybinding_modifiers().iter() {
+        println!("{}", mods);
+    }
+
+    println!("\n--Modes--");
+    for modes in get_reedline_prompt_edit_modes().iter() {
+        println!("{}", modes);
+    }
+
+    println!("\n--Key Codes--");
+    for kcs in get_reedline_keycodes().iter() {
+        println!("{}", kcs);
+    }
+
+    println!("\n--Reedline Events--");
+    for rle in get_reedline_reedline_events().iter() {
+        println!("{}", rle);
+    }
+
+    println!("\n--Edit Commands--");
+    for edit in get_reedline_edit_commands().iter() {
+        println!("{}", edit);
+    }
+
+    println!("\n--Default Keybindings--");
+    for (mode, modifier, code, event) in get_reedline_default_keybindings() {
+        println!(
+            "mode: {}, keymodifiers: {}, keycode: {}, event: {}",
+            mode, modifier, code, event
+        );
+    }
+}


### PR DESCRIPTION
Separate fully featured demo from keybinding listing and event listener

Allows to make `gethostname` dev-dependency

## Launching the examples

What was previously accessible through flags on `cargo run` now becomes:

#### Basic demo (emacs style bindings):
```
cargo run --example demo
```

#### Vi mode demo
```
cargo run --example demo -- --vi
```

#### Listening for the different terminal events
```
cargo run --example event_listener
```

#### Listing the bindable keys and events as well as the default config
```
cargo run --example list_bindings
```