### PR TITLE
VACUUM after deleting SQLite data

### DIFF
--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -141,6 +141,12 @@ impl History for SqliteBackedHistory {
             .execute("delete from history", params![])
             .map_err(map_sqlite_err)?;
 
+        // VACUUM to ensure that sensitive data is completely erased
+        // instead of being marked as available for reuse
+        self.db
+            .execute("VACUUM", params![])
+            .map_err(map_sqlite_err)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
Quick follow-up to #535: we should run [`VACUUM`](https://www.sqlite.org/lang_vacuum.html) after clearing the `history` table, to ensure that history is fully erased. Without a `VACUUM`, history may be recoverable by looking at the raw database files.