### PR TITLE
Make reedline handling cursor shapes more configurable

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -12,12 +12,10 @@ use {
     },
 };
 
-use std::collections::HashMap;
-
 use crossterm::cursor::CursorShape;
+use reedline::CursorConfig;
 #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
 use reedline::FileBackedHistory;
-use reedline::PromptEditMode;
 
 fn main() -> Result<()> {
     println!("Ctrl-D to quit");
@@ -62,23 +60,18 @@ fn main() -> Result<()> {
 
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 
-    let cursor_shapes = HashMap::from([
-        (
-            PromptEditMode::Vi(reedline::PromptViMode::Insert),
-            CursorShape::Line,
-        ),
-        (
-            PromptEditMode::Vi(reedline::PromptViMode::Normal),
-            CursorShape::Block,
-        ),
-    ]);
+    let cursor_config = CursorConfig {
+        vi_insert: Some(CursorShape::Line),
+        vi_normal: Some(CursorShape::Block),
+        emacs: None,
+    };
 
     let mut line_editor = Reedline::create()
         .with_history(history)
         .with_completer(completer)
         .with_quick_completions(true)
         .with_partial_completions(true)
-        .with_cursor_shapes(cursor_shapes)
+        .with_cursor_config(cursor_config)
         .with_highlighter(Box::new(ExampleHighlighter::new(commands)))
         .with_hinter(Box::new(
             DefaultHinter::default().with_style(Style::new().fg(Color::DarkGray)),

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -12,8 +12,12 @@ use {
     },
 };
 
+use std::collections::HashMap;
+
+use crossterm::cursor::CursorShape;
 #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
 use reedline::FileBackedHistory;
+use reedline::PromptEditMode;
 
 fn main() -> Result<()> {
     println!("Ctrl-D to quit");
@@ -58,11 +62,23 @@ fn main() -> Result<()> {
 
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 
+    let cursor_shapes = HashMap::from([
+        (
+            PromptEditMode::Vi(reedline::PromptViMode::Insert),
+            CursorShape::Line,
+        ),
+        (
+            PromptEditMode::Vi(reedline::PromptViMode::Normal),
+            CursorShape::Block,
+        ),
+    ]);
+
     let mut line_editor = Reedline::create()
         .with_history(history)
         .with_completer(completer)
         .with_quick_completions(true)
         .with_partial_completions(true)
+        .with_cursor_shapes(cursor_shapes)
         .with_highlighter(Box::new(ExampleHighlighter::new(commands)))
         .with_hinter(Box::new(
             DefaultHinter::default().with_style(Style::new().fg(Color::DarkGray)),

--- a/src/edit_mode/cursors.rs
+++ b/src/edit_mode/cursors.rs
@@ -1,0 +1,22 @@
+use crossterm::cursor::CursorShape;
+
+/// Maps cursor shapes to each edit mode (emacs, vi normal & vi insert).
+/// If any of the fields is `None`, the cursor won't get changed by Reedline for that mode.
+pub struct CursorConfig {
+    /// The cursor to be used when in vi insert mode
+    pub vi_insert: Option<CursorShape>,
+    /// The cursor to be used when in vi normal mode
+    pub vi_normal: Option<CursorShape>,
+    /// The cursor to be used when in emacs mode
+    pub emacs: Option<CursorShape>,
+}
+
+impl Default for CursorConfig {
+    fn default() -> Self {
+        Self {
+            vi_insert: None,
+            vi_normal: None,
+            emacs: None,
+        }
+    }
+}

--- a/src/edit_mode/cursors.rs
+++ b/src/edit_mode/cursors.rs
@@ -2,6 +2,7 @@ use crossterm::cursor::CursorShape;
 
 /// Maps cursor shapes to each edit mode (emacs, vi normal & vi insert).
 /// If any of the fields is `None`, the cursor won't get changed by Reedline for that mode.
+#[derive(Default)]
 pub struct CursorConfig {
     /// The cursor to be used when in vi insert mode
     pub vi_insert: Option<CursorShape>,
@@ -9,14 +10,4 @@ pub struct CursorConfig {
     pub vi_normal: Option<CursorShape>,
     /// The cursor to be used when in emacs mode
     pub emacs: Option<CursorShape>,
-}
-
-impl Default for CursorConfig {
-    fn default() -> Self {
-        Self {
-            vi_insert: None,
-            vi_normal: None,
-            emacs: None,
-        }
-    }
 }

--- a/src/edit_mode/mod.rs
+++ b/src/edit_mode/mod.rs
@@ -1,9 +1,11 @@
 mod base;
+mod cursors;
 mod emacs;
 mod keybindings;
 mod vi;
 
 pub use base::EditMode;
+pub use cursors::CursorConfig;
 pub use emacs::{default_emacs_keybindings, Emacs};
 pub use keybindings::Keybindings;
 pub use vi::{default_vi_insert_keybindings, default_vi_normal_keybindings, Vi};

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -128,6 +128,9 @@ pub struct Reedline {
     // Text editor used to open the line buffer for editing
     buffer_editor: Option<BufferEditor>,
 
+    // If reedline should set the cursor shape based on the current mode
+    handle_cursor_shape: bool,
+
     #[cfg(feature = "external_printer")]
     external_printer: Option<ExternalPrinter<String>>,
 }
@@ -179,6 +182,7 @@ impl Reedline {
             use_ansi_coloring: true,
             menus: Vec::new(),
             buffer_editor: None,
+            handle_cursor_shape: false,
             #[cfg(feature = "external_printer")]
             external_printer: None,
         }
@@ -374,6 +378,14 @@ impl Reedline {
     #[must_use]
     pub fn clear_menus(mut self) -> Self {
         self.menus = Vec::new();
+        self
+    }
+
+    /// A builder which enables or disables reedline changing the cursor shape based on the current editing mode.
+    /// The current implementation sets the cursor shape when drawing the prompt.
+    /// Do not enable this if the cursor shape is set elsewhere, e.g. in the terminal or by ansi escape sequences.
+    pub fn with_cursor_shape(mut self, handle_cursor_shape: bool) -> Self {
+        self.handle_cursor_shape = handle_cursor_shape;
         self
     }
 
@@ -1393,6 +1405,7 @@ impl Reedline {
                 self.prompt_edit_mode(),
                 None,
                 self.use_ansi_coloring,
+                self.handle_cursor_shape,
             )?;
         }
 
@@ -1460,6 +1473,7 @@ impl Reedline {
             self.prompt_edit_mode(),
             menu,
             self.use_ansi_coloring,
+            self.handle_cursor_shape,
         )
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,4 @@
-use std::collections::HashMap;
-
-use crossterm::cursor::CursorShape;
-
+use crate::CursorConfig;
 #[cfg(feature = "bashisms")]
 use crate::{
     history::SearchFilter,
@@ -133,7 +130,7 @@ pub struct Reedline {
     buffer_editor: Option<BufferEditor>,
 
     // Use different cursors depending on the current edit mode
-    cursor_shapes: Option<HashMap<PromptEditMode, CursorShape>>,
+    cursor_shapes: Option<CursorConfig>,
 
     #[cfg(feature = "external_printer")]
     external_printer: Option<ExternalPrinter<String>>,
@@ -388,10 +385,7 @@ impl Reedline {
     /// A builder that enables reedline changing the cursor shape based on the current edit mode.
     /// The current implementation sets the cursor shape when drawing the prompt.
     /// Do not use this if the cursor shape is set elsewhere, e.g. in the terminal settings or by ansi escape sequences.
-    pub fn with_cursor_shapes(
-        mut self,
-        cursor_shapes: HashMap<PromptEditMode, CursorShape>,
-    ) -> Self {
+    pub fn with_cursor_config(mut self, cursor_shapes: CursorConfig) -> Self {
         self.cursor_shapes = Some(cursor_shapes);
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ pub use prompt::{
 mod edit_mode;
 pub use edit_mode::{
     default_emacs_keybindings, default_vi_insert_keybindings, default_vi_normal_keybindings,
-    EditMode, Emacs, Keybindings, Vi,
+    CursorConfig, EditMode, Emacs, Keybindings, Vi,
 };
 
 mod highlighter;

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1,3 +1,7 @@
+use std::collections::HashMap;
+
+use crossterm::cursor::CursorShape;
+
 use crate::PromptEditMode;
 
 use {
@@ -137,7 +141,7 @@ impl Painter {
         prompt_mode: PromptEditMode,
         menu: Option<&ReedlineMenu>,
         use_ansi_coloring: bool,
-        handle_cursor_shape: bool,
+        cursor_shapes: &Option<HashMap<PromptEditMode, CursorShape>>,
     ) -> Result<()> {
         self.stdout.queue(cursor::Hide)?;
 
@@ -177,12 +181,11 @@ impl Painter {
         self.last_required_lines = required_lines;
 
         self.stdout.queue(RestorePosition)?;
-        if handle_cursor_shape {
-            self.stdout
-                .queue(cursor::SetCursorShape(match prompt_mode {
-                    PromptEditMode::Vi(crate::PromptViMode::Insert) => cursor::CursorShape::Line,
-                    _ => cursor::CursorShape::Block,
-                }))?;
+
+        if let Some(shapes) = cursor_shapes {
+            if let Some(shape) = shapes.get(&prompt_mode) {
+                self.stdout.queue(cursor::SetCursorShape(*shape))?;
+            }
         }
         self.stdout.queue(cursor::Show)?;
 

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -137,6 +137,7 @@ impl Painter {
         prompt_mode: PromptEditMode,
         menu: Option<&ReedlineMenu>,
         use_ansi_coloring: bool,
+        handle_cursor_shape: bool,
     ) -> Result<()> {
         self.stdout.queue(cursor::Hide)?;
 
@@ -175,13 +176,15 @@ impl Painter {
         // can print without overwriting the things written during the painting
         self.last_required_lines = required_lines;
 
-        self.stdout
-            .queue(RestorePosition)?
-            .queue(cursor::SetCursorShape(match prompt_mode {
-                PromptEditMode::Vi(crate::PromptViMode::Insert) => cursor::CursorShape::Line,
-                _ => cursor::CursorShape::Block,
-            }))?
-            .queue(cursor::Show)?;
+        self.stdout.queue(RestorePosition)?;
+        if handle_cursor_shape {
+            self.stdout
+                .queue(cursor::SetCursorShape(match prompt_mode {
+                    PromptEditMode::Vi(crate::PromptViMode::Insert) => cursor::CursorShape::Line,
+                    _ => cursor::CursorShape::Block,
+                }))?;
+        }
+        self.stdout.queue(cursor::Show)?;
 
         self.stdout.flush()
     }

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -42,7 +42,7 @@ impl PromptHistorySearch {
 }
 
 /// Modes that the prompt can be in
-#[derive(Serialize, Deserialize, Clone, Debug, EnumIter, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, EnumIter)]
 pub enum PromptEditMode {
     /// The default mode
     Default,
@@ -58,7 +58,7 @@ pub enum PromptEditMode {
 }
 
 /// The vi-specific modes that the prompt can be in
-#[derive(Serialize, Deserialize, Clone, Debug, EnumIter, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Debug, EnumIter)]
 pub enum PromptViMode {
     /// The default mode
     Normal,

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -42,7 +42,7 @@ impl PromptHistorySearch {
 }
 
 /// Modes that the prompt can be in
-#[derive(Serialize, Deserialize, Clone, Debug, EnumIter)]
+#[derive(Serialize, Deserialize, Clone, Debug, EnumIter, PartialEq, Eq, Hash)]
 pub enum PromptEditMode {
     /// The default mode
     Default,
@@ -58,7 +58,7 @@ pub enum PromptEditMode {
 }
 
 /// The vi-specific modes that the prompt can be in
-#[derive(Serialize, Deserialize, Clone, Debug, EnumIter)]
+#[derive(Serialize, Deserialize, Clone, Debug, EnumIter, PartialEq, Eq, Hash)]
 pub enum PromptViMode {
     /// The default mode
     Normal,


### PR DESCRIPTION
This pr is a follow-up to #494. There were various complaints about my implementation being to invasive, so for now I made it toggleable, but I would like not only be able to toggle this, but to actually make it configurable.

If merged, this should resolve #514.