### PR TITLE
Allow history searching via session id

### DIFF
--- a/src/hinter/default.rs
+++ b/src/hinter/default.rs
@@ -20,7 +20,10 @@ impl Hinter for DefaultHinter {
     ) -> String {
         self.current_hint = if line.chars().count() >= self.min_chars {
             history
-                .search(SearchQuery::last_with_prefix(line.to_string()))
+                .search(SearchQuery::last_with_prefix(
+                    line.to_string(),
+                    history.session(),
+                ))
                 .expect("todo: error handling")
                 .get(0)
                 .map_or_else(String::new, |entry| {

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use crate::{
     result::{ReedlineError, ReedlineErrorVariants},
-    Result,
+    HistorySessionId, Result,
 };
 
 use std::{
@@ -30,6 +30,7 @@ pub struct FileBackedHistory {
     entries: VecDeque<String>,
     file: Option<PathBuf>,
     len_on_disk: usize, // Keep track what was previously written to disk
+    session: Option<HistorySessionId>,
 }
 
 impl Default for FileBackedHistory {
@@ -268,6 +269,10 @@ impl History for FileBackedHistory {
         }
         Ok(())
     }
+
+    fn session(&self) -> Option<HistorySessionId> {
+        self.session
+    }
 }
 
 impl FileBackedHistory {
@@ -285,6 +290,7 @@ impl FileBackedHistory {
             entries: VecDeque::new(),
             file: None,
             len_on_disk: 0,
+            session: None,
         }
     }
 

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use rusqlite::ToSql;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{fmt::Display, time::Duration};
 
@@ -29,6 +30,14 @@ impl HistorySessionId {
 impl Display for HistorySessionId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl ToSql for HistorySessionId {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        Ok(rusqlite::types::ToSqlOutput::Owned(
+            rusqlite::types::Value::Integer(self.0),
+        ))
     }
 }
 


### PR DESCRIPTION
This PR attempts to allow reedline to have the ability to search the entire history, *OR* search only based on the current history session id. To demonstration this functionality, I've added a few commands to the demo example.

1. `history` - This shows the entire history regardless of session
2. `history session` - This shows the history only with the current history session id
3. `history sessionid` - This shows the current history session id or None
4. `toggle history_session` - This shows the ability to start off without a history session, create one, and then start to show only the history items with the current history session id. It also shows the opposite. You can toggle the history session searching off.

I've only tested this with the sqlite_backed history. More testing is required.
I haven't added any new tests. It may be a good idea to add some but I'm not quite sure how.