### PR TITLE
Bump version for `0.18.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reedline"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["The Nushell Project Developers", "JT <jonathan.d.turner@gmail.com>"]
 edition = "2021"
 rust-version = "1.62.1"


### PR DESCRIPTION
for `nushell 0.78.0`
