### PR TITLE
Fix a crash when enabling multi-line editing and help menu

### DIFF
--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -161,7 +161,8 @@ impl LineBuffer {
 
     /// Cursor position *in front of* the next unicode grapheme to the left
     pub fn grapheme_left_index(&self) -> usize {
-        self.lines[..self.insertion_point]
+        let index = std::cmp::min(self.insertion_point, self.lines.len());
+        self.lines[..index]
             .grapheme_indices(true)
             .last()
             .map(|(i, _)| i)


### PR DESCRIPTION
This is an attempt to fix a crash when enabling multi-line editing and help menu.

Related #602 nushell/nushell#9627

PS: Can't reproduce nushell/nushell#9627 on linux after this change.

[![asciicast](https://asciinema.org/a/598319.svg)](https://asciinema.org/a/598319)