### PR TITLE
always disable bracketed paste after read_line

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -573,8 +573,9 @@ impl Reedline {
 
         let result = self.read_line_helper(prompt);
 
+        #[cfg(not(target_os = "windows"))]
+        self.disable_bracketed_paste()?;
         terminal::disable_raw_mode()?;
-
         result
     }
 


### PR DESCRIPTION
According to @sholderbach 's comment: https://github.com/nushell/nushell/pull/9399#issuecomment-1585692641

It's good to disable bracketed paste in reedline rather than nushell