### PR TITLE
Forward buffer content and offset to EditMode

### DIFF
--- a/src/edit_mode/base.rs
+++ b/src/edit_mode/base.rs
@@ -7,7 +7,7 @@ pub use crossterm::event::Event;
 /// - Vi
 pub trait EditMode: Send {
     /// Translate the given user input event into what the `LineEditor` understands
-    fn parse_event(&mut self, event: Event) -> ReedlineEvent;
+    fn parse_event(&mut self, event: Event, line: &str, cursor: usize) -> ReedlineEvent;
 
     /// What to display in the prompt indicator
     fn edit_mode(&self) -> PromptEditMode;

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -108,7 +108,7 @@ impl Default for Emacs {
 }
 
 impl EditMode for Emacs {
-    fn parse_event(&mut self, event: Event) -> ReedlineEvent {
+    fn parse_event(&mut self, event: Event, _line: &str, _offset: usize) -> ReedlineEvent {
         match event {
             Event::Key(KeyEvent { code, modifiers }) => match (modifiers, code) {
                 (modifier, KeyCode::Char(c)) => {
@@ -179,7 +179,7 @@ mod test {
             modifiers: KeyModifiers::CONTROL,
             code: KeyCode::Char('l'),
         });
-        let result = emacs.parse_event(ctrl_l);
+        let result = emacs.parse_event(ctrl_l, "", 0);
 
         assert_eq!(result, ReedlineEvent::ClearScreen);
     }
@@ -198,7 +198,7 @@ mod test {
             modifiers: KeyModifiers::CONTROL,
             code: KeyCode::Char('l'),
         });
-        let result = emacs.parse_event(ctrl_l);
+        let result = emacs.parse_event(ctrl_l, "", 0);
 
         assert_eq!(result, ReedlineEvent::HistoryHintComplete);
     }
@@ -210,7 +210,7 @@ mod test {
             modifiers: KeyModifiers::NONE,
             code: KeyCode::Char('l'),
         });
-        let result = emacs.parse_event(l);
+        let result = emacs.parse_event(l, "", 0);
 
         assert_eq!(
             result,
@@ -226,7 +226,7 @@ mod test {
             modifiers: KeyModifiers::SHIFT,
             code: KeyCode::Char('l'),
         });
-        let result = emacs.parse_event(uppercase_l);
+        let result = emacs.parse_event(uppercase_l, "", 0);
 
         assert_eq!(
             result,
@@ -243,7 +243,7 @@ mod test {
             modifiers: KeyModifiers::CONTROL,
             code: KeyCode::Char('l'),
         });
-        let result = emacs.parse_event(ctrl_l);
+        let result = emacs.parse_event(ctrl_l, "", 0);
 
         assert_eq!(result, ReedlineEvent::None);
     }
@@ -256,7 +256,7 @@ mod test {
             modifiers: KeyModifiers::SHIFT,
             code: KeyCode::Char('😀'),
         });
-        let result = emacs.parse_event(uppercase_l);
+        let result = emacs.parse_event(uppercase_l, "", 0);
 
         assert_eq!(
             result,

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -57,7 +57,7 @@ impl Vi {
 }
 
 impl EditMode for Vi {
-    fn parse_event(&mut self, event: Event) -> ReedlineEvent {
+    fn parse_event(&mut self, event: Event, _line: &str, _offset: usize) -> ReedlineEvent {
         match event {
             Event::Key(KeyEvent { code, modifiers }) => match (self.mode, modifiers, code) {
                 (ViMode::Normal, modifier, KeyCode::Char(c)) => {
@@ -172,7 +172,7 @@ mod test {
             modifiers: KeyModifiers::NONE,
             code: KeyCode::Esc,
         });
-        let result = vi.parse_event(esc);
+        let result = vi.parse_event(esc, "", 0);
 
         assert_eq!(
             result,
@@ -201,7 +201,7 @@ mod test {
             modifiers: KeyModifiers::NONE,
             code: KeyCode::Char('e'),
         });
-        let result = vi.parse_event(esc);
+        let result = vi.parse_event(esc, "", 0);
 
         assert_eq!(result, ReedlineEvent::ClearScreen);
     }
@@ -226,7 +226,7 @@ mod test {
             modifiers: KeyModifiers::SHIFT,
             code: KeyCode::Char('$'),
         });
-        let result = vi.parse_event(esc);
+        let result = vi.parse_event(esc, "", 0);
 
         assert_eq!(result, ReedlineEvent::CtrlD);
     }
@@ -245,7 +245,7 @@ mod test {
             modifiers: KeyModifiers::NONE,
             code: KeyCode::Char('q'),
         });
-        let result = vi.parse_event(esc);
+        let result = vi.parse_event(esc, "", 0);
 
         assert_eq!(result, ReedlineEvent::None);
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -548,12 +548,15 @@ impl Reedline {
                     reedline_events.push(ReedlineEvent::Resize(x, y));
                 }
 
+                let input = self.editor.get_buffer();
+                let offset = self.editor.insertion_point();
+
                 // Accelerate pasted text by fusing `EditCommand`s
                 //
                 // (Text should only be `EditCommand::InsertChar`s)
                 let mut last_edit_commands = None;
                 for event in crossterm_events.drain(..) {
-                    match (&mut last_edit_commands, self.edit_mode.parse_event(event)) {
+                    match (&mut last_edit_commands, self.edit_mode.parse_event(event, input, offset)) {
                         (None, ReedlineEvent::Edit(ec)) => {
                             last_edit_commands = Some(ec);
                         }


### PR DESCRIPTION
This is a breaking change.

It would allow to improve keybindings precision, such as autocompleting a quote (") only if the character on the right of the cursor isn't already one.