### PR TITLE
Fix move to line start in multi-line history entries

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1354,15 +1354,6 @@ impl Reedline {
     /// Executes [`EditCommand`] actions by modifying the internal state appropriately. Does not output itself.
     pub fn run_edit_commands(&mut self, commands: &[EditCommand]) {
         if self.input_mode == InputMode::HistoryTraversal {
-            if matches!(
-                self.history_cursor.get_navigation(),
-                HistoryNavigationQuery::Normal(_)
-            ) {
-                if let Some(string) = self.history_cursor.string_at_cursor() {
-                    self.editor
-                        .set_buffer(string, UndoBehavior::HistoryNavigation);
-                }
-            }
             self.input_mode = InputMode::Regular;
         }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1710,11 +1710,11 @@ impl Reedline {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::result::Result;
-    use std::error::Error;
     use crate::DefaultPrompt;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
+    use std::error::Error;
+    use std::result::Result;
 
     #[test]
     fn thread_safe() {
@@ -1725,12 +1725,15 @@ mod test {
     #[rstest]
     #[case("")]
     #[case("line of text")]
-    #[case("longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line of text")]
+    #[case(
+        "longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg line of text"
+    )]
     fn test_move_to_line_start(#[case] input: &str) -> Result<(), Box<dyn Error>> {
         let mut reedline = Reedline::create();
         let prompt = DefaultPrompt::default();
 
-        let insert_input_event = ReedlineEvent::Edit(vec![EditCommand::InsertString(input.to_string())]);
+        let insert_input_event =
+            ReedlineEvent::Edit(vec![EditCommand::InsertString(input.to_string())]);
         let move_to_line_start_event = ReedlineEvent::Edit(vec![EditCommand::MoveToLineStart]);
 
         // Have to resize, or painting.utils.estimate_single_line_wraps panics with divide-by-zero.
@@ -1761,11 +1764,11 @@ mod test {
         #[case] second_line_start: usize,
         #[case] last_line_start: usize,
     ) -> Result<(), Box<dyn Error>> {
-
         let mut reedline = Reedline::create();
         let prompt = DefaultPrompt::default();
 
-        let insert_input_event = ReedlineEvent::Edit(vec![EditCommand::InsertString(input.to_string())]);
+        let insert_input_event =
+            ReedlineEvent::Edit(vec![EditCommand::InsertString(input.to_string())]);
         let move_to_line_start_event = ReedlineEvent::Edit(vec![EditCommand::MoveToLineStart]);
         let move_to_end_event = ReedlineEvent::Edit(vec![EditCommand::MoveToEnd]);
 
@@ -1775,7 +1778,10 @@ mod test {
         // Write the string, and then move to the start of the last line.
         reedline.handle_event(&prompt, insert_input_event)?;
         reedline.handle_event(&prompt, move_to_line_start_event.clone())?;
-        assert_eq!(reedline.editor.line_buffer().insertion_point(), last_line_start);
+        assert_eq!(
+            reedline.editor.line_buffer().insertion_point(),
+            last_line_start
+        );
 
         // Enter the string into history, then scroll back up and move to the start of the first line.
         reedline.handle_event(&prompt, ReedlineEvent::Enter)?;
@@ -1789,7 +1795,10 @@ mod test {
         reedline.handle_event(&prompt, ReedlineEvent::Up)?;
         reedline.handle_event(&prompt, ReedlineEvent::Down)?;
         reedline.handle_event(&prompt, move_to_line_start_event.clone())?;
-        assert_eq!(reedline.editor.line_buffer().insertion_point(), second_line_start);
+        assert_eq!(
+            reedline.editor.line_buffer().insertion_point(),
+            second_line_start
+        );
 
         // Enter the string again, then scroll up in history, move to the end of the text,
         // and move to the start of the last line.
@@ -1797,9 +1806,11 @@ mod test {
         reedline.handle_event(&prompt, ReedlineEvent::Up)?;
         reedline.handle_event(&prompt, move_to_end_event)?;
         reedline.handle_event(&prompt, move_to_line_start_event)?;
-        assert_eq!(reedline.editor.line_buffer().insertion_point(), last_line_start);
+        assert_eq!(
+            reedline.editor.line_buffer().insertion_point(),
+            last_line_start
+        );
 
         Ok(())
     }
 }
-


### PR DESCRIPTION
Fixes #582 

Reverts part of #97 -- Normal traversal sets history string at cursor to line buffer. It's not clear to me what that was added in response to.

Added tests covering the problem and the fix in `engine.rs`. The bug occurs in `engine.rs`, so it's not possible to test in `core_editor/line_buffer.rs`, where the other edit command tests are.

Completed the UX checklist the best I could, and ran nushell with the fix for a bit.

## Manual checks

Relevant features tested (leave open if you did not consider those areas touched by your PR):

- [x] core editing and default Emacs keybindings
- [x] history
- [ ] syntax highlighting
- [x] completion/hinting
- [x] vi mode

### Info

Build: [x] debug / [ ] release

Platform:

Terminal emulator:

Inside a [ ] ssh,[ ] tmux or [ ] screen session?

### Basics

- [x] Typing of a short line containing both upper- and lowercase characters.
- [x] Movement left/right using the arrow keys
- [x] Word to the left with `Ctrl-b` or `Ctrl-Left`, Word to the right with `Ctrl-f`
- [x] `Enter` to complete entry

#### Clearing

- [x] Type something and abort the entry with `Ctrl-c`, you should end up on an empty prompt below.
- [x] Type something and press `Ctrl-l` to clear the screen. Your current entry should still be there and passed through when pressing `Enter`

#### Unicode and Emojis

- [x] Paste the line `Emoji test 😊 checks 🤦🏼‍♂️ unicode` and move the cursor over the emojis.
- [x] Are you able to delete the smiley?
- [x] `Home`/`End` at accurate positions
- [x] Check that the emoji containing line can be entered

## History

- [x] On the empty line press the `up-arrow` key to see if you can recall the previous entry
- [x] Press `Enter` to execute this line (it should *not* be duplicated in the history, after checking leave history recall by `down-arrow`)
- [x] On an empty line start typing the beginning of a line in the history. Hit the `up-arrow` to find the matching entry.
- [x] After that run `Ctrl-r` to start traditional reverse search. Type your initial search. Can you find more hits by pressing `Ctrl-r` or `up-arrow`?
- [x] Abort this search by pressing `Ctrl-c`
