### PR TITLE
Split hinter tokens at Unicode word boundaries

### DIFF
--- a/src/hinter/cwd_aware.rs
+++ b/src/hinter/cwd_aware.rs
@@ -1,14 +1,10 @@
 use crate::{
+    hinter::get_first_token,
     history::SearchQuery,
     result::{ReedlineError, ReedlineErrorVariants::HistoryFeatureUnsupported},
     Hinter, History,
 };
 use nu_ansi_term::{Color, Style};
-use unicode_segmentation::UnicodeSegmentation;
-
-pub fn is_whitespace_str(s: &str) -> bool {
-    s.chars().all(char::is_whitespace)
-}
 
 /// A hinter that uses the completions or the history to show a hint to the user
 ///
@@ -68,22 +64,7 @@ impl Hinter for CwdAwareHinter {
     }
 
     fn next_hint_token(&self) -> String {
-        let mut reached_content = false;
-        let result: String = self
-            .current_hint
-            .split_word_bounds()
-            .take_while(|word| match (is_whitespace_str(word), reached_content) {
-                (_, true) => false,
-                (true, false) => true,
-                (false, false) => {
-                    reached_content = true;
-                    true
-                }
-            })
-            .collect::<Vec<&str>>()
-            .join("")
-            .to_string();
-        result
+        get_first_token(&self.current_hint)
     }
 }
 

--- a/src/hinter/cwd_aware.rs
+++ b/src/hinter/cwd_aware.rs
@@ -4,6 +4,11 @@ use crate::{
     Hinter, History,
 };
 use nu_ansi_term::{Color, Style};
+use unicode_segmentation::UnicodeSegmentation;
+
+pub fn is_whitespace_str(s: &str) -> bool {
+    s.chars().all(char::is_whitespace)
+}
 
 /// A hinter that uses the completions or the history to show a hint to the user
 ///
@@ -66,17 +71,18 @@ impl Hinter for CwdAwareHinter {
         let mut reached_content = false;
         let result: String = self
             .current_hint
-            .chars()
-            .take_while(|c| match (c.is_whitespace(), reached_content) {
-                (true, true) => false,
+            .split_word_bounds()
+            .take_while(|word| match (is_whitespace_str(word), reached_content) {
+                (_, true) => false,
                 (true, false) => true,
-                (false, true) => true,
                 (false, false) => {
                     reached_content = true;
                     true
                 }
             })
-            .collect();
+            .collect::<Vec<&str>>()
+            .join("")
+            .to_string();
         result
     }
 }

--- a/src/hinter/default.rs
+++ b/src/hinter/default.rs
@@ -1,5 +1,10 @@
 use crate::{history::SearchQuery, Hinter, History};
 use nu_ansi_term::{Color, Style};
+use unicode_segmentation::UnicodeSegmentation;
+
+pub fn is_whitespace_str(s: &str) -> bool {
+    s.chars().all(char::is_whitespace)
+}
 
 /// A hinter that uses the completions or the history to show a hint to the user
 pub struct DefaultHinter {
@@ -50,17 +55,18 @@ impl Hinter for DefaultHinter {
         let mut reached_content = false;
         let result: String = self
             .current_hint
-            .chars()
-            .take_while(|c| match (c.is_whitespace(), reached_content) {
-                (true, true) => false,
+            .split_word_bounds()
+            .take_while(|word| match (is_whitespace_str(word), reached_content) {
+                (_, true) => false,
                 (true, false) => true,
-                (false, true) => true,
                 (false, false) => {
                     reached_content = true;
                     true
                 }
             })
-            .collect();
+            .collect::<Vec<&str>>()
+            .join("")
+            .to_string();
         result
     }
 }

--- a/src/hinter/default.rs
+++ b/src/hinter/default.rs
@@ -1,10 +1,5 @@
-use crate::{history::SearchQuery, Hinter, History};
+use crate::{hinter::get_first_token, history::SearchQuery, Hinter, History};
 use nu_ansi_term::{Color, Style};
-use unicode_segmentation::UnicodeSegmentation;
-
-pub fn is_whitespace_str(s: &str) -> bool {
-    s.chars().all(char::is_whitespace)
-}
 
 /// A hinter that uses the completions or the history to show a hint to the user
 pub struct DefaultHinter {
@@ -52,22 +47,7 @@ impl Hinter for DefaultHinter {
     }
 
     fn next_hint_token(&self) -> String {
-        let mut reached_content = false;
-        let result: String = self
-            .current_hint
-            .split_word_bounds()
-            .take_while(|word| match (is_whitespace_str(word), reached_content) {
-                (_, true) => false,
-                (true, false) => true,
-                (false, false) => {
-                    reached_content = true;
-                    true
-                }
-            })
-            .collect::<Vec<&str>>()
-            .join("")
-            .to_string();
-        result
+        get_first_token(&self.current_hint)
     }
 }
 

--- a/src/hinter/mod.rs
+++ b/src/hinter/mod.rs
@@ -3,6 +3,30 @@ mod default;
 pub use cwd_aware::CwdAwareHinter;
 pub use default::DefaultHinter;
 
+use unicode_segmentation::UnicodeSegmentation;
+
+pub fn is_whitespace_str(s: &str) -> bool {
+    s.chars().all(char::is_whitespace)
+}
+
+pub fn get_first_token(string: &str) -> String {
+    let mut reached_content = false;
+    let result = string
+        .split_word_bounds()
+        .take_while(|word| match (is_whitespace_str(word), reached_content) {
+            (_, true) => false,
+            (true, false) => true,
+            (false, false) => {
+                reached_content = true;
+                true
+            }
+        })
+        .collect::<Vec<&str>>()
+        .join("")
+        .to_string();
+    result
+}
+
 use crate::History;
 /// A trait that's responsible for returning the hint for the current line and position
 /// Hints are often shown in-line as part of the buffer, showing the user text they can accept or ignore


### PR DESCRIPTION
Partial completion behaves now like usual word movements by C-Left and C-Right.

This is also useful to accept only parts of a suggested path.