### PR TITLE
Allow to build HistoryItemId values from the outside

### DIFF
--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -9,6 +9,7 @@ use std::{fmt::Display, time::Duration};
 pub struct HistoryItemId(pub i64);
 
 impl HistoryItemId {
+    /// Create a new `HistoryItemId` value
     pub const fn new(i: i64) -> HistoryItemId {
         HistoryItemId(i)
     }

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -6,9 +6,10 @@ use std::{fmt::Display, time::Duration};
 
 /// Unique ID for the [`HistoryItem`]. More recent items have higher ids than older ones.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct HistoryItemId(pub(crate) i64);
+pub struct HistoryItemId(pub i64);
+
 impl HistoryItemId {
-    pub(crate) const fn new(i: i64) -> HistoryItemId {
+    pub const fn new(i: i64) -> HistoryItemId {
         HistoryItemId(i)
     }
 }


### PR DESCRIPTION
This PR allows to restore `HistoryItemId` values (and so `HistoryItem` as well) from e.g. a custom serialized history.
Required to implement a custom `History`.