### PR TITLE
Add History::clear() function

### DIFF
--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -165,6 +165,8 @@ pub trait History: Send {
         id: HistoryItemId,
         updater: &dyn Fn(HistoryItem) -> HistoryItem,
     ) -> Result<()>;
+    /// delete all history items
+    fn clear(&mut self) -> Result<()>;
     /// remove an item from this history
     fn delete(&mut self, h: HistoryItemId) -> Result<()>;
     /// ensure that this history is written to disk
@@ -319,6 +321,16 @@ mod test {
             ..SearchQuery::everything(SearchDirection::Forward)
         })?;
         search_returned(&*history, res, vec![1, 4])?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn clear_history() -> Result<()> {
+        let mut history = create_filled_example_history()?;
+        assert_ne!(history.count_all()?, 0);
+        history.clear().unwrap();
+        assert_eq!(history.count_all()?, 0);
 
         Ok(())
     }

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -178,6 +178,19 @@ impl History for FileBackedHistory {
         ))
     }
 
+    fn clear(&mut self) -> Result<()> {
+        self.entries.clear();
+        self.len_on_disk = 0;
+
+        if let Some(file) = &self.file {
+            if let Err(err) = std::fs::remove_file(file) {
+                return Err(ReedlineError(ReedlineErrorVariants::IOError(err)));
+            }
+        }
+
+        Ok(())
+    }
+
     fn delete(&mut self, _h: super::HistoryItemId) -> Result<()> {
         Err(ReedlineError(
             ReedlineErrorVariants::HistoryFeatureUnsupported {

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -136,6 +136,14 @@ impl History for SqliteBackedHistory {
         Ok(())
     }
 
+    fn clear(&mut self) -> Result<()> {
+        self.db
+            .execute("delete from history", params![])
+            .map_err(map_sqlite_err)?;
+
+        Ok(())
+    }
+
     fn delete(&mut self, h: HistoryItemId) -> Result<()> {
         let changed = self
             .db

--- a/src/result.rs
+++ b/src/result.rs
@@ -15,6 +15,8 @@ pub(crate) enum ReedlineErrorVariants {
         history: &'static str,
         feature: &'static str,
     },
+    #[error("I/O error: {0}")]
+    IOError(std::io::Error),
 }
 
 /// separate struct to not expose anything to the public (for now)


### PR DESCRIPTION
Adds a `History::clear()` function that deletes all history items. Closes #535.

Will eventually close https://github.com/nushell/nushell/issues/7991