### PR TITLE
update `strip-ansi-escapes` to their latest api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,12 +44,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,9 +779,9 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "strip-ansi-escapes"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+checksum = "dad0ed65755f6fdd06f7afd1afefe7b2b220c2b197844687c2ea9d6d4807305e"
 dependencies = [
  "vte",
 ]
@@ -893,11 +887,10 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vte"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
 dependencies = [
- "arrayvec",
  "utf8parse",
  "vte_generate_state_changes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ nu-ansi-term = "0.49.0"
 rusqlite = { version = "0.29.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true }
-strip-ansi-escapes = "0.1.1"
+strip-ansi-escapes = "0.1.2"
 strum = "0.25"
 strum_macros = "0.25"
 thiserror = "1.0.31"

--- a/src/painting/utils.rs
+++ b/src/painting/utils.rs
@@ -36,9 +36,8 @@ pub(crate) fn coerce_crlf(input: &str) -> Cow<str> {
 ///
 /// If parsing fails silently returns the input string
 pub(crate) fn strip_ansi(string: &str) -> String {
-    strip_ansi_escapes::strip(string)
+    String::from_utf8(strip_ansi_escapes::strip(string))
         .map_err(|_| ())
-        .and_then(|x| String::from_utf8(x).map_err(|_| ()))
         .unwrap_or_else(|_| string.to_owned())
 }
 


### PR DESCRIPTION
This PR updates `strip-ansi-escapes` to their latest api changes. Apparently, `strip_ansi()` cannot fail now?

Closes #616