### PR TITLE
Fix panic when history size set to 0

### DIFF
--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -428,9 +428,9 @@ mod test {
         Ok(())
     }
 
+    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
     #[test]
     fn history_size_zero() -> Result<()> {
-        #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
         let mut history = crate::FileBackedHistory::new(0);
         history.save(create_item(1, "/home/me", "cd ~/Downloads", 0))?;
         assert_eq!(history.count_all()?, 0);

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -427,4 +427,17 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn history_size_zero() -> Result<()> {
+        #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+        let mut history = crate::FileBackedHistory::new(0);
+        history.save(create_item(1, "/home/me", "cd ~/Downloads", 0))?;
+        assert_eq!(history.count_all()?, 0);
+        let _ = history.sync();
+        history.clear()?;
+        drop(history);
+
+        Ok(())
+    }
 }

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -60,6 +60,7 @@ impl History for FileBackedHistory {
             .back()
             .map_or(true, |previous| previous != &entry)
             && !entry.is_empty()
+            && self.capacity > 0
         {
             if self.entries.len() == self.capacity {
                 // History is "full", so we delete the oldest entry first,
@@ -234,7 +235,9 @@ impl History for FileBackedHistory {
                     .collect::<std::io::Result<VecDeque<_>>>()?;
                 if from_file.len() + own_entries.len() > self.capacity {
                     (
-                        from_file.split_off(from_file.len() - (self.capacity - own_entries.len())),
+                        from_file.split_off(
+                            from_file.len() - (self.capacity.saturating_sub(own_entries.len())),
+                        ),
                         true,
                     )
                 } else {


### PR DESCRIPTION
As of now, setting `capacity` to 0 causes a panic, defaulting to 1 solves this issue with minimum overhead.

Fixed issue: nushell/nushell#10826