### PR TITLE
Set MSRV to 1.62.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,22 @@ history.sqlite3*
 .DS_Store
 target-coverage/
 tarpaulin-report.html
-.vscode
-.helix
 
 # ignore the git mailmap file
 .mailmap
+
+# JetBrains' IDE items
+.idea/*
+
+# VSCode's IDE items
+.vscode/*
+
+# Helix configuration folder
+.helix/*
+.helix
+
+# Visual Studio
+.vs/*
+*.rsproj
+*.rsproj.user
+*.sln

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "reedline"
 version = "0.17.0"
 authors = ["The Nushell Project Developers", "JT <jonathan.d.turner@gmail.com>"]
 edition = "2021"
+rust-version = "1.62.1"
 description = "A readline-like crate for CLI text input"
 license = "MIT"
 repository = "https://github.com/nushell/reedline"
@@ -42,4 +43,3 @@ bashisms = []
 external_printer = ["crossbeam"]
 sqlite = ["rusqlite/bundled", "serde_json"]
 sqlite-dynlib = ["rusqlite", "serde_json"]
-


### PR DESCRIPTION
I validated it with the cli `cargo msrv`:

```
cargo msrv
  [Meta]   cargo-msrv 0.16.0-beta.8 (a1b5066)                                                                                                                                                                                                                                                                       
Compatibility Check #1: Rust 1.62.1
  [OK]     Is compatible 

Compatibility Check #2: Rust 1.59.0                                                                                                                                                                                                                                                                                   [FAIL]   Is incompatible 
                                                                                                            
  ╭────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │     Updating crates.io index                                                                           │
  │ error: failed to select a version for the requirement `rstest = "^0.16.0"`                             │
  │ candidate versions found which didn't match: 0.13.0, 0.12.0, 0.11.0, ...                               │
  │ location searched: crates.io index                                                                     │
  │ required by package `reedline v0.17.0 (/home/jaudiger/Development/git-repositories/jaudiger/reedline)` │
  │                                                                                                        │
  ╰────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                            

Compatibility Check #3: Rust 1.60.0                                                                                                                                                                                                                                                                                   [FAIL]   Is incompatible 
                                                                                                                                                                                                                     
  ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │ error: package `reedline v0.17.0 (/home/jaudiger/Development/git-repositories/jaudiger/reedline)` cannot be built because it requires rustc 1.62.1 or newer, while the currently active rustc version is 1.60.0 │
  │                                                                                                                                                                                                                 │
  ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                                                                                                                     

Compatibility Check #4: Rust 1.61.0                                                                                                                                                                                                                                                                                   [FAIL]   Is incompatible 
                                                                                                                                                                                                                     
  ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
  │ error: package `reedline v0.17.0 (/home/jaudiger/Development/git-repositories/jaudiger/reedline)` cannot be built because it requires rustc 1.62.1 or newer, while the currently active rustc version is 1.61.0 │
  │                                                                                                                                                                                                                 │
  ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                                                                                                                     

Result:
   Considered (min … max):   Rust 1.56.0 … Rust 1.68.0 
   Search method:            bisect                    
   MSRV:                     1.62.1                    
   Target:                   x86_64-unknown-linux-gnu 
```