### PR TITLE
Add history exclusion configuration

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -60,6 +60,7 @@ fn main() -> Result<()> {
 
     let mut line_editor = Reedline::create()
         .with_history(history)
+        .with_history_exclusion_prefix(Some(" ".to_string()))
         .with_completer(completer)
         .with_quick_completions(true)
         .with_partial_completions(true)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1523,7 +1523,7 @@ impl Reedline {
         // Additional repaint to show the content without hints etc.
         self.repaint(prompt)?;
 
-        if !buffer.is_empty()  {
+        if !buffer.is_empty() {
             // Support the Bash HISTCONTROL thing of skipping history saving if command starts with a certain string
             let skip_history_save = match &self.history_exclusion_prefix {
                 Some(s) => buffer.starts_with(s),


### PR DESCRIPTION
A rough draft PR to solve #516, by letting users configure which command lines get excluded from history. For example, users can configure reedline so that command lines starting with a space are not saved.

@sholderbach Let me know what you think, happy to revise this.