### PR TITLE
don't allow certain examples to compile without their features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,11 @@ external_printer = ["crossbeam"]
 sqlite = ["rusqlite/bundled", "serde_json"]
 sqlite-dynlib = ["rusqlite", "serde_json"]
 system_clipboard = ["clipboard"]
+
+[[example]]
+name = "cwd_aware_hinter"
+required-features = ["sqlite"]
+
+[[example]]
+name = "external_printer"
+required-features = ["external_printer"]

--- a/examples/cwd_aware_hinter.rs
+++ b/examples/cwd_aware_hinter.rs
@@ -58,7 +58,7 @@ fn main() -> io::Result<()> {
 
     let mut line_editor = Reedline::create()
         .with_hinter(Box::new(
-            CwdAwareHinter::default().with_style(Style::new().italic().fg(Color::Yellow)),
+            CwdAwareHinter::default().with_style(Style::new().bold().italic().fg(Color::Yellow)),
         ))
         .with_history(history);
 

--- a/examples/external_printer.rs
+++ b/examples/external_printer.rs
@@ -2,7 +2,6 @@
 // to run:
 // cargo run --example external_printer --features=external_printer
 
-#[cfg(feature = "external_printer")]
 use {
     reedline::ExternalPrinter,
     reedline::{DefaultPrompt, Reedline, Signal},
@@ -11,7 +10,6 @@ use {
     std::time::Duration,
 };
 
-#[cfg(feature = "external_printer")]
 fn main() {
     let printer = ExternalPrinter::default();
     // make a clone to use it in a different thread
@@ -58,9 +56,4 @@ fn main() {
         }
         break;
     }
-}
-
-#[cfg(not(feature = "external_printer"))]
-fn main() {
-    println!("Please enable the feature: ‘external_printer‘")
 }


### PR DESCRIPTION
This PR forces examples that need certain features to nag about needing those features and not compile without specifying them.

![image](https://github.com/nushell/reedline/assets/343840/4518f8a9-9ce3-4548-9686-d0fd95897a48)
