### PR TITLE
re-enable bracketed paste on not(windows) (fixes #9944) (fixes #648)

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -630,9 +630,6 @@ impl Reedline {
 
         let result = self.read_line_helper(prompt);
 
-        #[cfg(not(target_os = "windows"))]
-        self.disable_bracketed_paste()?;
-
         if self.use_kitty_protocol {
             let _ = execute!(io::stdout(), event::PopKeyboardEnhancementFlags);
         }


### PR DESCRIPTION
Due to a supposed issue (https://github.com/nushell/nushell/issues/9218) in nushell regarding commands that read standard input, a fix (https://github.com/nushell/nushell/pull/9399) was proposed that temporarily disables bracketed_paste during the execution of [eval_source](https://github.com/WindSoilder/nushell/blob/cf7040a215fa8d4008844f7fefc2abacc7482546/crates/nu-cli/src/util.rs#L205-L230). 

Instead, this issue was moved over to reedline and a new PR was created (https://github.com/nushell/reedline/pull/598). In this version of the "fix", bracketed_paste is disabled completely after the first execution of reedline. This has led to issue https://github.com/nushell/reedline/issues/648, where multiline paste is now being disabled on non-windows environments.

This PR effectively reverts https://github.com/nushell/reedline/pull/598. This might cause https://github.com/nushell/nushell/issues/9218 to reappear in nushell.

I have personally not been able to reproduce https://github.com/nushell/nushell/issues/9218,  modern versions of gpg use a GUI prompt for the password, or alternatively a curses window. I did try to replicate the issue using GNU readline and other prompting methods but I wasn't succesful.

If https://github.com/nushell/nushell/issues/9218 is a reproducible issue, I think the best course of action is to merge https://github.com/nushell/nushell/pull/9399, which supposedly fixes the issue, but on the nushell side. It seems like this issue might be specific to nushell, and thus it should be fixed in that repository. No need to affect all other reedline dependent packages with it.