### PR TITLE
make Control-w and alt-backspace behave more like bash

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -50,7 +50,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
         KC::Char('y'),
         edit_bind(EC::PasteCutBufferBefore),
     );
-    kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
+    kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutBigWordLeft));
     kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToEnd));
     kb.add_binding(KM::CONTROL, KC::Char('u'), edit_bind(EC::CutFromStart));
     // Edits

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -51,6 +51,11 @@ pub fn default_emacs_keybindings() -> Keybindings {
         edit_bind(EC::PasteCutBufferBefore),
     );
     kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutBigWordLeft));
+    kb.add_binding(
+        KM::CONTROL | KM::ALT,
+        KC::Char('h'),
+        edit_bind(EC::CutWordLeft),
+    );
     kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToEnd));
     kb.add_binding(KM::CONTROL, KC::Char('u'), edit_bind(EC::CutFromStart));
     // Edits

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -193,5 +193,4 @@ pub fn add_common_edit_bindings(kb: &mut Keybindings) {
     kb.add_binding(KM::CONTROL, KC::Delete, edit_bind(EC::DeleteWord));
     // Base commands should not affect cut buffer
     kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
-    kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::BackspaceWord));
 }

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -30,10 +30,15 @@ pub fn default_vi_normal_keybindings() -> Keybindings {
 /// Default Vi insert keybindings
 pub fn default_vi_insert_keybindings() -> Keybindings {
     let mut kb = Keybindings::new();
+    use EditCommand as EC;
+    use KeyCode as KC;
+    use KeyModifiers as KM;
 
     add_common_control_bindings(&mut kb);
     add_common_navigation_bindings(&mut kb);
     add_common_edit_bindings(&mut kb);
+
+    kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::BackspaceWord));
 
     kb
 }


### PR DESCRIPTION
see https://github.com/nushell/nushell/pull/10288 for more context

From the commit messages:
```
    make control-w behave like bash
    
    'man bash' documents this as:
    
           unix-word-rubout (C-w)
                  Kill the word behind point, using white space as a word boundary.
                  The killed text is saved on the kill-ring.
    
    zsh does not have a concept of small/big words, but its 'word' is slightly
    bigger than nushell's small word, because it includes -./_ and a few other
    punctuation marks.
    
    fish's control-w is slightly larger than nushell's small word in that it
    seems to delete up to the next / (and doesn't need an extra control-w to
    delete the '/' 'thing/').

```

```
    make alt+backspace work in vscode by default
    
    On MacOS, vscode generates control-alt-h in response to alt+backspace.
    This is handled in bash as cut-smallword-left and in zsh as cut-word-left
    (zsh doesn't seem to have a concept of small/big words). Fish treats this
    as cut small word left (fish bigwords include anything up to /, and its
    small words stop on any punctuation).
```

As mentioned in my nushell PR, I realise that keybindings are the kind of thing that can cause holy wars, so I'm happy to back out any changes that people dislike.