### PR TITLE
Allow binding of CTRL+ALT+<c>, SHIFT+<c> and CTRL+ALT+SHIFT+<c>

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -127,24 +127,28 @@ impl EditMode for Emacs {
                         _ => c.to_ascii_lowercase(),
                     };
 
-                    if modifier == KeyModifiers::NONE
-                        || modifier == KeyModifiers::SHIFT
-                        || modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
-                        || modifier
-                            == KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
-                    {
-                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(
-                            if modifier == KeyModifiers::SHIFT {
-                                c.to_ascii_uppercase()
+                    self.keybindings
+                        .find_binding(modifier, KeyCode::Char(c))
+                        .unwrap_or_else(|| {
+                            if modifier == KeyModifiers::NONE
+                                || modifier == KeyModifiers::SHIFT
+                                || modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
+                                || modifier
+                                    == KeyModifiers::CONTROL
+                                        | KeyModifiers::ALT
+                                        | KeyModifiers::SHIFT
+                            {
+                                ReedlineEvent::Edit(vec![EditCommand::InsertChar(
+                                    if modifier == KeyModifiers::SHIFT {
+                                        c.to_ascii_uppercase()
+                                    } else {
+                                        c
+                                    },
+                                )])
                             } else {
-                                c
-                            },
-                        )])
-                    } else {
-                        self.keybindings
-                            .find_binding(modifier, KeyCode::Char(c))
-                            .unwrap_or(ReedlineEvent::None)
-                    }
+                                ReedlineEvent::None
+                            }
+                        })
                 }
                 _ => self
                     .keybindings

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -111,24 +111,28 @@ impl EditMode for Vi {
                         _ => c.to_ascii_lowercase(),
                     };
 
-                    if modifier == KeyModifiers::NONE
-                        || modifier == KeyModifiers::SHIFT
-                        || modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
-                        || modifier
-                            == KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
-                    {
-                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(
-                            if modifier == KeyModifiers::SHIFT {
-                                c.to_ascii_uppercase()
+                    self.insert_keybindings
+                        .find_binding(modifier, KeyCode::Char(c))
+                        .unwrap_or_else(|| {
+                            if modifier == KeyModifiers::NONE
+                                || modifier == KeyModifiers::SHIFT
+                                || modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
+                                || modifier
+                                    == KeyModifiers::CONTROL
+                                        | KeyModifiers::ALT
+                                        | KeyModifiers::SHIFT
+                            {
+                                ReedlineEvent::Edit(vec![EditCommand::InsertChar(
+                                    if modifier == KeyModifiers::SHIFT {
+                                        c.to_ascii_uppercase()
+                                    } else {
+                                        c
+                                    },
+                                )])
                             } else {
-                                c
-                            },
-                        )])
-                    } else {
-                        self.insert_keybindings
-                            .find_binding(modifier, KeyCode::Char(c))
-                            .unwrap_or(ReedlineEvent::None)
-                    }
+                                ReedlineEvent::None
+                            }
+                        })
                 }
                 (_, KeyModifiers::NONE, KeyCode::Esc) => {
                     self.cache.clear();


### PR DESCRIPTION
# Context
Nushell exposes `control_alt` and similar keybinding modifiers, but currently it's not possible to actually use those mappings in nushell (at least on none of my keyboards).

From some limited testing, it appears like GNU readline also doesn't allow mapping `CTRL+ALT+f` and similar keybinds. I don't know if there's some deeper reason behind this, or just a limitation of readline itself. I can't think of any edgecases my change would break, since it's only if you actively choose to add a binding.

I use those keybinds quite extensively in other shells, so it'd be nice to have in nu as well.

# Commit message
Combinations like `Ctrl+Alt+a` could not be mapped previously, since some non-us keyboard layouts use those combinations for sending characters like `@`.

Now, first check if there a binding was defined using that combination, else interpret as raw characters. This should not affect those special keyboard layouts, since they would be sending `Ctrl+Alt+<special char>`, rather than what would be on the US layout.

E.g.
- Map `Ctrl+Alt+a` to an action
- `Ctrl+Alt+a` on (some) german keyboards would send `@`
- A german layout pressing those keys would send a key combination of `Ctrl+Alt+@`, so they are unaffected by this change (they would have to specifically map `Ctrl+Alt+@`)
- For any layout actually sending `Ctrl+Alt+a`, they get the mapped action

This affects emacs mode and vi insert mode (vi normal mode already allows such keybindings).