### PR TITLE
Avoid waiting 10ms after normal key events

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -774,12 +774,10 @@ impl Reedline {
                         busy = false;
                         break;
                     }
+                } else if event::poll(Duration::from_millis(0))? {
+                    busy = true;
                 } else {
-                    if event::poll(Duration::from_millis(0))? {
-                        busy = true;
-                    } else {
-                        break;
-                    }
+                    break;
                 }
             }
 


### PR DESCRIPTION
Avoid waiting 10ms after normal key events, so that we process normal key events quickly when they arrive.

To handle pastes and resize bursts, introduce a "busy" state. When we see events immediately ready after an event, assume it's a paste, and enter the "busy" state. Similarly, after a resize, enter the "busy" state. When the paste or resize burst appears to be done, leave the "busy" state and resume processing normal key events quickly. See the comments in the code for more details.

Also, bump `POLL_WAIT` to 100ms. The previous change means we're not waiting for `POLL_WAIT` after normal keyboard input events, so we can afford to make this a little longer, and empirically, 100ms seems to be needed to avoid processing events during a resize burst on my machine.

And, remove the `EVENTS_THRESHOLD`, which now apppears to be redundant.

Fixes #643.