### PR TITLE
Make DefaultPrompt configurable

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -102,7 +102,7 @@ fn main() -> Result<()> {
     // Adding vi as text editor
     line_editor = line_editor.with_buffer_editor("vi".into(), "nu".into());
 
-    let prompt = DefaultPrompt::new();
+    let prompt = DefaultPrompt::default();
 
     loop {
         let sig = line_editor.read_line(&prompt);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,8 +253,8 @@ pub use history::{
 
 mod prompt;
 pub use prompt::{
-    DefaultPrompt, Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus,
-    PromptViMode, DefaultPromptSegment
+    DefaultPrompt, DefaultPromptSegment, Prompt, PromptEditMode, PromptHistorySearch,
+    PromptHistorySearchStatus, PromptViMode,
 };
 
 mod edit_mode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ pub use history::{
 mod prompt;
 pub use prompt::{
     DefaultPrompt, Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus,
-    PromptViMode,
+    PromptViMode, DefaultPromptSegment
 };
 
 mod edit_mode;

--- a/src/prompt/default.rs
+++ b/src/prompt/default.rs
@@ -32,7 +32,7 @@ pub enum DefaultPromptSegment {
     /// The current date and time
     CurrentDateTime,
     /// An empty prompt segment
-    Empty
+    Empty,
 }
 
 /// Given a prompt segment, render it to a Cow<str> that we can use to
@@ -40,11 +40,11 @@ pub enum DefaultPromptSegment {
 /// functions.
 fn render_prompt_segment(prompt: &DefaultPromptSegment) -> Cow<str> {
     match &prompt {
-        DefaultPromptSegment::Basic(s) => Cow::Borrowed(&s),
+        DefaultPromptSegment::Basic(s) => Cow::Borrowed(s),
         DefaultPromptSegment::WorkingDirectory => {
             let prompt = get_working_dir().unwrap_or_else(|_| String::from("no path"));
             Cow::Owned(prompt)
-        },
+        }
         DefaultPromptSegment::CurrentDateTime => Cow::Owned(get_now()),
         DefaultPromptSegment::Empty => Cow::Borrowed(""),
     }
@@ -104,7 +104,10 @@ impl DefaultPrompt {
     /// Constructor for the default prompt, which takes a configurable left and right prompt.
     /// For less customization, use [`DefaultPrompt::default`].
     /// For more fine-tuned configuration, implement the [`Prompt`] trait.
-    pub fn new(left_prompt: DefaultPromptSegment, right_prompt: DefaultPromptSegment) -> DefaultPrompt {
+    pub fn new(
+        left_prompt: DefaultPromptSegment,
+        right_prompt: DefaultPromptSegment,
+    ) -> DefaultPrompt {
         DefaultPrompt {
             left_prompt,
             right_prompt,

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -5,7 +5,4 @@ pub use base::{
     Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode,
 };
 
-pub use default::{
-    DefaultPrompt,
-    DefaultPromptSegment
-};
+pub use default::{DefaultPrompt, DefaultPromptSegment};

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -5,4 +5,7 @@ pub use base::{
     Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode,
 };
 
-pub use default::DefaultPrompt;
+pub use default::{
+    DefaultPrompt,
+    DefaultPromptSegment
+};


### PR DESCRIPTION
I was working on a small REPL application, and I found that the default prompt was a bit overkill (and more suited for a shell).

So, I made the `DefaultPrompt` struct more configurable, so you can do things like this:

```rust
    let prompt = DefaultPrompt {
        left_prompt: DefaultPromptSegment::Basic("rand-api".to_owned()),
        right_prompt: DefaultPromptSegment::Empty
    };
    // or
    let prompt = DefaultPrompt::new(
        DefaultPromptSegment::Basic("rand-api".to_owned()),
        DefaultPromptSegment::Empty
    );
```

with a result like this:
![WindowsTerminal_qLrrmRTYx1](https://user-images.githubusercontent.com/1783464/204719128-43b5d3c6-8177-4041-9ec9-34d9a2401bb2.png)

I modified `DefaultPrompt::default()` to produce the same behavior as before. So, users who were using `DefaultPrompt::default()` (as per the example in the readme) should in theory see no breaking changes.

I.e., the following

```rust
let prompt = DefaultPrompt::default()
```

will still produce the following:

![WindowsTerminal_UEBcbXOWfr](https://user-images.githubusercontent.com/1783464/204719414-7c28c1b6-dab8-40ba-ae4a-6bc0f8dff643.png)
