### PR TITLE
Bump `itertools` to `0.12.0` from `0.10.x`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ clipboard = { version = "0.5.0", optional = true }
 crossbeam = { version = "0.8.2", optional = true }
 crossterm = { version = "0.27.0", features = ["serde"] }
 fd-lock = "3.0.3"
-itertools = "0.10.3"
+itertools = "0.12.0"
 nu-ansi-term = "0.49.0"
 rusqlite = { version = "0.29.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Most recent version of itertools.
Used by nushell crates.
Several crates in the ecosystem are still working with `0.11.0`
