### PR TITLE
feat: add `current_insertion_point()` to return the current insertion point of the input buffer

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -510,6 +510,11 @@ impl Reedline {
         result
     }
 
+    /// Returns the current insertion point of the input buffer.
+    pub fn current_insertion_point(&self) -> usize {
+        self.editor.insertion_point()
+    }
+
     /// Returns the current contents of the input buffer.
     pub fn current_buffer_contents(&self) -> &str {
         self.editor.get_buffer()


### PR DESCRIPTION
For [fix: set the initial repl cursor pos, fixes #8943 by stevenxxiu · Pull Request #8955 · nushell/nushell](https://github.com/nushell/nushell/pull/8955).
