### PR TITLE
Fix `read_line` docs

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -593,9 +593,8 @@ impl Reedline {
 
     /// Wait for input and provide the user with a specified [`Prompt`].
     ///
-    /// Returns a [`crossterm::Result`] in which the `Err` type is [`crossterm::ErrorKind`]
-    /// to distinguish I/O errors and the `Ok` variant wraps a [`Signal`] which
-    /// handles user inputs.
+    /// Returns a [`std::io::Result`] in which the `Err` type is [`std::io::Result`]
+    /// and the `Ok` variant wraps a [`Signal`] which handles user inputs.
     pub fn read_line(&mut self, prompt: &dyn Prompt) -> Result<Signal> {
         terminal::enable_raw_mode()?;
 


### PR DESCRIPTION
The result type is not `crossterm::Result` (anymore), but `std::io::Result`
