### PR TITLE
turn off default prompt styling (bold) to prevent leakage

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -256,8 +256,7 @@ impl Painter {
         // print our prompt with color
         if use_ansi_coloring {
             self.stdout
-                .queue(SetForegroundColor(prompt.get_prompt_color()))?
-                .queue(SetAttribute(Attribute::Bold))?;
+                .queue(SetForegroundColor(prompt.get_prompt_color()))?;
         }
 
         self.stdout
@@ -270,22 +269,22 @@ impl Painter {
 
         if use_ansi_coloring {
             self.stdout
-                .queue(SetForegroundColor(prompt.get_indicator_color()))?
-                .queue(SetAttribute(Attribute::Bold))?;
+                .queue(SetForegroundColor(prompt.get_indicator_color()))?;
         }
 
         self.stdout.queue(Print(&coerce_crlf(prompt_indicator)))?;
 
         if use_ansi_coloring {
             self.stdout
-                .queue(SetForegroundColor(prompt.get_prompt_right_color()))?
-                .queue(SetAttribute(Attribute::Bold))?;
+                .queue(SetForegroundColor(prompt.get_prompt_right_color()))?;
         }
 
         self.print_right_prompt(lines)?;
 
         if use_ansi_coloring {
-            self.stdout.queue(ResetColor)?;
+            self.stdout
+                .queue(SetAttribute(Attribute::Reset))?
+                .queue(ResetColor)?;
         }
 
         self.stdout


### PR DESCRIPTION
Before this PR, the bold attribute was hard coded and therefore leaked through. Example:

### Before
![image](https://github.com/nushell/reedline/assets/343840/615ff6ca-8f81-47f7-b3ca-a4c33f3c3a7f)
Notice that the prompt is green bold even though I told it just green. Also, when i draw the prompt with the `do` command, it's drawn right. This is because the `do` command is rendering a buffer and the PROMPT_COMMAND is going through this code in reedline and hard-coding bold everywhere.

### After
![image](https://github.com/nushell/reedline/assets/343840/4d6d1708-ed0e-44da-97a6-2ece548cf271)
Notice that when i tell it green, the prompt is drawn in green and with the `do` command. When I tell it green_bold the prompt is drawn in green_bold as well as with the `do` command.

This is meant to close https://github.com/nushell/nushell/issues/9123 when it's implemented in nushell.