### PR TITLE
enable paste buffer to be changed before pasting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -578,6 +578,7 @@ dependencies = [
  "itertools",
  "nu-ansi-term",
  "pretty_assertions",
+ "regex",
  "rstest",
  "rusqlite",
  "serde",
@@ -593,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -605,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -616,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "relative-path"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ crossterm = { version = "0.27.0", features = ["serde"] }
 fd-lock = "3.0.3"
 itertools = "0.10.3"
 nu-ansi-term = "0.49.0"
+regex = "1.10.2"
 rusqlite = { version = "0.29.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true }


### PR DESCRIPTION
This PR is just a thought starter. What would it be like to be able to paste data into reedline and have it manipulate that data?

In this example, I paste some shell script syntax and it's changed to nushell syntax.

### Input from clipboard:
```
ENV_VAR1=var1
export ENV_VAR2=var2
line one \
line two \
line three \
line four
```
### Output in reedline command buffer 
(note the different env var syntax and the line continuation characters are removed)
![image](https://github.com/nushell/reedline/assets/343840/ce71252e-237e-46ac-b21c-c6629fd62924)

I was thinking it would be cool to have some type of hook/callback where in nushell one could provide a custom command/script/module to manipulate data that is pasted. I'm not even sure that it's possible, but like I said, this is a thought starter.

I do not expect this PR to land. Just wanted to use it as an example.