### PR TITLE
Cut/Yank multiple words

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+
 use std::slice::SliceIndex;
 
 use super::{edit_stack::EditStack, Clipboard, ClipboardMode, LineBuffer};

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -116,6 +116,7 @@ impl Editor {
             EditCommand::CutLeftBefore(c) => self.cut_left_until_char(*c, true, true),
             EditCommand::MoveLeftUntil(c) => self.move_left_until_char(*c, false, true),
             EditCommand::MoveLeftBefore(c) => self.move_left_until_char(*c, true, true),
+            EditCommand::StopCutting => self.last_cut_command = LastCutCommand::BeforeLast,
         }
 
         self.last_cut_command = match self.last_cut_command {

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -285,6 +285,9 @@ mod test {
 
         #[rstest]
         #[case::edit_dw_P(&["^", "dw", "P"])]
+        #[case::edit_db_P(&["db", "P"])]
+        #[case::edit_dW_P(&["^", "dW", "P"])]
+        #[case::edit_dB_P(&["dB", "P"])]
         #[case::edit_3dw_P(&["^", "3dw", "P"])]
         #[case::edit_d3w_P(&["^", "d3w", "P"])]
         #[case::edit_dtz_P(&["^", "dtz", "P"])]
@@ -293,9 +296,14 @@ mod test {
         #[case::edit_dFz_P(&["dFz", "P"])]
         #[case::edit_dw_dw_P(&[
             // duplicate the first word, because dw dw P should drop the first word
-            "^", "dw", "P", "P", "b",
+            "^", "dw", "P", "P", "Fj",
             // run the actual test, and it should put us back where we started.
             "dw", "dw", "P"])]
+        #[case::edit_dW_dW_P(&[
+            // duplicate the first word, because dW dW P should drop the first word
+            "^", "dW", "P", "P", "B",
+            // run the actual test, and it should put us back where we started.
+            "dW", "dW", "P"])]
         #[case::edit_dd_u(&["dd", "u"])]
         // not actually a no-op because it adds a newline, but we .trim_end()
         #[case::edit_dd_p(&["dd", "p"])]
@@ -305,7 +313,7 @@ mod test {
         // UntilFound([MenuUp, Up]) event, and I'm not sure how to handle that.
         #[case::edit_d2d_p(&["d2d", "p"])]
         fn sum_to_zero(#[case] commands: &[&str]) {
-            let initial_input = "the quick brown fox\njumps over the lazy dog";
+            let initial_input = "the quick brown fox\njumps-over the lazy-dog";
             let keybindings = default_vi_normal_keybindings();
             let mut vi = Vi {
                 insert_keybindings: default_vi_insert_keybindings(),
@@ -322,9 +330,11 @@ mod test {
                 let command: Vec<char> = command.chars().collect();
                 let parsed = parse(&mut command.iter().peekable());
                 let commands = unwrap_edits(parsed.to_reedline_event(&mut vi));
-                has_changed |= initial_input != reedline.current_buffer_contents().trim_end();
 
-                reedline.run_edit_commands(&commands)
+                reedline.run_edit_commands(&commands);
+
+                dbg!(command);
+                has_changed |= initial_input != dbg!(reedline.current_buffer_contents().trim_end());
             }
 
             assert_eq!(initial_input, reedline.current_buffer_contents().trim_end());

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -287,6 +287,10 @@ mod test {
         #[case::edit_dw_P(&["^", "dw", "P"])]
         #[case::edit_3dw_P(&["^", "3dw", "P"])]
         #[case::edit_d3w_P(&["^", "d3w", "P"])]
+        #[case::edit_dtz_P(&["^", "dtz", "P"])]
+        #[case::edit_dTz_P(&["dTz", "P"])]
+        #[case::edit_dfz_P(&["^", "dfz", "P"])]
+        #[case::edit_dFz_P(&["dFz", "P"])]
         #[case::edit_dw_dw_P(&[
             // duplicate the first word, because dw dw P should drop the first word
             "^", "dw", "P", "P", "b",
@@ -311,17 +315,23 @@ mod test {
             };
 
             let mut reedline = Reedline::create();
+            let mut has_changed = false;
             reedline.run_edit_commands(&[EditCommand::InsertString(initial_input.into())]);
 
             for command in commands {
                 let command: Vec<char> = command.chars().collect();
                 let parsed = parse(&mut command.iter().peekable());
                 let commands = unwrap_edits(parsed.to_reedline_event(&mut vi));
+                has_changed |= initial_input != reedline.current_buffer_contents().trim_end();
 
                 reedline.run_edit_commands(&commands)
             }
 
             assert_eq!(initial_input, reedline.current_buffer_contents().trim_end());
+            assert!(
+                has_changed,
+                "The sequence of commands should change the input and then restore it"
+            )
         }
     }
 }

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -452,24 +452,52 @@ mod tests {
             ])]))]
     #[case(&['0'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineStart])]))]
     #[case(&['$'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineEnd])]))]
-    #[case(&['i'], ReedlineEvent::Multiple(vec![ReedlineEvent::Repaint]))]
-    #[case(&['p'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter])]))]
+    #[case(&['i'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Repaint,
+        ReedlineEvent::Edit(vec![EditCommand::StopCutting]),
+        ]))]
+    #[case(&['p'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter]),
+        ReedlineEvent::Edit(vec![EditCommand::StopCutting]),
+        ]))]
     #[case(&['2', 'p'], ReedlineEvent::Multiple(vec![
         ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter]),
-        ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter])
+        ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter]),
+        ReedlineEvent::Edit(vec![EditCommand::StopCutting]),
         ]))]
-    #[case(&['u'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::Undo])]))]
+    #[case(&['u'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Edit(vec![EditCommand::Undo]),
+        ReedlineEvent::Edit(vec![EditCommand::StopCutting]),
+        ]))]
     #[case(&['2', 'u'], ReedlineEvent::Multiple(vec![
         ReedlineEvent::Edit(vec![EditCommand::Undo]),
-        ReedlineEvent::Edit(vec![EditCommand::Undo])
+        ReedlineEvent::Edit(vec![EditCommand::Undo]),
+        ReedlineEvent::Edit(vec![EditCommand::StopCutting]),
         ]))]
     #[case(&['d', 'd'], ReedlineEvent::Multiple(vec![
-        ReedlineEvent::Edit(vec![EditCommand::CutCurrentLine])]))]
-    #[case(&['d', 'w'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRightToNext])]))]
-    #[case(&['d', 'W'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutBigWordRightToNext])]))]
-    #[case(&['d', 'e'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRight])]))]
-    #[case(&['d', 'b'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordLeft])]))]
-    #[case(&['d', 'B'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutBigWordLeft])]))]
+        ReedlineEvent::Edit(vec![EditCommand::CutCurrentLine]),
+        ReedlineEvent::Edit(vec![EditCommand::StopCutting]),
+        ]))]
+    #[case(&['d', 'w'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Edit(vec![EditCommand::CutWordRightToNext]),
+        ReedlineEvent::Edit(vec![EditCommand::StopCutting]),
+        ]))]
+    #[case(&['d', 'W'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Edit(vec![EditCommand::CutBigWordRightToNext]),
+        ReedlineEvent::Edit(vec![EditCommand::StopCutting]),
+        ]))]
+    #[case(&['d', 'e'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Edit(vec![EditCommand::CutWordRight]),
+        ReedlineEvent::Edit(vec![EditCommand::StopCutting]),
+        ]))]
+    #[case(&['d', 'b'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Edit(vec![EditCommand::CutWordLeft]),
+        ReedlineEvent::Edit(vec![EditCommand::StopCutting]),
+        ]))]
+    #[case(&['d', 'B'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Edit(vec![EditCommand::CutBigWordLeft]),
+        ReedlineEvent::Edit(vec![EditCommand::StopCutting]),
+        ]))]
     fn test_reedline_move(#[case] input: &[char], #[case] expected: ReedlineEvent) {
         let mut vi = Vi::default();
         let res = vi_parse(input);

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -189,6 +189,9 @@ pub enum EditCommand {
 
     /// CutUntil left before char
     MoveLeftBefore(char),
+
+    /// Stop emacs-style cut buffer growth. Next cut command will make a new cut buffer.
+    StopCutting,
 }
 
 impl Display for EditCommand {
@@ -250,6 +253,7 @@ impl Display for EditCommand {
             EditCommand::CutLeftBefore(_) => write!(f, "CutLeftBefore Value: <char>"),
             EditCommand::MoveLeftUntil(_) => write!(f, "MoveLeftUntil Value: <char>"),
             EditCommand::MoveLeftBefore(_) => write!(f, "MoveLeftBefore Value: <char>"),
+            EditCommand::StopCutting => write!(f, "StopCutting"),
         }
     }
 }
@@ -277,7 +281,8 @@ impl EditCommand {
             | EditCommand::MoveRightUntil(_)
             | EditCommand::MoveRightBefore(_)
             | EditCommand::MoveLeftUntil(_)
-            | EditCommand::MoveLeftBefore(_) => EditType::MoveCursor,
+            | EditCommand::MoveLeftBefore(_)
+            | EditCommand::StopCutting => EditType::MoveCursor,
 
             // Text edits
             EditCommand::InsertChar(_)


### PR DESCRIPTION
Currently, using control-w to cut multiple words leaves only
the most recently cut word in your cut buffer for yanking with
control-y.

This patch makes reedline behave like readline: it restores all
concecutive cuts as a single buffer. This means that typing
`control-w` `control-w` `control-y` gets you back where you started.

Before this is merged, it would be useful to:

- [x] ~make a `trait ClipboardExt` with `fn update(&mut self, content: &str, mode: ClipboardMode, operation: ReplaceOrAppendOrPrepent);` rather than copy-pasting the same 5 lines everywhere~ turns out there's a lot of repeated code to do with cutting, and it was easy enough to DRY out. It also made more sense to keep everything internal to Editor rather than pushing it out into the Clipboard trait.
- [x] write some unit tests
  - ~[ ] it may be possible to write a proptest/fuzz test that generates a random buffer and a random position and a random set of cut commands~
- [x] ~follow UX_TESTING.md to make sure I've not broken anything.~
  - [x] here the behavior in VI mode and probably also what happens when you undo/redo certain operations will be the most critical to me.
  - [ ] I also made a quick stab at a kind-of integration test suite for the vi edit mode keybindings, but I'm not really sure what `UntilFound([MenuUp, Up])` really means (as generated by the k key in vi), so I didn't test multiline editing that well. Feedback welcome, or we can just ship it as-is and improve it later.
- [x] double check whether each of the things should be a prepend or append operation. I only use control-w and control-y in readline, so I don't really know how the other edit commands are supposed to behave.
  - [x] with `1 2 3 4 5 6 7 8 9` in my editor, and the cursor in the middle, C-w followed by C-k or C-u then C-y does the same thing as bash, which is good enough for me. https://www.masteringemacs.org/article/keyboard-shortcuts-every-command-line-hacker-should-know-about-gnu-readline lists a whole bunch more keybindings, but I don't even know how to type meta on macos and I don't have a physical linux box around to test, so I didn't try all keybindings.
- ~[ ] should I actually check what readline's logic is? If I read the source code, does my contribution here become a derived work?~ I decided to treat it as a black box.

~There is a known edge case that if you delete a word and then delete the whole line that you're on, you won't get back where you started, because the line will be appended to the word.~ As far as I can tell, bash's emacs mode doesn't have any whole-line-cutting shortcuts, and vi now sends the StopCutting command, so it is impossible to hit this edge case. If it ever *becomes* a problem in the future then we could change the LastCutCommand state machine to include a ClipboardMode, and reset the cut buffer if ClipboardMode changes from Normal to Lines.

~If we decide that we don't want `control-w` `control-w` `control-y` to get you back where you started, I think the first few commits are probably worth having. I'm happy to clean them up for inclusion first if you prefer.~