### PR TITLE
Revert removal of patch versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,28 +13,28 @@ version = "0.19.2"
 doctest = true
 
 [dependencies]
-chrono = "0.4"
-clipboard = { version = "0.5", optional = true }
-crossbeam = { version = "0.8", optional = true }
-crossterm = { version = "0.26", features = ["serde"] }
-fd-lock = "3.0"
-itertools = "0.10"
-nu-ansi-term = "0.47"
-rusqlite = { version = "0.29", optional = true }
+chrono = "0.4.19"
+clipboard = { version = "0.5.0", optional = true }
+crossbeam = { version = "0.8.2", optional = true }
+crossterm = { version = "0.26.1", features = ["serde"] }
+fd-lock = "3.0.3"
+itertools = "0.10.3"
+nu-ansi-term = "0.47.0"
+rusqlite = { version = "0.29.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
-strip-ansi-escapes = "0.1"
+serde_json = { version = "1.0.79", optional = true }
+strip-ansi-escapes = "0.1.1"
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0"
-unicode-segmentation = "1.9"
-unicode-width = "0.1"
+thiserror = "1.0.31"
+unicode-segmentation = "1.9.0"
+unicode-width = "0.1.9"
 
 [dev-dependencies]
-gethostname = "0.4"
-pretty_assertions = "1.1"
-rstest = { version = "0.17", default-features = false }
-tempfile = "3.3"
+gethostname = "0.4.0"
+pretty_assertions = "1.1.0"
+rstest = { version = "0.17.0", default-features = false }
+tempfile = "3.3.0"
 
 [features]
 bashisms = []


### PR DESCRIPTION
Reincludes the patch versions that were removed in #586 to ensure
reedline gets built with a version with which we tested reedline at some
point.
