### PR TITLE
Make `Result` and `ReedlineError` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ mod engine;
 pub use engine::Reedline;
 
 mod result;
-pub use result::{Result, ReedlineError};
+pub use result::{ReedlineError, Result};
 
 mod history;
 #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ mod engine;
 pub use engine::Reedline;
 
 mod result;
-pub(crate) use result::Result;
+pub use result::{Result, ReedlineError};
 
 mod history;
 #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]

--- a/src/result.rs
+++ b/src/result.rs
@@ -30,5 +30,5 @@ impl Display for ReedlineError {
 }
 impl std::error::Error for ReedlineError {}
 
-// for now don't expose the above error type to the public
+/// Standard [`std::result::Result`], with [`ReedlineError`] as the error variant
 pub type Result<T> = std::result::Result<T, ReedlineError>;


### PR DESCRIPTION
Allows implementing custom `History` types

Closes #545