### PR TITLE
Add more derive impl for HistoryItemId

### DIFF
--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -5,7 +5,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{fmt::Display, time::Duration};
 
 /// Unique ID for the [`HistoryItem`]. More recent items have higher ids than older ones.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HistoryItemId(pub(crate) i64);
 impl HistoryItemId {
     pub(crate) const fn new(i: i64) -> HistoryItemId {


### PR DESCRIPTION
As the item's documentation indicates, the history item's internal ID is auto-incremented.

Which means we can use it to order entries, as well as using it as e.g. an `HashMap`s key.