### PR TITLE
fix: prompt position on resize

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -413,8 +413,9 @@ impl Painter {
             // Note: you can't just subtract the offset from the origin,
             // as we could be shrinking so fast that the offset we read back from
             // crossterm is past where it would have been.
-            let prompt_height = prev_terminal_size.1 - prev_prompt_row;
-            self.prompt_start_row = height - prompt_height;
+            let prompt_height = prev_terminal_size.1.saturating_sub(prev_prompt_row);
+            let prompt_height = prompt_height.max(1);
+            self.prompt_start_row = height.saturating_sub(prompt_height);
         } else if prev_terminal_size.1 < height {
             // Terminal is growing down, so move the prompt down the same amount to make space
             // for history that's on the screen

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -407,13 +407,14 @@ impl Painter {
         self.terminal_size = (width, height);
         // TODO properly adjusting prompt_origin on resizing while lines > 1
 
-        if prev_prompt_row >= (height - 1) {
+        if prev_prompt_row >= height {
             // Terminal is shrinking up
             // FIXME: use actual prompt size at some point
             // Note: you can't just subtract the offset from the origin,
             // as we could be shrinking so fast that the offset we read back from
             // crossterm is past where it would have been.
-            self.prompt_start_row = height - 2;
+            let prompt_height = prev_terminal_size.1 - prev_prompt_row;
+            self.prompt_start_row = height - prompt_height;
         } else if prev_terminal_size.1 < height {
             // Terminal is growing down, so move the prompt down the same amount to make space
             // for history that's on the screen

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -407,22 +407,12 @@ impl Painter {
         self.terminal_size = (width, height);
         // TODO properly adjusting prompt_origin on resizing while lines > 1
 
-        if prev_prompt_row >= height {
-            // Terminal is shrinking up
-            // FIXME: use actual prompt size at some point
-            // Note: you can't just subtract the offset from the origin,
-            // as we could be shrinking so fast that the offset we read back from
-            // crossterm is past where it would have been.
-            let prompt_height = prev_terminal_size.1.saturating_sub(prev_prompt_row);
-            let prompt_height = prompt_height.max(1);
-            self.prompt_start_row = height.saturating_sub(prompt_height);
-        } else if prev_terminal_size.1 < height {
-            // Terminal is growing down, so move the prompt down the same amount to make space
-            // for history that's on the screen
-            // Note: if the terminal doesn't have sufficient history, this will leave a trail
-            // of previous prompts currently.
-            self.prompt_start_row = prev_prompt_row + (height - prev_terminal_size.1);
-        }
+        let prompt_height = prev_terminal_size.1.saturating_sub(prev_prompt_row);
+        let prompt_height = prompt_height.max(1);
+
+        // Note: if the terminal doesn't have sufficient history, this will leave a trail
+        // of previous prompts currently.
+        self.prompt_start_row = height.saturating_sub(prompt_height);
     }
 
     /// Writes `line` to the terminal with a following carriage return and newline

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -415,20 +415,12 @@ impl Painter {
         // - The terminal got larger
         //   - Note: if the terminal doesn't have sufficient history, this will leave a trail
         //     of previous prompts currently.
+        //   - Note: if the the prompt contains multiple lines, this will leave a trail of
+        //     previous prompts currently.
         // - The terminal got smaller and the whole prompt is no longer visible
-        //   - FIXME: Reproducing steps:
-        //     1. Make sure the input prompt is at the bottom
-        //     2. Type something every long so that it wraps
-        //     3. Press enter to make it a completion suggestion in the future
-        //     4. Perform the operations at the same time:
-        //        - Shrink the terminal height
-        //        - Type the same command again without wrapping it but still trigger the
-        //          wrapping completion suggestion
-        //     5. The prompt may eat the previous line
-        let prompt_height = prev_terminal_size.1.saturating_sub(prev_prompt_row);
-        let prompt_height = prompt_height.max(1);
-        let prompt_height = prompt_height.min(self.last_required_lines.max(1));
-        self.prompt_start_row = height.saturating_sub(prompt_height);
+        //   - Note: if the the prompt contains multiple lines, this will leave a trail of
+        //     previous prompts currently.
+        self.prompt_start_row = height.saturating_sub(1);
     }
 
     /// Writes `line` to the terminal with a following carriage return and newline

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -406,20 +406,25 @@ impl Painter {
 
         self.terminal_size = (width, height);
 
-        if prev_prompt_row < height && height <= prev_terminal_size.1 {
-            // The terminal got smaller but the start of the prompt is still visible
+        if prev_prompt_row < height
+            && height <= prev_terminal_size.1
+            && width == prev_terminal_size.0
+        {
+            // The terminal got smaller in height but the start of the prompt is still visible
+            // The width didn't change
             return;
         }
 
         // Either:
-        // - The terminal got larger
+        // - The terminal got larger in height
         //   - Note: if the terminal doesn't have sufficient history, this will leave a trail
         //     of previous prompts currently.
         //   - Note: if the the prompt contains multiple lines, this will leave a trail of
         //     previous prompts currently.
-        // - The terminal got smaller and the whole prompt is no longer visible
+        // - The terminal got smaller in height and the whole prompt is no longer visible
         //   - Note: if the the prompt contains multiple lines, this will leave a trail of
         //     previous prompts currently.
+        // - The width changed
         self.prompt_start_row = height.saturating_sub(1);
     }
 


### PR DESCRIPTION
Fix: https://github.com/nushell/nushell/issues/9015

Previously, when the terminal window shrinks its height, the prompt eats the previous line.
Now, the prompt will not overwrite the previous line.
