### PR TITLE
Bump to `0.20.0` for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reedline"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["The Nushell Project Developers", "JT <jonathan.d.turner@gmail.com>"]
 edition = "2021"
 rust-version = "1.62.1"


### PR DESCRIPTION
~Intended for nushell `0.80`~
**Update:** will not ship with 0.80 due to insufficient real world testing.

See the concerns around the features in https://github.com/nushell/nushell/pull/9207
