### PR TITLE
Add a configuration to codecov.io

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 50%
+        threshold: 2%
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: reach, diff, files
+  behavior: default
+  require_base: yes
+  require_head: yes
+  after_n_builds: 5 # Our test matrix currently has 5 configurations

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,8 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 50%
-        threshold: 2%
+        informational: true
     patch:
       default:
         informational: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/reedline)](https://crates.io/crates/reedline)
 [![docs.rs](https://img.shields.io/docsrs/reedline)](https://docs.rs/reedline/)
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/nushell/reedline/ci.yml?branch=main)
+[![codecov](https://codecov.io/gh/nushell/reedline/graph/badge.svg?token=NUTC465WOL)](https://codecov.io/gh/nushell/reedline)
 [![Discord](https://img.shields.io/discord/601130461678272522.svg?logo=discord)](https://discord.gg/NtAbbGn)
 
 ## Introduction


### PR DESCRIPTION
For the file took most of the settings we used for nushell/nushell
Adjusted the warning threshold (not sure how we should set it up in practice, yet)
