### PR TITLE
Update to make work with new lines embedded in sent string.

### DIFF
--- a/examples/external_printer.rs
+++ b/examples/external_printer.rs
@@ -24,7 +24,9 @@ fn main() {
         let mut i = 1;
         loop {
             sleep(Duration::from_secs(1));
-            assert!(p_clone.print(format!("Message {i} delivered.\nWith two lines!")).is_ok());
+            assert!(p_clone
+                .print(format!("Message {i} delivered.\nWith two lines!"))
+                .is_ok());
             i += 1;
         }
     });

--- a/examples/external_printer.rs
+++ b/examples/external_printer.rs
@@ -24,7 +24,7 @@ fn main() {
         let mut i = 1;
         loop {
             sleep(Duration::from_secs(1));
-            assert!(p_clone.print(format!("Message {i} delivered.")).is_ok());
+            assert!(p_clone.print(format!("Message {i} delivered.\nWith two lines!")).is_ok());
             i += 1;
         }
     });

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1669,7 +1669,8 @@ impl Reedline {
             let result = external_printer.receiver().try_recv();
             match result {
                 Ok(line) => {
-                    messages.push(line);
+                    let lines = line.lines().map(String::from).collect::<Vec<_>>();
+                    messages.extend(lines);
                 }
                 Err(TryRecvError::Empty) => {
                     break;


### PR DESCRIPTION
Currently if a sent string doesn't contain \r, it just prints on a new line without the carriage return:
![](https://cdn.discordapp.com/attachments/855886335980994600/1113218318233518231/image.png)

This is the expected output:
![](https://cdn.discordapp.com/attachments/855886335980994600/1113218670072709140/image.png)

This fixes that by always splitting the received line into lines.  The example is updated to demonstrate.