### PR TITLE
add a new disable_bracketed_paste method

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -234,6 +234,15 @@ impl Reedline {
         res
     }
 
+    /// Disable BracketedPaste feature.
+    pub fn disable_bracketed_paste(&mut self) -> Result<()> {
+        let res = execute!(io::stdout(), DisableBracketedPaste);
+        if res.is_ok() {
+            self.bracket_paste_enabled = false;
+        }
+        res
+    }
+
     /// Return the previously generated history session id
     pub fn get_history_session_id(&self) -> Option<HistorySessionId> {
         self.history_session_id

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -440,7 +440,7 @@ pub enum ReedlineEvent {
     /// Mouse
     Mouse, // Fill in details later
 
-    /// trigger termimal resize
+    /// trigger terminal resize
     Resize(u16, u16),
 
     /// Run these commands in the editor


### PR DESCRIPTION
Want to add `disable_bracketed_paste` method for reedline engine, hope it can make nushell works with `bracketed_paste` better.

Relative issue: https://github.com/nushell/nushell/issues/9218
I think paste password inside `gpg` should work fine even when `bracketed_paste` is enabled.

To fix the issue, we can have something like a `DisableBracketedPaste` guard during nushell repl.  But it requires reedline to provide this funciton.