### PR TITLE
Fix columnar menu completion corrupting the editor insertion point

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -667,8 +667,8 @@ impl Menu for ColumnarMenu {
             line_buffer.replace_range(start..end, &value);
 
             let mut offset = line_buffer.insertion_point();
-            offset += value.len();
-            offset -= end.saturating_sub(start);
+            offset = offset.saturating_add(value.len());
+            offset = offset.saturating_sub(end.saturating_sub(start));
             line_buffer.set_insertion_point(offset);
             editor.set_line_buffer(line_buffer, UndoBehavior::CreateUndoPoint);
         }


### PR DESCRIPTION
See: https://github.com/nushell/nushell/issues/7885 for more context.

Repro:
1. type `` open FILENAME` ``
2. press TAB (`` ` `` gets removed at the end)
3. press `` ` ``