### PR TITLE
Allow configuration of multiline prompt color

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -15,7 +15,7 @@ fn main() -> io::Result<()> {
         let sig = line_editor.read_line(&prompt)?;
         match sig {
             Signal::Success(buffer) => {
-                println!("We processed: {}", buffer);
+                println!("We processed: {buffer}");
             }
             Signal::CtrlD | Signal::CtrlC => {
                 println!("\nAborted!");

--- a/examples/completions.rs
+++ b/examples/completions.rs
@@ -47,7 +47,7 @@ fn main() -> io::Result<()> {
         let sig = line_editor.read_line(&prompt)?;
         match sig {
             Signal::Success(buffer) => {
-                println!("We processed: {}", buffer);
+                println!("We processed: {buffer}");
             }
             Signal::CtrlD | Signal::CtrlC => {
                 println!("\nAborted!");

--- a/examples/custom_prompt.rs
+++ b/examples/custom_prompt.rs
@@ -26,7 +26,7 @@ impl Prompt for CustomPrompt {
         {
             let old = self.0.get();
             self.0.set(old + 1);
-            Cow::Owned(format!("[{}]", old))
+            Cow::Owned(format!("[{old}]"))
         }
     }
 
@@ -64,7 +64,7 @@ fn main() -> io::Result<()> {
         let sig = line_editor.read_line(&prompt)?;
         match sig {
             Signal::Success(buffer) => {
-                println!("We processed: {}", buffer);
+                println!("We processed: {buffer}");
             }
             Signal::CtrlD | Signal::CtrlC => {
                 println!("\nAborted!");

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -149,7 +149,7 @@ fn main() -> Result<()> {
                     line_editor.print_history()?;
                     continue;
                 }
-                println!("Our buffer: {}", buffer);
+                println!("Our buffer: {buffer}");
                 #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
                 if !buffer.is_empty() {
                     line_editor
@@ -165,7 +165,7 @@ fn main() -> Result<()> {
                 // Prompt has been cleared and should start on the next line
             }
             Err(err) => {
-                println!("Error: {:?}", err);
+                println!("Error: {err:?}");
             }
         }
     }

--- a/examples/event_listener.rs
+++ b/examples/event_listener.rs
@@ -51,13 +51,12 @@ fn print_events_helper() -> Result<()> {
                     }
                     _ => {
                         println!(
-                            "Keycode: {:?}; Modifier {:?}; Flags {:#08b}\r",
-                            code, modifiers, modifiers
+                            "Keycode: {code:?}; Modifier {modifiers:?}; Flags {modifiers:#08b}\r"
                         );
                     }
                 }
             } else {
-                println!("Event::{:?}\r", event);
+                println!("Event::{event:?}\r");
             }
 
             // hit the esc key to git out

--- a/examples/external_printer.rs
+++ b/examples/external_printer.rs
@@ -24,7 +24,7 @@ fn main() {
         let mut i = 1;
         loop {
             sleep(Duration::from_secs(1));
-            assert!(p_clone.print(format!("Message {} delivered.", i)).is_ok());
+            assert!(p_clone.print(format!("Message {i} delivered.")).is_ok());
             i += 1;
         }
     });
@@ -34,7 +34,7 @@ fn main() {
         sleep(Duration::from_secs(3));
         for _ in 0..10 {
             sleep(Duration::from_millis(1));
-            assert!(p_sender.send(format!("Fast Hello !")).is_ok());
+            assert!(p_sender.send("Fast Hello !".to_string()).is_ok());
         }
     });
 
@@ -45,7 +45,7 @@ fn main() {
         if let Ok(sig) = line_editor.read_line(&prompt) {
             match sig {
                 Signal::Success(buffer) => {
-                    println!("We processed: {}", buffer);
+                    println!("We processed: {buffer}");
                 }
                 Signal::CtrlD | Signal::CtrlC => {
                     println!("\nAborted!");

--- a/examples/highlighter.rs
+++ b/examples/highlighter.rs
@@ -20,7 +20,7 @@ fn main() -> io::Result<()> {
         let sig = line_editor.read_line(&prompt)?;
         match sig {
             Signal::Success(buffer) => {
-                println!("We processed: {}", buffer);
+                println!("We processed: {buffer}");
             }
             Signal::CtrlD | Signal::CtrlC => {
                 println!("\nAborted!");

--- a/examples/hinter.rs
+++ b/examples/hinter.rs
@@ -20,7 +20,7 @@ fn main() -> io::Result<()> {
         let sig = line_editor.read_line(&prompt)?;
         match sig {
             Signal::Success(buffer) => {
-                println!("We processed: {}", buffer);
+                println!("We processed: {buffer}");
             }
             Signal::CtrlD | Signal::CtrlC => {
                 println!("\nAborted!");

--- a/examples/history.rs
+++ b/examples/history.rs
@@ -22,7 +22,7 @@ fn main() -> io::Result<()> {
         let sig = line_editor.read_line(&prompt)?;
         match sig {
             Signal::Success(buffer) => {
-                println!("We processed: {}", buffer);
+                println!("We processed: {buffer}");
             }
             Signal::CtrlD | Signal::CtrlC => {
                 println!("\nAborted!");

--- a/examples/list_bindings.rs
+++ b/examples/list_bindings.rs
@@ -17,34 +17,33 @@ fn main() -> Result<()> {
 fn get_all_keybinding_info() {
     println!("--Key Modifiers--");
     for mods in get_reedline_keybinding_modifiers().iter() {
-        println!("{}", mods);
+        println!("{mods}");
     }
 
     println!("\n--Modes--");
     for modes in get_reedline_prompt_edit_modes().iter() {
-        println!("{}", modes);
+        println!("{modes}");
     }
 
     println!("\n--Key Codes--");
     for kcs in get_reedline_keycodes().iter() {
-        println!("{}", kcs);
+        println!("{kcs}");
     }
 
     println!("\n--Reedline Events--");
     for rle in get_reedline_reedline_events().iter() {
-        println!("{}", rle);
+        println!("{rle}");
     }
 
     println!("\n--Edit Commands--");
     for edit in get_reedline_edit_commands().iter() {
-        println!("{}", edit);
+        println!("{edit}");
     }
 
     println!("\n--Default Keybindings--");
     for (mode, modifier, code, event) in get_reedline_default_keybindings() {
         println!(
-            "mode: {}, keymodifiers: {}, keycode: {}, event: {}",
-            mode, modifier, code, event
+            "mode: {mode}, keymodifiers: {modifier}, keycode: {code}, event: {event}"
         );
     }
 }

--- a/examples/list_bindings.rs
+++ b/examples/list_bindings.rs
@@ -42,8 +42,6 @@ fn get_all_keybinding_info() {
 
     println!("\n--Default Keybindings--");
     for (mode, modifier, code, event) in get_reedline_default_keybindings() {
-        println!(
-            "mode: {mode}, keymodifiers: {modifier}, keycode: {code}, event: {event}"
-        );
+        println!("mode: {mode}, keymodifiers: {modifier}, keycode: {code}, event: {event}");
     }
 }

--- a/examples/validator.rs
+++ b/examples/validator.rs
@@ -30,7 +30,7 @@ fn main() -> io::Result<()> {
         let sig = line_editor.read_line(&prompt)?;
         match sig {
             Signal::Success(buffer) => {
-                println!("We processed: {}", buffer);
+                println!("We processed: {buffer}");
             }
             Signal::CtrlD | Signal::CtrlC => {
                 println!("\nAborted!");

--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -17,9 +17,7 @@ impl Span {
     pub fn new(start: usize, end: usize) -> Span {
         assert!(
             end >= start,
-            "Can't create a Span whose end < start, start={}, end={}",
-            start,
-            end
+            "Can't create a Span whose end < start, start={start}, end={end}"
         );
 
         Span { start, end }

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -83,7 +83,7 @@ impl Completer for DefaultCompleter {
                     if span_line.is_empty() {
                         span_line = s.to_string();
                     } else {
-                        span_line = format!("{} {}", s, span_line);
+                        span_line = format!("{s} {span_line}");
                     }
                     if let Some(mut extensions) = self.root.complete(span_line.chars()) {
                         extensions.sort();
@@ -97,7 +97,7 @@ impl Completer for DefaultCompleter {
                                     );
 
                                     Suggestion {
-                                        value: format!("{}{}", span_line, ext),
+                                        value: format!("{span_line}{ext}"),
                                         description: None,
                                         extra: None,
                                         span,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1425,7 +1425,7 @@ impl Reedline {
             .highlight(buffer_to_paint, cursor_position_in_buffer)
             .render_around_insertion_point(
                 cursor_position_in_buffer,
-                prompt.render_prompt_multiline_indicator().borrow(),
+                prompt,
                 self.use_ansi_coloring,
             );
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1336,7 +1336,7 @@ impl Reedline {
             None => Ok(()),
             Some(BufferEditor { editor, extension }) => {
                 let temp_directory = std::env::temp_dir();
-                let temp_file = temp_directory.join(format!("reedline_buffer.{}", extension));
+                let temp_file = temp_directory.join(format!("reedline_buffer.{extension}"));
 
                 {
                     let mut file = File::create(temp_file.clone())?;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -34,9 +34,7 @@ use {
         event::{Event, KeyCode, KeyEvent, KeyModifiers},
         terminal, Result,
     },
-    std::{
-        borrow::Borrow, fs::File, io, io::Write, process::Command, time::Duration, time::SystemTime,
-    },
+    std::{fs::File, io, io::Write, process::Command, time::Duration, time::SystemTime},
 };
 
 // The POLL_WAIT is used to specify for how long the POLL should wait for

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -557,10 +557,10 @@ mod tests {
                 let hfile = histfile.clone();
                 std::thread::spawn(move || {
                     let (mut hist, _) = create_history_at(cap, &hfile);
-                    hist.save(HistoryItem::from_command_line(&format!("A{}", i)))
+                    hist.save(HistoryItem::from_command_line(format!("A{i}")))
                         .unwrap();
                     hist.sync().unwrap();
-                    hist.save(HistoryItem::from_command_line(&format!("B{}", i)))
+                    hist.save(HistoryItem::from_command_line(format!("B{i}")))
                         .unwrap();
                 })
             })
@@ -580,8 +580,8 @@ mod tests {
         );
 
         for i in 0..num_threads {
-            assert!(actual.contains(&format!("A{}", i)),);
-            assert!(actual.contains(&format!("B{}", i)),);
+            assert!(actual.contains(&format!("A{i}")),);
+            assert!(actual.contains(&format!("B{i}")),);
         }
 
         tmp.close().unwrap();

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -226,7 +226,7 @@ impl History for FileBackedHistory {
             {
                 let mut writer = BufWriter::new(writer_guard.deref_mut());
                 if truncate {
-                    writer.seek(SeekFrom::Start(0))?;
+                    writer.rewind()?;
 
                     for line in &foreign_entries {
                         writer.write_all(encode_entry(line).as_bytes())?;

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -157,8 +157,7 @@ impl History for SqliteBackedHistory {
 fn map_sqlite_err(err: rusqlite::Error) -> ReedlineError {
     // TODO: better error mapping
     ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(format!(
-        "{:?}",
-        err
+        "{err:?}"
     )))
 }
 
@@ -174,8 +173,7 @@ impl SqliteBackedHistory {
         if let Some(base_dir) = file.parent() {
             std::fs::create_dir_all(base_dir).map_err(|e| {
                 ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(format!(
-                    "{}",
-                    e
+                    "{e}"
                 )))
             })?;
         }

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -172,9 +172,7 @@ impl SqliteBackedHistory {
     pub fn with_file(file: PathBuf) -> Result<Self> {
         if let Some(base_dir) = file.parent() {
             std::fs::create_dir_all(base_dir).map_err(|e| {
-                ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(format!(
-                    "{e}"
-                )))
+                ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(format!("{e}")))
             })?;
         }
         let db = Connection::open(&file).map_err(map_sqlite_err)?;

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -319,7 +319,7 @@ impl ListMenu {
                     RESET
                 )
             } else {
-                format!("({}) ", desc)
+                format!("({desc}) ")
             }
         });
 
@@ -339,7 +339,7 @@ impl ListMenu {
             let line_str = if index == self.index() {
                 format!("{}{}>{}", row_number, description, line.to_uppercase())
             } else {
-                format!("{}{}{}", row_number, description, line)
+                format!("{row_number}{description}{line}")
             };
 
             // Final string with formatting

--- a/src/painting/styled_text.rs
+++ b/src/painting/styled_text.rs
@@ -1,5 +1,10 @@
+use std::borrow::Borrow;
+
+use nu_ansi_term::Style;
+
+use crate::Prompt;
+
 use super::utils::strip_ansi;
-use nu_ansi_term::{Color, Style};
 
 /// A representation of a buffer with styling, used for doing syntax highlighting
 pub struct StyledText {
@@ -34,18 +39,22 @@ impl StyledText {
     pub fn render_around_insertion_point(
         &self,
         insertion_point: usize,
-        multiline_prompt: &str,
+        prompt: &dyn Prompt,
+        // multiline_prompt: &str,
         use_ansi_coloring: bool,
     ) -> (String, String) {
         let mut current_idx = 0;
         let mut left_string = String::new();
         let mut right_string = String::new();
-        let prompt_style = Style::new().fg(Color::LightBlue);
+
+        let multiline_prompt = prompt.render_prompt_multiline_indicator();
+        let prompt_style = Style::new().fg(prompt.get_prompt_multiline_color());
+
         for pair in &self.buffer {
             if current_idx >= insertion_point {
-                right_string.push_str(&render_as_string(pair, &prompt_style, multiline_prompt));
+                right_string.push_str(&render_as_string(pair, &prompt_style, &multiline_prompt));
             } else if pair.1.len() + current_idx <= insertion_point {
-                left_string.push_str(&render_as_string(pair, &prompt_style, multiline_prompt));
+                left_string.push_str(&render_as_string(pair, &prompt_style, &multiline_prompt));
             } else if pair.1.len() + current_idx > insertion_point {
                 let offset = insertion_point - current_idx;
 
@@ -55,12 +64,12 @@ impl StyledText {
                 left_string.push_str(&render_as_string(
                     &(pair.0, left_side),
                     &prompt_style,
-                    multiline_prompt,
+                    &multiline_prompt,
                 ));
                 right_string.push_str(&render_as_string(
                     &(pair.0, right_side),
                     &prompt_style,
-                    multiline_prompt,
+                    &multiline_prompt,
                 ));
             }
             current_idx += pair.1.len();

--- a/src/painting/styled_text.rs
+++ b/src/painting/styled_text.rs
@@ -100,7 +100,7 @@ fn render_as_string(
     multiline_prompt: &str,
 ) -> String {
     let mut rendered = String::new();
-    let formatted_multiline_prompt = format!("\n{}", multiline_prompt);
+    let formatted_multiline_prompt = format!("\n{multiline_prompt}");
     for (line_number, line) in renderable.1.split('\n').enumerate() {
         if line_number != 0 {
             rendered.push_str(&prompt_style.paint(&formatted_multiline_prompt).to_string());

--- a/src/painting/styled_text.rs
+++ b/src/painting/styled_text.rs
@@ -1,5 +1,3 @@
-use std::borrow::Borrow;
-
 use nu_ansi_term::Style;
 
 use crate::Prompt;

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -10,6 +10,7 @@ use {
 
 /// The default color for the prompt, indicator, and right prompt
 pub static DEFAULT_PROMPT_COLOR: Color = Color::Green;
+pub static DEFAULT_PROMPT_MULTILINE_COLOR: nu_ansi_term::Color = nu_ansi_term::Color::LightBlue;
 pub static DEFAULT_INDICATOR_COLOR: Color = Color::Cyan;
 pub static DEFAULT_PROMPT_RIGHT_COLOR: Color = Color::AnsiValue(5);
 
@@ -104,6 +105,10 @@ pub trait Prompt: Send {
     /// Get the default prompt color
     fn get_prompt_color(&self) -> Color {
         DEFAULT_PROMPT_COLOR
+    }
+    /// Get the default right prompt color
+    fn get_prompt_multiline_color(&self) -> nu_ansi_term::Color {
+        DEFAULT_PROMPT_MULTILINE_COLOR
     }
     /// Get the default indicator color
     fn get_indicator_color(&self) -> Color {

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -80,7 +80,7 @@ impl Display for PromptEditMode {
             PromptEditMode::Default => write!(f, "Default"),
             PromptEditMode::Emacs => write!(f, "Emacs"),
             PromptEditMode::Vi(_) => write!(f, "Vi_Normal\nVi_Insert"),
-            PromptEditMode::Custom(s) => write!(f, "Custom_{}", s),
+            PromptEditMode::Custom(s) => write!(f, "Custom_{s}"),
         }
     }
 }

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -106,7 +106,7 @@ pub trait Prompt: Send {
     fn get_prompt_color(&self) -> Color {
         DEFAULT_PROMPT_COLOR
     }
-    /// Get the default right prompt color
+    /// Get the default multilince prompt color
     fn get_prompt_multiline_color(&self) -> nu_ansi_term::Color {
         DEFAULT_PROMPT_MULTILINE_COLOR
     }

--- a/src/prompt/default.rs
+++ b/src/prompt/default.rs
@@ -66,7 +66,7 @@ impl Prompt for DefaultPrompt {
                 PromptViMode::Normal => DEFAULT_VI_NORMAL_PROMPT_INDICATOR.into(),
                 PromptViMode::Insert => DEFAULT_VI_INSERT_PROMPT_INDICATOR.into(),
             },
-            PromptEditMode::Custom(str) => format!("({})", str).into(),
+            PromptEditMode::Custom(str) => format!("({str})").into(),
         }
     }
 

--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -79,7 +79,7 @@ pub fn get_reedline_prompt_edit_modes() -> Vec<String> {
 /// Return a `Vec<String>` of the Reedline `KeyCode`s
 pub fn get_reedline_keycodes() -> Vec<String> {
     ReedLineCrossTermKeyCode::iterator()
-        .map(|kc| format!("{}", kc))
+        .map(|kc| format!("{kc}"))
         .collect()
 }
 
@@ -121,7 +121,7 @@ fn get_keybinding_strings(
                 mode.to_string(),
                 format!("{:?}", combination.modifier),
                 format!("{:?}", combination.key_code),
-                format!("{:?}", event),
+                format!("{event:?}"),
             )
         })
         .collect();


### PR DESCRIPTION
The color of the multiline prompt is currently hard-coded to be `LightBlue`. This ended up being a pretty straightforward change to allow it to be configured using the `Prompt` trait similar to the other prompt colors.

One oddity in here is that the multiline prompt uses a `nu_ansi_term::Color`, whereas the other colors use a `crossterm::style::Color`. I'm not sure which one is preferred at this point, but I'd be willing to work toward some consistency if there's a current direction toward one or the other. 