### PR TITLE
Accept `Command` with args for `BufferEditor`

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -130,7 +130,7 @@ fn main() -> std::io::Result<()> {
     let temp_file = temp_dir().join("temp_file.nu");
     let mut command = Command::new("vi");
     command.arg(&temp_file);
-    line_editor = line_editor.with_buffer_editor_command(command, temp_file);
+    line_editor = line_editor.with_buffer_editor(command, temp_file);
 
     let prompt = DefaultPrompt::default();
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -13,6 +13,8 @@ use {
     },
     std::io::stdout,
 };
+use std::env::temp_dir;
+use std::process::Command;
 
 use reedline::CursorConfig;
 #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
@@ -125,7 +127,10 @@ fn main() -> std::io::Result<()> {
     line_editor = line_editor.with_edit_mode(edit_mode);
 
     // Adding vi as text editor
-    line_editor = line_editor.with_buffer_editor("vi".into(), "nu".into());
+    let temp_file = temp_dir().join("temp_file.nu");
+    let mut command = Command::new("vi");
+    command.arg(&temp_file);
+    line_editor = line_editor.with_buffer_editor_command(command, temp_file);
 
     let prompt = DefaultPrompt::default();
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,3 +1,5 @@
+use std::env::temp_dir;
+use std::process::Command;
 use {
     crossterm::{
         cursor::SetCursorStyle,
@@ -13,8 +15,6 @@ use {
     },
     std::io::stdout,
 };
-use std::env::temp_dir;
-use std::process::Command;
 
 use reedline::CursorConfig;
 #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -463,7 +463,7 @@ impl Reedline {
     /// command.arg("-p"); // open in a vim tab (just for demonstration)
     /// // you don't have to pass the filename to the command
     /// let mut line_editor =
-    /// Reedline::create().with_buffer_editor("vim".into(), temp_file);
+    /// Reedline::create().with_buffer_editor(command, temp_file);
     /// ```
     #[must_use]
     pub fn with_buffer_editor(mut self, editor: Command, temp_file: PathBuf) -> Self {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -449,10 +449,11 @@ impl Reedline {
     /// use reedline::{DefaultValidator, Reedline};
     /// use std::process::Command;
     /// let mut command = Command::new("vim");
-    /// command.args(vec!["-e"]);
+    /// // Command should contain full arguments including the path of temp_file
+    /// command.args(vec!["-e", "temp.nu"]);
     ///
     /// let mut line_editor =
-    /// Reedline::create().with_buffer_editor_command(command, "nu".into());
+    /// Reedline::create().with_buffer_editor_command(command, "temp.nu".into());
     /// ```
     #[must_use]
     pub fn with_buffer_editor_command(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -456,15 +456,8 @@ impl Reedline {
     /// Reedline::create().with_buffer_editor_command(command, "temp.nu".into());
     /// ```
     #[must_use]
-    pub fn with_buffer_editor_command(
-        mut self,
-        command: Command,
-        temp_file: PathBuf,
-    ) -> Self {
-        self.buffer_editor = Some(BufferEditor {
-            command,
-            temp_file,
-        });
+    pub fn with_buffer_editor_command(mut self, command: Command, temp_file: PathBuf) -> Self {
+        self.buffer_editor = Some(BufferEditor { command, temp_file });
         self
     }
 


### PR DESCRIPTION
Thin pr contains the reedline-side change for  https://github.com/nushell/nushell/pull/10210

`BufferEditor` in current reedline only use a big string to represent editor and it's arguments, which is broken when editor's path contains any spaces. This pr make `BufferEditor` also accept `list<string>` from `$nu.EDITOR` just like `config env`.

(To avoid breaking current version of nushell, this pr add a new api `with_argumented_buffer_editor` instead of directly modify `with_buffer_editor`.)