### PR TITLE
re-export crossterm::style::Color for custom prompt implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,9 @@ pub use utils::{
 };
 
 // Reexport the key types to be independent from an explicit crossterm dependency.
-pub use crossterm::event::{KeyCode, KeyModifiers};
+pub use crossterm::{
+    event::{KeyCode, KeyModifiers},
+    style::Color,
+};
 #[cfg(feature = "external_printer")]
 pub use external_printer::ExternalPrinter;


### PR DESCRIPTION
Some default Prompt methods require crossterm::Color for manual implementation (`get_prompt_color` for example).  This re-exports Color for use by custom Prompt implementers.