### PR TITLE
Add inapplicable condition on menu activation and navigation

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -967,6 +967,11 @@ impl Reedline {
                             return Ok(EventStatus::Handled);
                         }
 
+                        if menu.get_values().len() == 0 {
+                            menu.menu_event(MenuEvent::Deactivate);
+                            return Ok(EventStatus::Inapplicable);
+                        }
+
                         return Ok(EventStatus::Handled);
                     }
                 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -967,7 +967,7 @@ impl Reedline {
                             return Ok(EventStatus::Handled);
                         }
 
-                        if menu.get_values().len() == 0 {
+                        if menu.get_values().is_empty() {
                             menu.menu_event(MenuEvent::Deactivate);
                             return Ok(EventStatus::Inapplicable);
                         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -980,6 +980,9 @@ impl Reedline {
             ReedlineEvent::MenuNext => {
                 self.active_menu()
                     .map_or(Ok(EventStatus::Inapplicable), |menu| {
+                        if menu.get_values().len() < 2 {
+                            return Ok(EventStatus::Inapplicable);
+                        }
                         menu.menu_event(MenuEvent::NextElement);
                         Ok(EventStatus::Handled)
                     })
@@ -987,6 +990,9 @@ impl Reedline {
             ReedlineEvent::MenuPrevious => {
                 self.active_menu()
                     .map_or(Ok(EventStatus::Inapplicable), |menu| {
+                        if menu.get_values().len() < 2 {
+                            return Ok(EventStatus::Inapplicable);
+                        }
                         menu.menu_event(MenuEvent::PreviousElement);
                         Ok(EventStatus::Handled)
                     })
@@ -994,6 +1000,9 @@ impl Reedline {
             ReedlineEvent::MenuUp => {
                 self.active_menu()
                     .map_or(Ok(EventStatus::Inapplicable), |menu| {
+                        if menu.get_values().len() < 2 {
+                            return Ok(EventStatus::Inapplicable);
+                        }
                         menu.menu_event(MenuEvent::MoveUp);
                         Ok(EventStatus::Handled)
                     })
@@ -1001,6 +1010,9 @@ impl Reedline {
             ReedlineEvent::MenuDown => {
                 self.active_menu()
                     .map_or(Ok(EventStatus::Inapplicable), |menu| {
+                        if menu.get_values().len() < 2 {
+                            return Ok(EventStatus::Inapplicable);
+                        }
                         menu.menu_event(MenuEvent::MoveDown);
                         Ok(EventStatus::Handled)
                     })
@@ -1008,6 +1020,9 @@ impl Reedline {
             ReedlineEvent::MenuLeft => {
                 self.active_menu()
                     .map_or(Ok(EventStatus::Inapplicable), |menu| {
+                        if menu.get_values().len() < 2 {
+                            return Ok(EventStatus::Inapplicable);
+                        }
                         menu.menu_event(MenuEvent::MoveLeft);
                         Ok(EventStatus::Handled)
                     })
@@ -1015,6 +1030,9 @@ impl Reedline {
             ReedlineEvent::MenuRight => {
                 self.active_menu()
                     .map_or(Ok(EventStatus::Inapplicable), |menu| {
+                        if menu.get_values().len() < 2 {
+                            return Ok(EventStatus::Inapplicable);
+                        }
                         menu.menu_event(MenuEvent::MoveRight);
                         Ok(EventStatus::Handled)
                     })

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -967,7 +967,10 @@ impl Reedline {
                             return Ok(EventStatus::Handled);
                         }
 
-                        if menu.get_values().is_empty() {
+                        if self.quick_completions
+                            && menu.can_quick_complete()
+                            && menu.get_values().is_empty()
+                        {
                             menu.menu_event(MenuEvent::Deactivate);
                             return Ok(EventStatus::Inapplicable);
                         }


### PR DESCRIPTION
Allow `until` keybinding with `send: menu*` (activation and navigation) stacked with other action by defining some `Inapplicable` conditions.

Fixes #603.
Fixes #604.