### PR TITLE
Add Kitty protocol keyboard enhancement support

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -260,15 +260,13 @@ impl Reedline {
     }
 
     /// Enable keyboard enhancement to disambiguate escape code
-    pub fn enable_kitty_protocol(&mut self) -> Result<()> {
+    pub fn enable_kitty_protocol(&mut self) {
         self.use_kitty_protocol = true;
-        Ok(())
     }
 
     /// Disable keyboard enhancement to disambiguate escape code
-    pub fn disable_kitty_protocol(&mut self) -> Result<()> {
+    pub fn disable_kitty_protocol(&mut self) {
         self.use_kitty_protocol = false;
-        Ok(())
     }
 
     /// Return the previously generated history session id

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -140,6 +140,9 @@ pub struct Reedline {
     // Indicate if global terminal have enabled BracketedPaste
     bracket_paste_enabled: bool,
 
+    // Use kitty protocol to handle escape code input or not
+    use_kitty_protocol: bool,
+
     #[cfg(feature = "external_printer")]
     external_printer: Option<ExternalPrinter<String>>,
 }
@@ -164,6 +167,9 @@ impl Drop for Reedline {
         let _ignore = terminal::disable_raw_mode();
         if self.bracket_paste_enabled {
             let _ = execute!(io::stdout(), DisableBracketedPaste);
+        }
+        if self.use_kitty_protocol {
+            let _ = execute!(io::stdout(), event::PopKeyboardEnhancementFlags);
         }
     }
 }
@@ -210,6 +216,7 @@ impl Reedline {
             buffer_editor: None,
             cursor_shapes: None,
             bracket_paste_enabled: false,
+            use_kitty_protocol: false,
             #[cfg(feature = "external_printer")]
             external_printer: None,
         }
@@ -241,6 +248,27 @@ impl Reedline {
             self.bracket_paste_enabled = false;
         }
         res
+    }
+
+    /// Return terminal support on keyboard enhancement
+    pub fn can_use_kitty_protocol(&mut self) -> bool {
+        if let Ok(b) = crossterm::terminal::supports_keyboard_enhancement() {
+            b
+        } else {
+            false
+        }
+    }
+
+    /// Enable keyboard enhancement to disambiguate escape code
+    pub fn enable_kitty_protocol(&mut self) -> Result<()> {
+        self.use_kitty_protocol = true;
+        Ok(())
+    }
+
+    /// Disable keyboard enhancement to disambiguate escape code
+    pub fn disable_kitty_protocol(&mut self) -> Result<()> {
+        self.use_kitty_protocol = false;
+        Ok(())
     }
 
     /// Return the previously generated history session id
@@ -619,6 +647,31 @@ impl Reedline {
 
         let mut crossterm_events: Vec<ReedlineRawEvent> = vec![];
         let mut reedline_events: Vec<ReedlineEvent> = vec![];
+
+        if self.use_kitty_protocol {
+            if let Ok(true) = crossterm::terminal::supports_keyboard_enhancement() {
+                // enable kitty protocol
+                //
+                // Note that, currently, only the following support this protocol:
+                // * [kitty terminal](https://sw.kovidgoyal.net/kitty/)
+                // * [foot terminal](https://codeberg.org/dnkl/foot/issues/319)
+                // * [WezTerm terminal](https://wezfurlong.org/wezterm/config/lua/config/enable_kitty_keyboard.html)
+                // * [notcurses library](https://github.com/dankamongmen/notcurses/issues/2131)
+                // * [neovim text editor](https://github.com/neovim/neovim/pull/18181)
+                // * [kakoune text editor](https://github.com/mawww/kakoune/issues/4103)
+                // * [dte text editor](https://gitlab.com/craigbarnes/dte/-/issues/138)
+                //
+                // Refer to https://sw.kovidgoyal.net/kitty/keyboard-protocol/ if you're curious.
+                let _ = execute!(
+                    io::stdout(),
+                    event::PushKeyboardEnhancementFlags(
+                        event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                    )
+                );
+            } else {
+                // TODO: Log or warning
+            }
+        }
 
         loop {
             let mut paste_enter_state = false;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -168,9 +168,6 @@ impl Drop for Reedline {
         if self.bracket_paste_enabled {
             let _ = execute!(io::stdout(), DisableBracketedPaste);
         }
-        if self.use_kitty_protocol {
-            let _ = execute!(io::stdout(), event::PopKeyboardEnhancementFlags);
-        }
     }
 }
 
@@ -766,6 +763,9 @@ impl Reedline {
             for event in reedline_events.drain(..) {
                 match self.handle_event(prompt, event)? {
                     EventStatus::Exits(signal) => {
+                        if self.use_kitty_protocol {
+                            let _ = execute!(io::stdout(), event::PopKeyboardEnhancementFlags);
+                        }
                         // Move the cursor below the input area, for external commands or new read_line call
                         self.painter.move_cursor_to_end()?;
                         return Ok(signal);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -601,6 +601,11 @@ impl Reedline {
 
         #[cfg(not(target_os = "windows"))]
         self.disable_bracketed_paste()?;
+
+        if self.use_kitty_protocol {
+            let _ = execute!(io::stdout(), event::PopKeyboardEnhancementFlags);
+        }
+
         terminal::disable_raw_mode()?;
         result
     }
@@ -764,9 +769,6 @@ impl Reedline {
             for event in reedline_events.drain(..) {
                 match self.handle_event(prompt, event)? {
                     EventStatus::Exits(signal) => {
-                        if self.use_kitty_protocol {
-                            let _ = execute!(io::stdout(), event::PopKeyboardEnhancementFlags);
-                        }
                         // Move the cursor below the input area, for external commands or new read_line call
                         self.painter.move_cursor_to_end()?;
                         return Ok(signal);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -168,6 +168,9 @@ impl Drop for Reedline {
         if self.bracket_paste_enabled {
             let _ = execute!(io::stdout(), DisableBracketedPaste);
         }
+        if self.use_kitty_protocol {
+            let _ = execute!(io::stdout(), event::PopKeyboardEnhancementFlags);
+        }
     }
 }
 


### PR DESCRIPTION
## Background
Supporting Kitty keyboard enhancement protocol to enable vi action on other keyboard layout (e.g. ctrl+i on Colemak). Without this, ctrl+i will equivalent to Tab and cannot be remapped to anything else.

## Change Summary
Add config `use_kitty_protocol` to determine whether to enable kitty protocol or not. Then if the terminal support this, send the request to enable this terminal feature. Also disable it back when ~the engine dropped~ the event handler finished.