### PR TITLE
Allow multi byte characters as the marker without panicking

### DIFF
--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -262,12 +262,12 @@ mod tests {
     #[cfg(feature = "bashisms")]
     #[test]
     fn handles_multi_byte_char_as_marker_and_number() {
-        let buffer = "Testは4!";
+        let buffer = "searchは6";
         let parse_result = parse_selection_char(buffer, 'は');
 
-        assert_eq!(parse_result.remainder, "Test");
-        assert_eq!(parse_result.index, Some(4));
-        assert_eq!(parse_result.marker, Some("は4"));
+        assert_eq!(parse_result.remainder, "search");
+        assert_eq!(parse_result.index, Some(6));
+        assert_eq!(parse_result.marker, Some("は6"));
     }
 
     #[cfg(feature = "bashisms")]
@@ -285,10 +285,10 @@ mod tests {
     #[cfg(feature = "bashisms")]
     #[test]
     fn handles_multi_byte_char_as_remainder() {
-        let buffer = "は!!";
+        let buffer = "Testは!!";
         let parse_result = parse_selection_char(buffer, '!');
 
-        assert_eq!(parse_result.remainder, "は");
+        assert_eq!(parse_result.remainder, "Testは");
         assert_eq!(parse_result.index, Some(0));
         assert_eq!(parse_result.marker, Some("!!"));
         assert!(matches!(parse_result.action, ParseAction::LastCommand));

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -67,7 +67,7 @@ pub fn parse_selection_char(buffer: &str, marker: char) -> ParseResult {
     let mut action = ParseAction::ForwardSearch;
     while let Some(char) = input.next() {
         if char == marker {
-            match input.peek() {                
+            match input.peek() {
                 #[cfg(feature = "bashisms")]
                 Some(&x) if x == marker => {
                     return ParseResult {

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -261,7 +261,7 @@ mod tests {
 
     #[cfg(feature = "bashisms")]
     #[test]
-    fn handles_multi_byte_char_as_marker() {
+    fn handles_multi_byte_char_as_marker_and_number() {
         let buffer = "Testは4!";
         let parse_result = parse_selection_char(buffer, 'は');
 
@@ -269,15 +269,31 @@ mod tests {
         assert_eq!(parse_result.index, Some(4));
         assert_eq!(parse_result.marker, Some("は4"));
 
-        let other_buffer = "Testはは";
-        let other_parse_result = parse_selection_char(other_buffer, 'は');
+    }
+    
+    #[cfg(feature = "bashisms")]
+    #[test]
+    fn handles_multi_byte_char_as_double_marker() {
+        let buffer = "Testはは";
+        let parse_result = parse_selection_char(buffer, 'は');
 
-        assert_eq!(other_parse_result.remainder, "Test");
-        assert_eq!(other_parse_result.index, Some(0));
-        assert_eq!(other_parse_result.marker, Some("はは"));
-        assert!(matches!(other_parse_result.action, ParseAction::LastCommand));
+        assert_eq!(parse_result.remainder, "Test");
+        assert_eq!(parse_result.index, Some(0));
+        assert_eq!(parse_result.marker, Some("はは"));
+        assert!(matches!(parse_result.action, ParseAction::LastCommand));
     }
 
+    #[cfg(feature = "bashisms")]
+    #[test]
+    fn handles_multi_byte_char_as_remainder() {
+        let buffer = "は!!";
+        let parse_result = parse_selection_char(buffer, '!');
+
+        assert_eq!(parse_result.remainder, "は");
+        assert_eq!(parse_result.index, Some(0));
+        assert_eq!(parse_result.marker, Some("!!"));
+        assert!(matches!(parse_result.action, ParseAction::LastCommand));
+    }
     
     #[test]
     fn parse_double_char() {

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -268,9 +268,8 @@ mod tests {
         assert_eq!(parse_result.remainder, "Test");
         assert_eq!(parse_result.index, Some(4));
         assert_eq!(parse_result.marker, Some("は4"));
-
     }
-    
+
     #[cfg(feature = "bashisms")]
     #[test]
     fn handles_multi_byte_char_as_double_marker() {
@@ -294,7 +293,8 @@ mod tests {
         assert_eq!(parse_result.marker, Some("!!"));
         assert!(matches!(parse_result.action, ParseAction::LastCommand));
     }
-    
+
+    #[cfg(feature = "bashisms")]
     #[test]
     fn parse_double_char() {
         let input = "search!!";


### PR DESCRIPTION
This is an attempt to fix https://github.com/nushell/nushell/issues/8412.
I believe that the issue is caused because of the reference to reedline.  

I believe that if we implement this fix, bump the version and use the new version inside nushell, then the bug should be resolved.  

This is my first PR in Rust so happy to change anything you see as an issue! 