### PR TITLE
enable deleting history items with keybinding

### DIFF
--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -101,6 +101,7 @@ pub fn add_common_control_bindings(kb: &mut Keybindings) {
     kb.add_binding(KM::CONTROL, KC::Char('d'), ReedlineEvent::CtrlD);
     kb.add_binding(KM::CONTROL, KC::Char('l'), ReedlineEvent::ClearScreen);
     kb.add_binding(KM::CONTROL, KC::Char('r'), ReedlineEvent::SearchHistory);
+    kb.add_binding(KM::SHIFT, KC::Delete, ReedlineEvent::DeleteHistoryItem);
     kb.add_binding(KM::CONTROL, KC::Char('o'), ReedlineEvent::OpenEditor);
 }
 /// Add the arrow navigation and its `Ctrl` variants

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1117,7 +1117,7 @@ impl Reedline {
                 {
                     Some(Ok(())) => {
                         self.update_buffer_from_history();
-                        // TODO: are these needed/correct?
+                        // Move to end of first line, see `Self::previous_history()`.
                         self.editor.move_to_start(UndoBehavior::HistoryNavigation);
                         self.editor
                             .move_to_line_end(UndoBehavior::HistoryNavigation);
@@ -1188,6 +1188,7 @@ impl Reedline {
             .back(self.history.as_ref())
             .expect("todo: error handling");
         self.update_buffer_from_history();
+        // Move to end of *first* line, so that pressing up again goes directly to previous item.
         self.editor.move_to_start(UndoBehavior::HistoryNavigation);
         self.editor
             .move_to_line_end(UndoBehavior::HistoryNavigation);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1108,7 +1108,8 @@ impl Reedline {
             }
             ReedlineEvent::DeleteHistoryItem => {
                 if self.input_mode != InputMode::HistoryTraversal {
-                    return Ok(EventStatus::Inapplicable);
+                    self.run_edit_commands(&[EditCommand::Clear]);
+                    return Ok(EventStatus::Handled);
                 }
                 match self
                     .history_cursor

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1313,7 +1313,7 @@ impl Reedline {
                         .set_buffer(prefix, UndoBehavior::HistoryNavigation);
                 }
             }
-            HistoryNavigationQuery::SubstringSearch(x) => todo!("{:?}", x),
+            HistoryNavigationQuery::SubstringSearch(_) => todo!(),
         }
     }
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -470,6 +470,9 @@ pub enum ReedlineEvent {
     /// Search the history for a string
     SearchHistory,
 
+    /// Delete currently selected history item
+    DeleteHistoryItem,
+
     /// In vi mode multiple reedline events can be chained while parsing the
     /// command or movement characters
     Multiple(Vec<ReedlineEvent>),
@@ -539,6 +542,7 @@ impl Display for ReedlineEvent {
             ReedlineEvent::Left => write!(f, "Left"),
             ReedlineEvent::NextHistory => write!(f, "NextHistory"),
             ReedlineEvent::SearchHistory => write!(f, "SearchHistory"),
+            ReedlineEvent::DeleteHistoryItem => write!(f, "DeleteHistoryItem"),
             ReedlineEvent::Multiple(_) => write!(f, "Multiple[ {{ ReedLineEvents, }} ]"),
             ReedlineEvent::UntilFound(_) => write!(f, "UntilFound [ {{ ReedLineEvents, }} ]"),
             ReedlineEvent::Menu(_) => write!(f, "Menu Name: <string>"),

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -99,13 +99,12 @@ impl HistoryCursor {
                 Ok(()) => {
                     // Cursor must be moved *after* deletion, as deleting may
                     // alter which entry a `HistoryItemId` points to.
-                    if self.back(history).is_err()
+                    if (self.back(history).is_err()
                         || self.current.is_none()
-                        || self.current.as_ref().unwrap().id == Some(id)
+                        || self.current.as_ref().unwrap().id == Some(id))
+                        && self.forward(history).is_err()
                     {
-                        if self.forward(history).is_err() {
-                            self.current = None;
-                        }
+                        self.current = None;
                     }
                     Some(Ok(()))
                 }

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -91,6 +91,34 @@ impl HistoryCursor {
         self.current.as_ref().map(|e| e.command_line.to_string())
     }
 
+    /// Delete the item (if present) at the cursor from the history, and go back or forward one item
+    pub fn delete_item_at_cursor(&mut self, history: &mut dyn History) -> Option<Result<()>> {
+        let current = self.current.as_ref()?;
+        if let Some(id) = current.id {
+            match history.delete(id) {
+                Ok(()) => {
+                    // Cursor must be moved *after* deletion, as deleting may
+                    // alter which entry a `HistoryItemId` points to.
+                    if self.back(history).is_err()
+                        || self.current.is_none()
+                        || self.current.as_ref().unwrap().id == Some(id)
+                    {
+                        if self.forward(history).is_err() {
+                            self.current = None;
+                        }
+                    }
+                    Some(Ok(()))
+                }
+                Err(e) => Some(Err(e)),
+            }
+        } else {
+            if self.back(history).is_err() {
+                self.current = None;
+            }
+            Some(Ok(()))
+        }
+    }
+
     /// Poll the current [`HistoryNavigationQuery`] mode
     pub fn get_navigation(&self) -> HistoryNavigationQuery {
         self.query.clone()

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -52,7 +52,7 @@ impl From<HistorySessionId> for i64 {
 /// This trait represents additional arbitrary context to be added to a history (optional, see [`HistoryItem`])
 pub trait HistoryItemExtraInfo: Serialize + DeserializeOwned + Default + Send {}
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
 /// something that is serialized as null and deserialized by ignoring everything
 pub struct IgnoreAllExtraInfo;
 


### PR DESCRIPTION
Inspired by https://github.com/fish-shell/fish-shell/issues/9454

When a history item is selected, delete it with shift-del (apparently a standard binding, according to the issue linked above).

Will not delete (it just refuses, without showing feedback), when using a file-backed history where the history item being targeted has already been written to the file. It's not trivial to implement for this case, due to the concurrent modification of the text file.

I don't understand the

```
self.editor.move_to_start(UndoBehavior::HistoryNavigation);
self.editor.move_to_line_end(UndoBehavior::HistoryNavigation);
```
statements, so those changes in src/engine.rs may not be correct. I see in some places it just does `move_to_line_end`.
