### PR TITLE
Bump version for `0.16.0` release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reedline"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["The Nushell Project Developers", "JT <jonathan.d.turner@gmail.com>"]
 edition = "2021"
 description = "A readline-like crate for CLI text input"


### PR DESCRIPTION
Expected to contain minor bugfix and work on `History::clear` API (work
to improve history metadata handling still in progress)
