### PR TITLE
Build docs.rs docs with all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,7 @@ required-features = ["sqlite"]
 [[example]]
 name = "external_printer"
 required-features = ["external_printer"]
+
+[package.metadata.docs.rs]
+# Whether to pass `--all-features` to Cargo (default: false)
+all-features = true


### PR DESCRIPTION
Inspired by https://github.com/nushell/nushell/pull/11180

Make sure you can see all available types/symbols on docs.rs
(e.g. `SqliteBackedHistory`)

In a second step we should take care of annotating feature gated stuff
correctly
