### PR TITLE
update to strip-ansi-escapes 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,9 +779,9 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "strip-ansi-escapes"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad0ed65755f6fdd06f7afd1afefe7b2b220c2b197844687c2ea9d6d4807305e"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
 dependencies = [
  "vte",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ nu-ansi-term = "0.49.0"
 rusqlite = { version = "0.29.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true }
-strip-ansi-escapes = "0.1.2"
+strip-ansi-escapes = "0.2.0"
 strum = "0.25"
 strum_macros = "0.25"
 thiserror = "1.0.31"


### PR DESCRIPTION
This PR updates strip-ansi-escapes to 0.2.0. Hopefully this will fix these problems once and for all.