### PR TITLE
Respect termios `ECHO` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.3.3",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +587,7 @@ dependencies = [
  "fd-lock",
  "gethostname",
  "itertools",
+ "nix",
  "nu-ansi-term",
  "pretty_assertions",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ crossbeam = { version = "0.8.2", optional = true }
 crossterm = { version = "0.27.0", features = ["serde"] }
 fd-lock = "3.0.3"
 itertools = "0.10.3"
-nix = { version = "0.27.1", features = ["term"] }
 nu-ansi-term = "0.49.0"
 rusqlite = { version = "0.29.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -30,6 +29,9 @@ strum_macros = "0.25"
 thiserror = "1.0.31"
 unicode-segmentation = "1.9.0"
 unicode-width = "0.1.9"
+
+[target.'cfg(target_family = "unix")'.dependencies]
+nix = { version = "0.27.1", features = ["term"] }
 
 [dev-dependencies]
 gethostname = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crossbeam = { version = "0.8.2", optional = true }
 crossterm = { version = "0.27.0", features = ["serde"] }
 fd-lock = "3.0.3"
 itertools = "0.10.3"
+nix = { version = "0.27.1", features = ["term"] }
 nu-ansi-term = "0.49.0"
 rusqlite = { version = "0.29.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -149,7 +149,14 @@ pub struct Reedline {
     // Manage optional kitty protocol
     kitty_protocol: KittyProtocolGuard,
 
-    // Echo typed input
+    /// Whether to echo typed input
+    ///
+    /// On unix systems, this corresponds to the
+    /// [termios](https://www.man7.org/linux/man-pages/man3/termios.3.html) `ECHO` flag.
+    /// If it is set by the terminal, typed characters will be printed.
+    /// Otherwise, typed characters are not shown.
+    ///
+    /// On non-unix systems this will always remain `true`.
     echo_on: bool,
 
     #[cfg(feature = "external_printer")]


### PR DESCRIPTION
This PR makes it so that the `ECHO` flag given by [termios](https://www.man7.org/linux/man-pages/man3/termios.3.html) is respected. That is, the input characters are not printed/echoed back to the user if the `ECHO` flag is missing. This will help with using `rexpect` to test `reedline` and `nushell`, as the syntax highlighting, etc. does not need to be accounted for.
Related to: https://github.com/nushell/nushell/pull/11178