### PR TITLE
vi mode: map `cw`/`cW` to `ce`/`cE` by default

### DIFF
--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -210,12 +210,10 @@ impl Command {
                         ReedlineOption::Edit(EditCommand::MoveToStart),
                         ReedlineOption::Edit(EditCommand::ClearToLineEnd),
                     ]),
-                    Motion::NextWord => {
-                        Some(vec![ReedlineOption::Edit(EditCommand::CutWordRightToNext)])
+                    Motion::NextWord => Some(vec![ReedlineOption::Edit(EditCommand::CutWordRight)]),
+                    Motion::NextBigWord => {
+                        Some(vec![ReedlineOption::Edit(EditCommand::CutBigWordRight)])
                     }
-                    Motion::NextBigWord => Some(vec![ReedlineOption::Edit(
-                        EditCommand::CutBigWordRightToNext,
-                    )]),
                     Motion::NextWordEnd => {
                         Some(vec![ReedlineOption::Edit(EditCommand::CutWordRight)])
                     }


### PR DESCRIPTION
make `cw`/`cW` delete uptil the next space (like `ce`/`cE`). See [the vim help page on `cw`](https://vimhelp.org/change.txt.html#cw). This behavior is in both `zsh` and `bash`