### PR TITLE
vi mode: Introduce alternate escape sequence for insert mode

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -114,7 +114,11 @@ fn main() -> std::io::Result<()> {
 
         add_newline_keybinding(&mut insert_keybindings);
 
-        Box::new(Vi::new(insert_keybindings, normal_keybindings))
+        Box::new(Vi::new(
+            insert_keybindings,
+            normal_keybindings,
+            (KeyCode::Null, KeyCode::Null),
+        ))
     } else {
         let mut keybindings = default_emacs_keybindings();
         add_menu_keybindings(&mut keybindings);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,12 +166,13 @@
 //! // Create a reedline object with custom edit mode
 //! // This can define a keybinding setting or enable vi-emulation
 //! use reedline::{
-//!     default_vi_insert_keybindings, default_vi_normal_keybindings, EditMode, Reedline, Vi,
+//!     default_vi_insert_keybindings, default_vi_normal_keybindings, EditMode, Reedline, Vi, KeyCode
 //! };
 //!
 //! let mut line_editor = Reedline::create().with_edit_mode(Box::new(Vi::new(
 //!     default_vi_insert_keybindings(),
 //!     default_vi_normal_keybindings(),
+//!     (KeyCode::Null, KeyCode::Null),
 //! )));
 //! ```
 //!


### PR DESCRIPTION
This PR introduces a new argument to the `Vi::new` constructor: the `alternate_esc_seq`. When set to `(KeyCode::Null, KeyCode::Null)`, this does nothing.

`alternate_esc_seq` can be set to something like `(KeyCode::Char('j'), KeyCode::Char('k'))` -- allowing the user to press "jk" (without modifiers) to move from Vi insert mode to Vi normal mode.

I wrote this because I would love to be able to use "jj" to enter normal mode in Nu (like I do for all other similar vi-modes).


(I am very new to Rust, Nu, and Reedline; if something is non-idiomatic, please tell me!)