### PR TITLE
fix bracketed paste

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -156,7 +156,9 @@ impl EditMode for Emacs {
             Event::Resize(width, height) => ReedlineEvent::Resize(width, height),
             Event::FocusGained => ReedlineEvent::None,
             Event::FocusLost => ReedlineEvent::None,
-            Event::Paste(body) => ReedlineEvent::Edit(vec![EditCommand::InsertString(body)]),
+            Event::Paste(body) => ReedlineEvent::Edit(vec![EditCommand::InsertString(
+                body.replace("\r\n", "\n").replace('\r', "\n"),
+            )]),
         }
     }
 

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -153,7 +153,9 @@ impl EditMode for Vi {
             Event::Resize(width, height) => ReedlineEvent::Resize(width, height),
             Event::FocusGained => ReedlineEvent::None,
             Event::FocusLost => ReedlineEvent::None,
-            Event::Paste(body) => ReedlineEvent::Edit(vec![EditCommand::InsertString(body)]),
+            Event::Paste(body) => ReedlineEvent::Edit(vec![EditCommand::InsertString(
+                body.replace("\r\n", "\n").replace('\r', "\n"),
+            )]),
         }
     }
 


### PR DESCRIPTION
Fixes: #576

Actually the issue comes from iterm2 setting when I want to paste multiline script:
![img](https://user-images.githubusercontent.com/22256154/235039891-7d8157c7-e694-4796-a7c6-33e566306ba5.png)

But yeah, when we enable bracketed paste, we can avoid pasted script to be executed automatically, I think it's safe to transfer from `\r` to `\n`. 

Currently I'm not sure how windows handle bracketed feature, since it doesn't work with crossterm lib, I'm going to convert from "\r\n" to "\n" to make sure that everything is working properly