### PR TITLE
Remove unstable rustdoc lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,6 @@
 //! - [rustyline](https://crates.io/crates/rustyline)
 //!
 #![warn(rustdoc::missing_crate_level_docs)]
-#![warn(rustdoc::missing_doc_code_examples)]
 #![warn(missing_docs)]
 // #![deny(warnings)]
 mod core_editor;


### PR DESCRIPTION
`rustdoc::missing_doc_code_examples` apparently only works on nightly and causes unnecessary warnings appearing in the CI output.