### PR TITLE
allow reedline ctrl+o to take editor arguments

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1348,7 +1348,7 @@ impl Reedline {
                     write!(file, "{}", self.editor.get_buffer())?;
                 }
 
-                let mut ed = editor.split(" ");
+                let mut ed = editor.split(' ');
                 let command = ed.next();
 
                 {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1348,8 +1348,12 @@ impl Reedline {
                     write!(file, "{}", self.editor.get_buffer())?;
                 }
 
+                let mut ed = editor.split(" ");
+                let command = ed.next();
+
                 {
-                    let mut process = Command::new(editor);
+                    let mut process = Command::new(command.unwrap_or(editor));
+                    process.args(ed);
                     process.arg(temp_file.as_path());
 
                     let mut child = process.spawn()?;


### PR DESCRIPTION
relevant: https://github.com/nushell/nushell/pull/8105

allows ctrl+o keybinding to take command arguments into account