### PR TITLE
Let prompts choose to repaint on enter

### DIFF
--- a/examples/custom_prompt.rs
+++ b/examples/custom_prompt.rs
@@ -52,6 +52,10 @@ impl Prompt for CustomPrompt {
             prefix, history_search.term
         ))
     }
+
+    fn repaint_on_enter(&self) -> bool {
+        true
+    }
 }
 
 fn main() -> io::Result<()> {

--- a/examples/custom_prompt.rs
+++ b/examples/custom_prompt.rs
@@ -12,10 +12,13 @@ use std::{borrow::Cow, cell::Cell, io};
 //
 // This example displays the number of keystrokes
 // or rather increments each time the prompt is rendered.
+// It also replaces the prompt for old lines with "!" as an
+// example of a transient prompt.
 #[derive(Clone)]
 pub struct CustomPrompt {
     count: Cell<u32>,
     left_prompt: &'static str,
+    /// Whether to show the transient prompt indicator instead of the normal one
     show_transient: Cell<bool>,
 }
 pub static DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
@@ -71,6 +74,8 @@ impl Prompt for CustomPrompt {
     }
 
     fn repaint_on_enter(&self) -> bool {
+        // This method is called whenever the user hits enter to go to the next
+        // line, so we want it to repaint and display the transient prompt
         self.show_transient.set(true);
         true
     }
@@ -87,6 +92,7 @@ fn main() -> io::Result<()> {
     };
 
     loop {
+        // We're on a new line, so make sure we're showing the normal prompt
         prompt.show_transient.set(false);
         let sig = line_editor.read_line(&prompt)?;
         match sig {

--- a/examples/transient_prompt.rs
+++ b/examples/transient_prompt.rs
@@ -131,7 +131,9 @@ fn main() -> io::Result<()> {
         .with_menu(ReedlineMenu::EngineCompleter(completion_menu))
         .with_edit_mode(edit_mode)
         .with_highlighter(Box::new(ExampleHighlighter::new(commands)))
-        .with_validator(Box::new(CustomValidator {}));
+        .with_validator(Box::new(CustomValidator {}))
+        .with_ansi_colors(true)
+        .with_history_exclusion_prefix(Some(String::from(" ")));
     #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
     {
         line_editor = line_editor.with_history(Box::new(SqliteBackedHistory::in_memory().unwrap()));

--- a/examples/transient_prompt.rs
+++ b/examples/transient_prompt.rs
@@ -1,7 +1,7 @@
-// Create a reedline object with a custom prompt.
-// cargo run --example custom_prompt
+// Create a reedline object with a transient prompt.
+// cargo run --example transient_prompt
 //
-// Pressing keys will increase the right prompt value
+// Prompts for previous lines will be replaced with a shorter prompt
 
 use reedline::{
     Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, Reedline, Signal,
@@ -10,28 +10,37 @@ use std::{borrow::Cow, cell::Cell, io};
 
 // For custom prompt, implement the Prompt trait
 //
-// This example displays the number of keystrokes
-// or rather increments each time the prompt is rendered.
+// This example replaces the prompt for old lines with "!" as an
+// example of a transient prompt.
 #[derive(Clone)]
-pub struct CustomPrompt(Cell<u32>, &'static str);
+pub struct TransientPrompt {
+    /// Whether to show the transient prompt indicator instead of the normal one
+    show_transient: Cell<bool>,
+}
 pub static DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
-impl Prompt for CustomPrompt {
+pub static NORMAL_PROMPT: &str = "(transient_prompt example)";
+pub static TRANSIENT_PROMPT: &str = "!";
+impl Prompt for TransientPrompt {
     fn render_prompt_left(&self) -> Cow<str> {
         {
-            Cow::Owned(self.1.to_string())
+            if self.show_transient.get() {
+                Cow::Owned(String::new())
+            } else {
+                Cow::Borrowed(NORMAL_PROMPT)
+            }
         }
     }
 
     fn render_prompt_right(&self) -> Cow<str> {
-        {
-            let old = self.0.get();
-            self.0.set(old + 1);
-            Cow::Owned(format!("[{old}]"))
-        }
+        Cow::Owned(String::new())
     }
 
     fn render_prompt_indicator(&self, _edit_mode: PromptEditMode) -> Cow<str> {
-        Cow::Owned(">".to_string())
+        if self.show_transient.get() {
+            Cow::Borrowed(TRANSIENT_PROMPT)
+        } else {
+            Cow::Owned(">".to_string())
+        }
     }
 
     fn render_prompt_multiline_indicator(&self) -> Cow<str> {
@@ -52,15 +61,26 @@ impl Prompt for CustomPrompt {
             prefix, history_search.term
         ))
     }
+
+    fn repaint_on_enter(&self) -> bool {
+        // This method is called whenever the user hits enter to go to the next
+        // line, so we want it to repaint and display the transient prompt
+        self.show_transient.set(true);
+        true
+    }
 }
 
 fn main() -> io::Result<()> {
-    println!("Custom prompt demo:\nAbort with Ctrl-C or Ctrl-D");
+    println!("Transient prompt demo:\nAbort with Ctrl-C or Ctrl-D");
     let mut line_editor = Reedline::create();
 
-    let prompt = CustomPrompt(Cell::new(0), "Custom Prompt");
+    let prompt = TransientPrompt {
+        show_transient: Cell::new(false),
+    };
 
     loop {
+        // We're on a new line, so make sure we're showing the normal prompt
+        prompt.show_transient.set(false);
         let sig = line_editor.read_line(&prompt)?;
         match sig {
             Signal::Success(buffer) => {

--- a/examples/transient_prompt.rs
+++ b/examples/transient_prompt.rs
@@ -25,7 +25,8 @@ pub struct TransientPrompt {
 }
 pub static DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
 pub static NORMAL_PROMPT: &str = "(transient_prompt example)";
-pub static TRANSIENT_PROMPT: &str = "!";
+pub static TRANSIENT_PROMPT: &str = "! ";
+pub static TRANSIENT_MULTILINE_INDICATOR: &str = ": ";
 impl Prompt for TransientPrompt {
     fn render_prompt_left(&self) -> Cow<str> {
         {
@@ -50,7 +51,11 @@ impl Prompt for TransientPrompt {
     }
 
     fn render_prompt_multiline_indicator(&self) -> Cow<str> {
-        Cow::Borrowed(DEFAULT_MULTILINE_INDICATOR)
+        if self.show_transient.get() {
+            Cow::Borrowed(TRANSIENT_MULTILINE_INDICATOR)
+        } else {
+            Cow::Borrowed(DEFAULT_MULTILINE_INDICATOR)
+        }
     }
 
     fn render_prompt_history_search_indicator(
@@ -76,15 +81,15 @@ impl Prompt for TransientPrompt {
     }
 }
 
-// To test multiline input. Only goes to the next line if the line ends with a ?
+// To test multiline input. Treats as multiline if input ends with a '\'
 struct CustomValidator;
 
 impl Validator for CustomValidator {
     fn validate(&self, line: &str) -> ValidationResult {
-        if line.ends_with("?") {
-            ValidationResult::Complete
-        } else {
+        if line.ends_with("\\") {
             ValidationResult::Incomplete
+        } else {
+            ValidationResult::Complete
         }
     }
 }

--- a/examples/transient_prompt.rs
+++ b/examples/transient_prompt.rs
@@ -7,8 +7,10 @@ use nu_ansi_term::{Color, Style};
 #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
 use reedline::SqliteBackedHistory;
 use reedline::{
-    ColumnarMenu, DefaultCompleter, DefaultHinter, Prompt, PromptEditMode, PromptHistorySearch,
-    PromptHistorySearchStatus, Reedline, ReedlineMenu, Signal, ExampleHighlighter, default_emacs_keybindings, Keybindings, KeyModifiers, KeyCode, ReedlineEvent, Emacs, Validator, ValidationResult,
+    default_emacs_keybindings, ColumnarMenu, DefaultCompleter, DefaultHinter, Emacs,
+    ExampleHighlighter, KeyCode, KeyModifiers, Keybindings, Prompt, PromptEditMode,
+    PromptHistorySearch, PromptHistorySearchStatus, Reedline, ReedlineEvent, ReedlineMenu, Signal,
+    ValidationResult, Validator,
 };
 use std::{borrow::Cow, cell::Cell, io};
 

--- a/examples/transient_prompt.rs
+++ b/examples/transient_prompt.rs
@@ -3,6 +3,8 @@
 //
 // Prompts for previous lines will be replaced with a shorter prompt
 
+#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+use reedline::SqliteBackedHistory;
 use reedline::{
     Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, Reedline, Signal,
 };
@@ -73,6 +75,10 @@ impl Prompt for TransientPrompt {
 fn main() -> io::Result<()> {
     println!("Transient prompt demo:\nAbort with Ctrl-C or Ctrl-D");
     let mut line_editor = Reedline::create();
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    {
+        line_editor = line_editor.with_history(Box::new(SqliteBackedHistory::in_memory().unwrap()));
+    }
 
     let prompt = TransientPrompt {
         show_transient: Cell::new(false),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -714,7 +714,14 @@ impl Reedline {
                 match self.handle_event(prompt, event)? {
                     EventStatus::Exits(signal) => {
                         if prompt.repaint_on_enter() {
-                            self.repaint(prompt)?;
+                            println!("{:?}", self.editor.line_buffer());
+                            if let Some(id) = self.history_last_run_id {
+                                if let Ok(last) = self.history.load(id) {
+                                    self.editor.edit_buffer(|buf| buf.insert_str(&last.command_line), UndoBehavior::UndoRedo);
+                                    self.repaint(prompt)?;
+                                    self.editor.edit_buffer(|buf| buf.clear(), UndoBehavior::UndoRedo);
+                                }
+                            }
                         }
                         // Move the cursor below the input area, for external commands or new read_line call
                         self.painter.move_cursor_to_end()?;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1712,12 +1712,10 @@ impl Reedline {
         let buffer = self.editor.get_buffer().to_string();
         self.hide_hints = true;
         // Additional repaint to show the content without hints etc.
-        match &mut self.transient_prompt {
-            Some(transient_prompt) => {
-                let prompt = transient_prompt.clone();
-                self.repaint(prompt.as_ref())?
-            }
-            None => self.repaint(prompt)?,
+        if let Some(transient_prompt) = &self.transient_prompt {
+            self.repaint(transient_prompt.clone().as_ref())?
+        } else {
+            self.repaint(prompt)?;
         }
         if !buffer.is_empty() {
             let mut entry = HistoryItem::from_command_line(&buffer);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1700,7 +1700,10 @@ impl Reedline {
         let buffer = self.editor.get_buffer().to_string();
         self.hide_hints = true;
         // Additional repaint to show the content without hints etc.
-        self.repaint(prompt)?;
+        match prompt.get_transient_prompt() {
+            Some(transient_prompt) => self.repaint(transient_prompt.as_ref())?,
+            None => self.repaint(prompt)?
+        }
         if !buffer.is_empty() {
             let mut entry = HistoryItem::from_command_line(&buffer);
             entry.session_id = self.get_history_session_id();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -713,22 +713,6 @@ impl Reedline {
             for event in reedline_events.drain(..) {
                 match self.handle_event(prompt, event)? {
                     EventStatus::Exits(signal) => {
-                        if prompt.repaint_on_enter() {
-                            if let Some(id) = self.history_last_run_id {
-                                if let Ok(last) = self.history.load(id) {
-                                    // Set the line buffer to the last entered line so that we can
-                                    // re-render it with the new prompt
-                                    self.editor.edit_buffer(
-                                        |buf| buf.insert_str(&last.command_line),
-                                        UndoBehavior::UndoRedo,
-                                    );
-                                    self.repaint(prompt)?;
-                                    // Clear the buffer again so that the next line can be typed
-                                    self.editor
-                                        .edit_buffer(|buf| buf.clear(), UndoBehavior::UndoRedo);
-                                }
-                            }
-                        }
                         // Move the cursor below the input area, for external commands or new read_line call
                         self.painter.move_cursor_to_end()?;
                         return Ok(signal);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1713,7 +1713,15 @@ impl Reedline {
         self.hide_hints = true;
         // Additional repaint to show the content without hints etc.
         if let Some(transient_prompt) = &self.transient_prompt {
-            self.repaint(transient_prompt.clone().lock().unwrap().as_ref())?
+            match transient_prompt.clone().lock() {
+                Ok(transient_prompt) => {
+                    self.repaint(transient_prompt.as_ref())?;
+                }
+                Err(_) => {
+                    // TODO log error
+                    self.repaint(prompt)?;
+                }
+            }
         } else {
             self.repaint(prompt)?;
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -716,11 +716,14 @@ impl Reedline {
                         if prompt.repaint_on_enter() {
                             if let Some(id) = self.history_last_run_id {
                                 if let Ok(last) = self.history.load(id) {
+                                    // Set the line buffer to the last entered line so that we can
+                                    // re-render it with the new prompt
                                     self.editor.edit_buffer(
                                         |buf| buf.insert_str(&last.command_line),
                                         UndoBehavior::UndoRedo,
                                     );
                                     self.repaint(prompt)?;
+                                    // Clear the buffer again so that the next line can be typed
                                     self.editor
                                         .edit_buffer(|buf| buf.clear(), UndoBehavior::UndoRedo);
                                 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -713,6 +713,9 @@ impl Reedline {
             for event in reedline_events.drain(..) {
                 match self.handle_event(prompt, event)? {
                     EventStatus::Exits(signal) => {
+                        if prompt.repaint_on_enter() {
+                            self.repaint(prompt)?;
+                        }
                         // Move the cursor below the input area, for external commands or new read_line call
                         self.painter.move_cursor_to_end()?;
                         return Ok(signal);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -716,9 +716,13 @@ impl Reedline {
                         if prompt.repaint_on_enter() {
                             if let Some(id) = self.history_last_run_id {
                                 if let Ok(last) = self.history.load(id) {
-                                    self.editor.edit_buffer(|buf| buf.insert_str(&last.command_line), UndoBehavior::UndoRedo);
+                                    self.editor.edit_buffer(
+                                        |buf| buf.insert_str(&last.command_line),
+                                        UndoBehavior::UndoRedo,
+                                    );
                                     self.repaint(prompt)?;
-                                    self.editor.edit_buffer(|buf| buf.clear(), UndoBehavior::UndoRedo);
+                                    self.editor
+                                        .edit_buffer(|buf| buf.clear(), UndoBehavior::UndoRedo);
                                 }
                             }
                         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -714,7 +714,6 @@ impl Reedline {
                 match self.handle_event(prompt, event)? {
                     EventStatus::Exits(signal) => {
                         if prompt.repaint_on_enter() {
-                            println!("{:?}", self.editor.line_buffer());
                             if let Some(id) = self.history_last_run_id {
                                 if let Ok(last) = self.history.load(id) {
                                     self.editor.edit_buffer(|buf| buf.insert_str(&last.command_line), UndoBehavior::UndoRedo);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1702,7 +1702,7 @@ impl Reedline {
         // Additional repaint to show the content without hints etc.
         match prompt.get_transient_prompt() {
             Some(transient_prompt) => self.repaint(transient_prompt.as_ref())?,
-            None => self.repaint(prompt)?
+            None => self.repaint(prompt)?,
         }
         if !buffer.is_empty() {
             let mut entry = HistoryItem::from_command_line(&buffer);

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -84,23 +84,35 @@ impl Display for PromptEditMode {
 /// Implementors have to provide [`str`]-based content which will be
 /// displayed before the `LineBuffer` is drawn.
 pub trait Prompt: Send {
-    /// Provide content off the right full prompt
+    /// Provide content of the left full prompt
     fn render_prompt_left(&self) -> Cow<str>;
-    /// Provide content off the left full prompt
+    /// Provide content of the left full prompt (after submitting)
+    fn render_prompt_left_post_submit(&self) -> Cow<str> {
+        self.render_prompt_left()
+    }
+    /// Provide content of the right full prompt
     fn render_prompt_right(&self) -> Cow<str>;
+    /// Provide content of the right full prompt (after submitting)
+    fn render_prompt_right_post_submit(&self) -> Cow<str> {
+        self.render_prompt_right()
+    }
     /// Render the prompt indicator (Last part of the prompt that changes based on the editor mode)
     fn render_prompt_indicator(&self, prompt_mode: PromptEditMode) -> Cow<str>;
+    /// Render the prompt indicator (after submitting)
+    fn render_prompt_indicator_post_submit(&self, prompt_mode: PromptEditMode) -> Cow<str> {
+        self.render_prompt_indicator(prompt_mode)
+    }
     /// Indicator to show before explicit new lines
     fn render_prompt_multiline_indicator(&self) -> Cow<str>;
+    /// Indicator to show before explicit new lines (after submitting)
+    fn render_prompt_multiline_indicator_post_submit(&self) -> Cow<str> {
+        self.render_prompt_multiline_indicator()
+    }
     /// Render the prompt indicator for `Ctrl-R` history search
     fn render_prompt_history_search_indicator(
         &self,
         history_search: PromptHistorySearch,
     ) -> Cow<str>;
-    /// Whether to repaint the prompt after the user hits enter (for transient prompts)
-    fn repaint_on_enter(&self) -> bool {
-        false
-    }
     /// Get the default prompt color
     fn get_prompt_color(&self) -> Color {
         DEFAULT_PROMPT_COLOR

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -118,9 +118,4 @@ pub trait Prompt: Send {
     fn right_prompt_on_last_line(&self) -> bool {
         false
     }
-
-    /// Prompt to display after submitting a line
-    fn get_transient_prompt(&self) -> Option<Box<dyn Prompt>> {
-        None
-    }
 }

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -97,6 +97,10 @@ pub trait Prompt: Send {
         &self,
         history_search: PromptHistorySearch,
     ) -> Cow<str>;
+    /// Whether to repaint the prompt after the user hits enter
+    fn repaint_on_enter(&self) -> bool {
+        false
+    }
     /// Get the default prompt color
     fn get_prompt_color(&self) -> Color {
         DEFAULT_PROMPT_COLOR

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -86,28 +86,12 @@ impl Display for PromptEditMode {
 pub trait Prompt: Send {
     /// Provide content of the left full prompt
     fn render_prompt_left(&self) -> Cow<str>;
-    /// Provide content of the left full prompt (after submitting)
-    fn render_prompt_left_post_submit(&self) -> Cow<str> {
-        self.render_prompt_left()
-    }
     /// Provide content of the right full prompt
     fn render_prompt_right(&self) -> Cow<str>;
-    /// Provide content of the right full prompt (after submitting)
-    fn render_prompt_right_post_submit(&self) -> Cow<str> {
-        self.render_prompt_right()
-    }
     /// Render the prompt indicator (Last part of the prompt that changes based on the editor mode)
     fn render_prompt_indicator(&self, prompt_mode: PromptEditMode) -> Cow<str>;
-    /// Render the prompt indicator (after submitting)
-    fn render_prompt_indicator_post_submit(&self, prompt_mode: PromptEditMode) -> Cow<str> {
-        self.render_prompt_indicator(prompt_mode)
-    }
     /// Indicator to show before explicit new lines
     fn render_prompt_multiline_indicator(&self) -> Cow<str>;
-    /// Indicator to show before explicit new lines (after submitting)
-    fn render_prompt_multiline_indicator_post_submit(&self) -> Cow<str> {
-        self.render_prompt_multiline_indicator()
-    }
     /// Render the prompt indicator for `Ctrl-R` history search
     fn render_prompt_history_search_indicator(
         &self,
@@ -133,5 +117,10 @@ pub trait Prompt: Send {
     /// Whether to render right prompt on the last line
     fn right_prompt_on_last_line(&self) -> bool {
         false
+    }
+
+    /// Prompt to display after submitting a line
+    fn get_transient_prompt(&self) -> Option<Box<dyn Prompt>> {
+        None
     }
 }

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -97,7 +97,7 @@ pub trait Prompt: Send {
         &self,
         history_search: PromptHistorySearch,
     ) -> Cow<str>;
-    /// Whether to repaint the prompt after the user hits enter
+    /// Whether to repaint the prompt after the user hits enter (for transient prompts)
     fn repaint_on_enter(&self) -> bool {
         false
     }


### PR DESCRIPTION
This PR goes towards addressing #348. It adds `fn repaint_on_enter(&self) -> bool` to the `Prompt` trait so that a prompt can choose to be repainted on enter. I figured an option could be added to `$env.config` on the Nushell side to enable a transient prompt. After that, the hooks described in [this issue](https://github.com/nushell/nushell/issues/7843) will hopefully start working.