### PR TITLE
Add ability to select and cut text in the input buffer

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -61,8 +61,8 @@ impl Editor {
             EditCommand::InsertNewline => self.line_buffer.insert_newline(),
             EditCommand::ReplaceChar(chr) => self.replace_char(*chr),
             EditCommand::ReplaceChars(n_chars, str) => self.replace_chars(*n_chars, str),
-            EditCommand::Backspace => self.line_buffer.delete_left_grapheme(),
-            EditCommand::Delete => self.line_buffer.delete_right_grapheme(),
+            EditCommand::Backspace => self.backspace(),
+            EditCommand::Delete => self.delete(),
             EditCommand::CutChar => self.cut_char(),
             EditCommand::BackspaceWord => self.line_buffer.delete_word_left(),
             EditCommand::DeleteWord => self.line_buffer.delete_word_right(),
@@ -564,6 +564,28 @@ impl Editor {
             self.selection_anchor = Some(self.insertion_point());
         }
         self.line_buffer.move_word_right();
+    }
+
+    fn delete_selection(&mut self) {
+        self.line_buffer.clear_range_safe(
+            self.selection_anchor.expect("Deleting a selection only makes sense if we indeed have a selection. Calling without one is probably a bug."), 
+            self.line_buffer.insertion_point());
+    }
+
+    fn backspace(&mut self) {
+        if self.selection_anchor.is_some() {
+            self.delete_selection();
+        } else {
+            self.line_buffer.delete_left_grapheme();
+        }
+    }
+
+    fn delete(&mut self) {
+        if self.selection_anchor.is_some() {
+            self.delete_selection();
+        } else {
+            self.line_buffer.delete_right_grapheme();
+        }
     }
 }
 

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -533,6 +533,18 @@ impl Editor {
     fn reset_selection(&mut self) {
         self.selection_anchor = None;
     }
+
+    /// If a selection is active returns the selected range, otherwise None.
+    /// The range is guaranteed to be ascending.
+    pub fn get_selection(&self) -> Option<(usize, usize)> {
+        self.selection_anchor.map(|selection_anchor| {
+            if self.insertion_point() > selection_anchor {
+                (selection_anchor, self.insertion_point())
+            } else {
+                (self.insertion_point(), selection_anchor)
+            }
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -102,6 +102,8 @@ impl Editor {
             EditCommand::SelectAll => self.select_all(),
             EditCommand::CutSelection => self.cut_selection(),
             EditCommand::CopySelection => self.copy_selection(),
+            EditCommand::SelectMoveWordLeft => self.select_move_word_left(),
+            EditCommand::SelectMoveWordRight => self.select_move_word_right(),
         }
 
         let new_undo_behavior = match (command, command.edit_type()) {
@@ -120,7 +122,11 @@ impl Editor {
         };
         if !matches!(
             command,
-            EditCommand::SelectMoveLeft | EditCommand::SelectMoveRight | EditCommand::SelectAll
+            EditCommand::SelectMoveLeft
+                | EditCommand::SelectMoveRight
+                | EditCommand::SelectMoveWordLeft
+                | EditCommand::SelectMoveWordRight
+                | EditCommand::SelectAll
         ) {
             self.reset_selection();
         }
@@ -544,6 +550,20 @@ impl Editor {
                 (self.insertion_point(), selection_anchor)
             }
         })
+    }
+
+    fn select_move_word_left(&mut self) {
+        if self.selection_anchor.is_none() {
+            self.selection_anchor = Some(self.insertion_point());
+        }
+        self.line_buffer.move_word_left();
+    }
+
+    fn select_move_word_right(&mut self) {
+        if self.selection_anchor.is_none() {
+            self.selection_anchor = Some(self.insertion_point());
+        }
+        self.line_buffer.move_word_right();
     }
 }
 

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -396,6 +396,27 @@ impl LineBuffer {
         self.insertion_point = 0;
     }
 
+    /// Clear all contents between `start` and `end` and change insertion point if necessary.
+    ///
+    /// If the cursor is located between `start` and `end` it is adjusted to `start`.
+    /// If the cursor is located after `end` it is adjusted to stay at its current char boundary.
+    pub fn clear_range_safe(&mut self, start: usize, end: usize) {
+        let (start, end) = if start > end {
+            (end, start)
+        } else {
+            (start, end)
+        };
+        if self.insertion_point <= start {
+            // No action necessary
+        } else if self.insertion_point < end {
+            self.insertion_point = start;
+        } else {
+            // Insertion point after end
+            self.insertion_point -= end - start;
+        }
+        self.clear_range(start..end);
+    }
+
     /// Clear text covered by `range` in the current line
     ///
     /// Safety: Does not change the insertion point/offset and is thus not unicode safe!

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -60,22 +60,30 @@ pub fn default_emacs_keybindings() -> Keybindings {
 
     // *** ALT ***
     // Moves
-    kb.add_binding(KM::ALT, KC::Left, edit_bind(EC::MoveWordLeft));
+    kb.add_binding(
+        KM::ALT,
+        KC::Left,
+        edit_bind(EC::MoveWordLeft { select: false }),
+    );
     kb.add_binding(
         KM::ALT,
         KC::Right,
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::HistoryHintWordComplete,
-            edit_bind(EC::MoveWordRight),
+            edit_bind(EC::MoveWordRight { select: false }),
         ]),
     );
-    kb.add_binding(KM::ALT, KC::Char('b'), edit_bind(EC::MoveWordLeft));
+    kb.add_binding(
+        KM::ALT,
+        KC::Char('b'),
+        edit_bind(EC::MoveWordLeft { select: false }),
+    );
     kb.add_binding(
         KM::ALT,
         KC::Char('f'),
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::HistoryHintWordComplete,
-            edit_bind(EC::MoveWordRight),
+            edit_bind(EC::MoveWordRight { select: false }),
         ]),
     );
     // Edits

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -2,7 +2,7 @@ use crate::{
     edit_mode::{
         keybindings::{
             add_common_control_bindings, add_common_edit_bindings, add_common_navigation_bindings,
-            edit_bind, Keybindings,
+            add_common_selection_bindings, edit_bind, Keybindings,
         },
         EditMode,
     },
@@ -21,6 +21,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
     add_common_control_bindings(&mut kb);
     add_common_navigation_bindings(&mut kb);
     add_common_edit_bindings(&mut kb);
+    add_common_selection_bindings(&mut kb);
 
     // This could be in common, but in Vi it also changes the mode
     kb.add_binding(KM::NONE, KC::Enter, ReedlineEvent::Enter);
@@ -53,6 +54,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
     kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
     kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToEnd));
     kb.add_binding(KM::CONTROL, KC::Char('u'), edit_bind(EC::CutFromStart));
+    kb.add_binding(KM::ALT, KC::Char('d'), edit_bind(EC::CutWordRight));
     // Edits
     kb.add_binding(KM::CONTROL, KC::Char('t'), edit_bind(EC::SwapGraphemes));
 
@@ -84,8 +86,6 @@ pub fn default_emacs_keybindings() -> Keybindings {
         KC::Char('m'),
         ReedlineEvent::Edit(vec![EditCommand::BackspaceWord]),
     );
-    // Cutting
-    kb.add_binding(KM::ALT, KC::Char('d'), edit_bind(EC::CutWordRight));
     // Case changes
     kb.add_binding(KM::ALT, KC::Char('u'), edit_bind(EC::UppercaseWord));
     kb.add_binding(KM::ALT, KC::Char('l'), edit_bind(EC::LowercaseWord));

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -210,5 +210,15 @@ pub fn add_common_selection_bindings(kb: &mut Keybindings) {
 
     kb.add_binding(KM::SHIFT, KC::Left, edit_bind(EC::SelectMoveLeft));
     kb.add_binding(KM::SHIFT, KC::Right, edit_bind(EC::SelectMoveRight));
+    kb.add_binding(
+        KM::SHIFT | KM::CONTROL,
+        KC::Left,
+        edit_bind(EC::SelectMoveWordLeft),
+    );
+    kb.add_binding(
+        KM::SHIFT | KM::CONTROL,
+        KC::Right,
+        edit_bind(EC::SelectMoveWordRight),
+    );
     kb.add_binding(KM::CONTROL, KC::Char('a'), edit_bind(EC::SelectAll));
 }

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -136,24 +136,36 @@ pub fn add_common_navigation_bindings(kb: &mut Keybindings) {
     );
 
     // Ctrl Left and Right
-    kb.add_binding(KM::CONTROL, KC::Left, edit_bind(EC::MoveWordLeft));
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Left,
+        edit_bind(EC::MoveWordLeft { select: false }),
+    );
     kb.add_binding(
         KM::CONTROL,
         KC::Right,
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::HistoryHintWordComplete,
-            edit_bind(EC::MoveWordRight),
+            edit_bind(EC::MoveWordRight { select: false }),
         ]),
     );
     // Home/End & ctrl+a/ctrl+e
-    kb.add_binding(KM::NONE, KC::Home, edit_bind(EC::MoveToLineStart));
-    kb.add_binding(KM::CONTROL, KC::Char('a'), edit_bind(EC::MoveToLineStart));
+    kb.add_binding(
+        KM::NONE,
+        KC::Home,
+        edit_bind(EC::MoveToLineStart { select: false }),
+    );
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Char('a'),
+        edit_bind(EC::MoveToLineStart { select: false }),
+    );
     kb.add_binding(
         KM::NONE,
         KC::End,
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::HistoryHintComplete,
-            edit_bind(EC::MoveToLineEnd),
+            edit_bind(EC::MoveToLineEnd { select: false }),
         ]),
     );
     kb.add_binding(
@@ -161,12 +173,20 @@ pub fn add_common_navigation_bindings(kb: &mut Keybindings) {
         KC::Char('e'),
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::HistoryHintComplete,
-            edit_bind(EC::MoveToLineEnd),
+            edit_bind(EC::MoveToLineEnd { select: false }),
         ]),
     );
     // Ctrl Home/End
-    kb.add_binding(KM::CONTROL, KC::Home, edit_bind(EC::MoveToStart));
-    kb.add_binding(KM::CONTROL, KC::End, edit_bind(EC::MoveToEnd));
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Home,
+        edit_bind(EC::MoveToStart { select: false }),
+    );
+    kb.add_binding(
+        KM::CONTROL,
+        KC::End,
+        edit_bind(EC::MoveToEnd { select: false }),
+    );
     // EMACS arrows
     kb.add_binding(
         KM::CONTROL,
@@ -208,17 +228,45 @@ pub fn add_common_selection_bindings(kb: &mut Keybindings) {
     use KeyCode as KC;
     use KeyModifiers as KM;
 
-    kb.add_binding(KM::SHIFT, KC::Left, edit_bind(EC::SelectMoveLeft));
-    kb.add_binding(KM::SHIFT, KC::Right, edit_bind(EC::SelectMoveRight));
+    kb.add_binding(
+        KM::SHIFT,
+        KC::Left,
+        edit_bind(EC::MoveLeft { select: true }),
+    );
+    kb.add_binding(
+        KM::SHIFT,
+        KC::Right,
+        edit_bind(EC::MoveRight { select: true }),
+    );
     kb.add_binding(
         KM::SHIFT | KM::CONTROL,
         KC::Left,
-        edit_bind(EC::SelectMoveWordLeft),
+        edit_bind(EC::MoveWordLeft { select: true }),
     );
     kb.add_binding(
         KM::SHIFT | KM::CONTROL,
         KC::Right,
-        edit_bind(EC::SelectMoveWordRight),
+        edit_bind(EC::MoveWordRight { select: true }),
+    );
+    kb.add_binding(
+        KM::SHIFT,
+        KC::End,
+        edit_bind(EC::MoveToLineEnd { select: true }),
+    );
+    kb.add_binding(
+        KM::SHIFT | KM::CONTROL,
+        KC::End,
+        edit_bind(EC::MoveToEnd { select: true }),
+    );
+    kb.add_binding(
+        KM::SHIFT,
+        KC::Home,
+        edit_bind(EC::MoveToLineStart { select: true }),
+    );
+    kb.add_binding(
+        KM::SHIFT | KM::CONTROL,
+        KC::Home,
+        edit_bind(EC::MoveToStart { select: true }),
     );
     kb.add_binding(KM::CONTROL, KC::Char('a'), edit_bind(EC::SelectAll));
 }

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -194,4 +194,21 @@ pub fn add_common_edit_bindings(kb: &mut Keybindings) {
     // Base commands should not affect cut buffer
     kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
     kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::BackspaceWord));
+    kb.add_binding(KM::CONTROL, KC::Char('x'), edit_bind(EC::CutSelection));
+    kb.add_binding(KM::CONTROL, KC::Char('c'), edit_bind(EC::CopySelection));
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Char('v'),
+        edit_bind(EC::PasteCutBufferBefore),
+    );
+}
+
+pub fn add_common_selection_bindings(kb: &mut Keybindings) {
+    use EditCommand as EC;
+    use KeyCode as KC;
+    use KeyModifiers as KM;
+
+    kb.add_binding(KM::SHIFT, KC::Left, edit_bind(EC::SelectMoveLeft));
+    kb.add_binding(KM::SHIFT, KC::Right, edit_bind(EC::SelectMoveRight));
+    kb.add_binding(KM::CONTROL, KC::Char('a'), edit_bind(EC::SelectAll));
 }

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -125,14 +125,20 @@ impl Command {
     pub fn to_reedline(&self, vi_state: &mut Vi) -> Vec<ReedlineOption> {
         match self {
             Self::EnterViInsert => vec![ReedlineOption::Event(ReedlineEvent::Repaint)],
-            Self::EnterViAppend => vec![ReedlineOption::Edit(EditCommand::MoveRight)],
+            Self::EnterViAppend => vec![ReedlineOption::Edit(EditCommand::MoveRight {
+                select: false,
+            })],
             Self::PasteAfter => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferAfter)],
             Self::PasteBefore => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferBefore)],
             Self::Undo => vec![ReedlineOption::Edit(EditCommand::Undo)],
             Self::ChangeToLineEnd => vec![ReedlineOption::Edit(EditCommand::ClearToLineEnd)],
             Self::DeleteToEnd => vec![ReedlineOption::Edit(EditCommand::CutToLineEnd)],
-            Self::AppendToEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
-            Self::PrependToStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],
+            Self::AppendToEnd => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd {
+                select: false,
+            })],
+            Self::PrependToStart => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart {
+                select: false,
+            })],
             Self::RewriteCurrentLine => vec![ReedlineOption::Edit(EditCommand::CutCurrentLine)],
             Self::DeleteChar => vec![ReedlineOption::Edit(EditCommand::CutChar)],
             Self::ReplaceChar(c) => {
@@ -207,7 +213,7 @@ impl Command {
                 let op = match motion {
                     Motion::End => Some(vec![ReedlineOption::Edit(EditCommand::ClearToLineEnd)]),
                     Motion::Line => Some(vec![
-                        ReedlineOption::Edit(EditCommand::MoveToStart),
+                        ReedlineOption::Edit(EditCommand::MoveToStart { select: false }),
                         ReedlineOption::Edit(EditCommand::ClearToLineEnd),
                     ]),
                     Motion::NextWord => Some(vec![ReedlineOption::Edit(EditCommand::CutWordRight)]),

--- a/src/edit_mode/vi/motion.rs
+++ b/src/edit_mode/vi/motion.rs
@@ -160,30 +160,60 @@ impl Motion {
                 ReedlineEvent::MenuDown,
                 ReedlineEvent::Down,
             ]))],
-            Motion::NextWord => vec![ReedlineOption::Edit(EditCommand::MoveWordRightStart)],
-            Motion::NextBigWord => vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightStart)],
-            Motion::NextWordEnd => vec![ReedlineOption::Edit(EditCommand::MoveWordRightEnd)],
-            Motion::NextBigWordEnd => vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightEnd)],
-            Motion::PreviousWord => vec![ReedlineOption::Edit(EditCommand::MoveWordLeft)],
-            Motion::PreviousBigWord => vec![ReedlineOption::Edit(EditCommand::MoveBigWordLeft)],
+            Motion::NextWord => vec![ReedlineOption::Edit(EditCommand::MoveWordRightStart {
+                select: false,
+            })],
+            Motion::NextBigWord => vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightStart {
+                select: false,
+            })],
+            Motion::NextWordEnd => vec![ReedlineOption::Edit(EditCommand::MoveWordRightEnd {
+                select: false,
+            })],
+            Motion::NextBigWordEnd => {
+                vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightEnd {
+                    select: false,
+                })]
+            }
+            Motion::PreviousWord => vec![ReedlineOption::Edit(EditCommand::MoveWordLeft {
+                select: false,
+            })],
+            Motion::PreviousBigWord => vec![ReedlineOption::Edit(EditCommand::MoveBigWordLeft {
+                select: false,
+            })],
             Motion::Line => vec![], // Placeholder as unusable standalone motion
-            Motion::Start => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart)],
-            Motion::End => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd)],
+            Motion::Start => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart {
+                select: false,
+            })],
+            Motion::End => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd {
+                select: false,
+            })],
             Motion::RightUntil(ch) => {
                 vi_state.last_char_search = Some(ViCharSearch::ToRight(*ch));
-                vec![ReedlineOption::Edit(EditCommand::MoveRightUntil(*ch))]
+                vec![ReedlineOption::Edit(EditCommand::MoveRightUntil {
+                    c: *ch,
+                    select: false,
+                })]
             }
             Motion::RightBefore(ch) => {
                 vi_state.last_char_search = Some(ViCharSearch::TillRight(*ch));
-                vec![ReedlineOption::Edit(EditCommand::MoveRightBefore(*ch))]
+                vec![ReedlineOption::Edit(EditCommand::MoveRightBefore {
+                    c: *ch,
+                    select: false,
+                })]
             }
             Motion::LeftUntil(ch) => {
                 vi_state.last_char_search = Some(ViCharSearch::ToLeft(*ch));
-                vec![ReedlineOption::Edit(EditCommand::MoveLeftUntil(*ch))]
+                vec![ReedlineOption::Edit(EditCommand::MoveLeftUntil {
+                    c: *ch,
+                    select: false,
+                })]
             }
             Motion::LeftBefore(ch) => {
                 vi_state.last_char_search = Some(ViCharSearch::TillLeft(*ch));
-                vec![ReedlineOption::Edit(EditCommand::MoveLeftBefore(*ch))]
+                vec![ReedlineOption::Edit(EditCommand::MoveLeftBefore {
+                    c: *ch,
+                    select: false,
+                })]
             }
             Motion::ReplayCharSearch => {
                 if let Some(char_search) = vi_state.last_char_search.as_ref() {
@@ -229,10 +259,22 @@ impl ViCharSearch {
 
     pub fn to_move(&self) -> EditCommand {
         match self {
-            ViCharSearch::ToRight(c) => EditCommand::MoveRightUntil(*c),
-            ViCharSearch::ToLeft(c) => EditCommand::MoveLeftUntil(*c),
-            ViCharSearch::TillRight(c) => EditCommand::MoveRightBefore(*c),
-            ViCharSearch::TillLeft(c) => EditCommand::MoveLeftBefore(*c),
+            ViCharSearch::ToRight(c) => EditCommand::MoveRightUntil {
+                c: *c,
+                select: false,
+            },
+            ViCharSearch::ToLeft(c) => EditCommand::MoveLeftUntil {
+                c: *c,
+                select: false,
+            },
+            ViCharSearch::TillRight(c) => EditCommand::MoveRightBefore {
+                c: *c,
+                select: false,
+            },
+            ViCharSearch::TillLeft(c) => EditCommand::MoveLeftBefore {
+                c: *c,
+                select: false,
+            },
         }
     }
 

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -418,9 +418,9 @@ mod tests {
                 ReedlineEvent::Up,
             ])]))]
     #[case(&['w'],
-        ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveWordRightStart])]))]
+        ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveWordRightStart{select:false}])]))]
     #[case(&['W'],
-        ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveBigWordRightStart])]))]
+        ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveBigWordRightStart{select:false}])]))]
     #[case(&['2', 'l'], ReedlineEvent::Multiple(vec![
         ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::HistoryHintComplete,
@@ -436,8 +436,8 @@ mod tests {
                 ReedlineEvent::MenuRight,
                 ReedlineEvent::Right,
             ])]))]
-    #[case(&['0'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineStart])]))]
-    #[case(&['$'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineEnd])]))]
+    #[case(&['0'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineStart{select:false}])]))]
+    #[case(&['$'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineEnd{select:false}])]))]
     #[case(&['i'], ReedlineEvent::Multiple(vec![ReedlineEvent::Repaint]))]
     #[case(&['p'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter])]))]
     #[case(&['2', 'p'], ReedlineEvent::Multiple(vec![

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -22,7 +22,11 @@ pub fn default_vi_normal_keybindings() -> Keybindings {
     add_common_navigation_bindings(&mut kb);
     add_common_selection_bindings(&mut kb);
     // Replicate vi's default behavior for Backspace and delete
-    kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::MoveLeft));
+    kb.add_binding(
+        KM::NONE,
+        KC::Backspace,
+        edit_bind(EC::MoveLeft { select: false }),
+    );
     kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
 
     kb

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -4,7 +4,7 @@ use crate::{
     edit_mode::{
         keybindings::{
             add_common_control_bindings, add_common_edit_bindings, add_common_navigation_bindings,
-            edit_bind,
+            add_common_selection_bindings, edit_bind,
         },
         Keybindings,
     },
@@ -20,6 +20,7 @@ pub fn default_vi_normal_keybindings() -> Keybindings {
 
     add_common_control_bindings(&mut kb);
     add_common_navigation_bindings(&mut kb);
+    add_common_selection_bindings(&mut kb);
     // Replicate vi's default behavior for Backspace and delete
     kb.add_binding(KM::NONE, KC::Backspace, edit_bind(EC::MoveLeft));
     kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
@@ -34,6 +35,7 @@ pub fn default_vi_insert_keybindings() -> Keybindings {
     add_common_control_bindings(&mut kb);
     add_common_navigation_bindings(&mut kb);
     add_common_edit_bindings(&mut kb);
+    add_common_selection_bindings(&mut kb);
 
     kb
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -267,20 +267,44 @@ pub enum EditCommand {
 impl Display for EditCommand {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            EditCommand::MoveToStart { .. } => write!(f, "MoveToStart"),
-            EditCommand::MoveToLineStart { .. } => write!(f, "MoveToLineStart"),
-            EditCommand::MoveToEnd { .. } => write!(f, "MoveToEnd"),
-            EditCommand::MoveToLineEnd { .. } => write!(f, "MoveToLineEnd"),
-            EditCommand::MoveLeft { .. } => write!(f, "MoveLeft"),
-            EditCommand::MoveRight { .. } => write!(f, "MoveRight"),
-            EditCommand::MoveWordLeft { .. } => write!(f, "MoveWordLeft"),
-            EditCommand::MoveBigWordLeft { .. } => write!(f, "MoveBigWordLeft"),
-            EditCommand::MoveWordRight { .. } => write!(f, "MoveWordRight"),
-            EditCommand::MoveWordRightEnd { .. } => write!(f, "MoveWordRightEnd"),
-            EditCommand::MoveBigWordRightEnd { .. } => write!(f, "MoveBigWordRightEnd"),
-            EditCommand::MoveWordRightStart { .. } => write!(f, "MoveWordRightStart"),
-            EditCommand::MoveBigWordRightStart { .. } => write!(f, "MoveBigWordRightStart"),
-            EditCommand::MoveToPosition { .. } => write!(f, "MoveToPosition  Value: <int>"),
+            EditCommand::MoveToStart { .. } => write!(f, "MoveToStart Optional[select: <bool>]"),
+            EditCommand::MoveToLineStart { .. } => {
+                write!(f, "MoveToLineStart Optional[select: <bool>]")
+            }
+            EditCommand::MoveToEnd { .. } => write!(f, "MoveToEnd Optional[select: <bool>]"),
+            EditCommand::MoveToLineEnd { .. } => {
+                write!(f, "MoveToLineEnd Optional[select: <bool>]")
+            }
+            EditCommand::MoveLeft { .. } => write!(f, "MoveLeft Optional[select: <bool>]"),
+            EditCommand::MoveRight { .. } => write!(f, "MoveRight Optional[select: <bool>]"),
+            EditCommand::MoveWordLeft { .. } => write!(f, "MoveWordLeft Optional[select: <bool>]"),
+            EditCommand::MoveBigWordLeft { .. } => {
+                write!(f, "MoveBigWordLeft Optional[select: <bool>]")
+            }
+            EditCommand::MoveWordRight { .. } => {
+                write!(f, "MoveWordRight Optional[select: <bool>]")
+            }
+            EditCommand::MoveWordRightEnd { .. } => {
+                write!(f, "MoveWordRightEnd Optional[select: <bool>]")
+            }
+            EditCommand::MoveBigWordRightEnd { .. } => {
+                write!(f, "MoveBigWordRightEnd Optional[select: <bool>]")
+            }
+            EditCommand::MoveWordRightStart { .. } => {
+                write!(f, "MoveWordRightStart Optional[select: <bool>]")
+            }
+            EditCommand::MoveBigWordRightStart { .. } => {
+                write!(f, "MoveBigWordRightStart Optional[select: <bool>]")
+            }
+            EditCommand::MoveToPosition { .. } => {
+                write!(f, "MoveToPosition  Value: <int>, Optional[select: <bool>]")
+            }
+            EditCommand::MoveLeftUntil { .. } => {
+                write!(f, "MoveLeftUntil Value: <char>, Optional[select: <bool>]")
+            }
+            EditCommand::MoveLeftBefore { .. } => {
+                write!(f, "MoveLeftBefore Value: <char>, Optional[select: <bool>]")
+            }
             EditCommand::InsertChar(_) => write!(f, "InsertChar  Value: <char>"),
             EditCommand::InsertString(_) => write!(f, "InsertString Value: <string>"),
             EditCommand::InsertNewline => write!(f, "InsertNewline"),
@@ -321,8 +345,6 @@ impl Display for EditCommand {
             EditCommand::MoveRightBefore { .. } => write!(f, "MoveRightBefore Value: <char>"),
             EditCommand::CutLeftUntil(_) => write!(f, "CutLeftUntil Value: <char>"),
             EditCommand::CutLeftBefore(_) => write!(f, "CutLeftBefore Value: <char>"),
-            EditCommand::MoveLeftUntil { .. } => write!(f, "MoveLeftUntil Value: <char>"),
-            EditCommand::MoveLeftBefore { .. } => write!(f, "MoveLeftBefore Value: <char>"),
             EditCommand::SelectAll => write!(f, "SelectAll"),
             EditCommand::CutSelection => write!(f, "CutSelection"),
             EditCommand::CopySelection => write!(f, "CopySelection"),

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -20,46 +20,90 @@ pub enum Signal {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, EnumIter)]
 pub enum EditCommand {
     /// Move to the start of the buffer
-    MoveToStart,
+    MoveToStart {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move to the start of the current line
-    MoveToLineStart,
+    MoveToLineStart {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move to the end of the buffer
-    MoveToEnd,
+    MoveToEnd {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move to the end of the current line
-    MoveToLineEnd,
+    MoveToLineEnd {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move one character to the left
-    MoveLeft,
+    MoveLeft {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move one character to the right
-    MoveRight,
+    MoveRight {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move one word to the left
-    MoveWordLeft,
+    MoveWordLeft {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move one WORD to the left
-    MoveBigWordLeft,
+    MoveBigWordLeft {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move one word to the right
-    MoveWordRight,
+    MoveWordRight {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move one word to the right, stop at start of word
-    MoveWordRightStart,
+    MoveWordRightStart {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move one WORD to the right, stop at start of WORD
-    MoveBigWordRightStart,
+    MoveBigWordRightStart {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move one word to the right, stop at end of word
-    MoveWordRightEnd,
+    MoveWordRightEnd {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move one WORD to the right, stop at end of WORD
-    MoveBigWordRightEnd,
+    MoveBigWordRightEnd {
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Move to position
-    MoveToPosition(usize),
+    MoveToPosition {
+        /// Position to move to
+        position: usize,
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Insert a character at the current insertion point
     InsertChar(char),
@@ -173,10 +217,20 @@ pub enum EditCommand {
     CutRightBefore(char),
 
     /// CutUntil right until char
-    MoveRightUntil(char),
+    MoveRightUntil {
+        /// Char to move towards
+        c: char,
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// CutUntil right before char
-    MoveRightBefore(char),
+    MoveRightBefore {
+        /// Char to move towards
+        c: char,
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// CutUntil left until char
     CutLeftUntil(char),
@@ -184,23 +238,21 @@ pub enum EditCommand {
     /// CutUntil left before char
     CutLeftBefore(char),
 
-    /// CutUntil left until char
-    MoveLeftUntil(char),
+    /// Move left until char
+    MoveLeftUntil {
+        /// Char to move towards
+        c: char,
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
-    /// CutUntil left before char
-    MoveLeftBefore(char),
-
-    /// Select and move left
-    SelectMoveLeft,
-
-    /// Select and move right
-    SelectMoveRight,
-
-    /// Select and move whole word left
-    SelectMoveWordLeft,
-
-    /// Select and move whole word right
-    SelectMoveWordRight,
+    /// Move left before char
+    MoveLeftBefore {
+        /// Char to move towards
+        c: char,
+        /// Select the text between the current cursor position and destination
+        select: bool,
+    },
 
     /// Select whole input buffer
     SelectAll,
@@ -215,20 +267,20 @@ pub enum EditCommand {
 impl Display for EditCommand {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            EditCommand::MoveToStart => write!(f, "MoveToStart"),
-            EditCommand::MoveToLineStart => write!(f, "MoveToLineStart"),
-            EditCommand::MoveToEnd => write!(f, "MoveToEnd"),
-            EditCommand::MoveToLineEnd => write!(f, "MoveToLineEnd"),
-            EditCommand::MoveLeft => write!(f, "MoveLeft"),
-            EditCommand::MoveRight => write!(f, "MoveRight"),
-            EditCommand::MoveWordLeft => write!(f, "MoveWordLeft"),
-            EditCommand::MoveBigWordLeft => write!(f, "MoveBigWordLeft"),
-            EditCommand::MoveWordRight => write!(f, "MoveWordRight"),
-            EditCommand::MoveWordRightEnd => write!(f, "MoveWordRightEnd"),
-            EditCommand::MoveBigWordRightEnd => write!(f, "MoveBigWordRightEnd"),
-            EditCommand::MoveWordRightStart => write!(f, "MoveWordRightStart"),
-            EditCommand::MoveBigWordRightStart => write!(f, "MoveBigWordRightStart"),
-            EditCommand::MoveToPosition(_) => write!(f, "MoveToPosition  Value: <int>"),
+            EditCommand::MoveToStart { .. } => write!(f, "MoveToStart"),
+            EditCommand::MoveToLineStart { .. } => write!(f, "MoveToLineStart"),
+            EditCommand::MoveToEnd { .. } => write!(f, "MoveToEnd"),
+            EditCommand::MoveToLineEnd { .. } => write!(f, "MoveToLineEnd"),
+            EditCommand::MoveLeft { .. } => write!(f, "MoveLeft"),
+            EditCommand::MoveRight { .. } => write!(f, "MoveRight"),
+            EditCommand::MoveWordLeft { .. } => write!(f, "MoveWordLeft"),
+            EditCommand::MoveBigWordLeft { .. } => write!(f, "MoveBigWordLeft"),
+            EditCommand::MoveWordRight { .. } => write!(f, "MoveWordRight"),
+            EditCommand::MoveWordRightEnd { .. } => write!(f, "MoveWordRightEnd"),
+            EditCommand::MoveBigWordRightEnd { .. } => write!(f, "MoveBigWordRightEnd"),
+            EditCommand::MoveWordRightStart { .. } => write!(f, "MoveWordRightStart"),
+            EditCommand::MoveBigWordRightStart { .. } => write!(f, "MoveBigWordRightStart"),
+            EditCommand::MoveToPosition { .. } => write!(f, "MoveToPosition  Value: <int>"),
             EditCommand::InsertChar(_) => write!(f, "InsertChar  Value: <char>"),
             EditCommand::InsertString(_) => write!(f, "InsertString Value: <string>"),
             EditCommand::InsertNewline => write!(f, "InsertNewline"),
@@ -265,19 +317,15 @@ impl Display for EditCommand {
             EditCommand::Redo => write!(f, "Redo"),
             EditCommand::CutRightUntil(_) => write!(f, "CutRightUntil Value: <char>"),
             EditCommand::CutRightBefore(_) => write!(f, "CutRightBefore Value: <char>"),
-            EditCommand::MoveRightUntil(_) => write!(f, "MoveRightUntil Value: <char>"),
-            EditCommand::MoveRightBefore(_) => write!(f, "MoveRightBefore Value: <char>"),
+            EditCommand::MoveRightUntil { .. } => write!(f, "MoveRightUntil Value: <char>"),
+            EditCommand::MoveRightBefore { .. } => write!(f, "MoveRightBefore Value: <char>"),
             EditCommand::CutLeftUntil(_) => write!(f, "CutLeftUntil Value: <char>"),
             EditCommand::CutLeftBefore(_) => write!(f, "CutLeftBefore Value: <char>"),
-            EditCommand::MoveLeftUntil(_) => write!(f, "MoveLeftUntil Value: <char>"),
-            EditCommand::MoveLeftBefore(_) => write!(f, "MoveLeftBefore Value: <char>"),
-            EditCommand::SelectMoveLeft => write!(f, "SelectMoveLeft"),
-            EditCommand::SelectMoveRight => write!(f, "SelectMoveRight"),
+            EditCommand::MoveLeftUntil { .. } => write!(f, "MoveLeftUntil Value: <char>"),
+            EditCommand::MoveLeftBefore { .. } => write!(f, "MoveLeftBefore Value: <char>"),
             EditCommand::SelectAll => write!(f, "SelectAll"),
             EditCommand::CutSelection => write!(f, "CutSelection"),
             EditCommand::CopySelection => write!(f, "CopySelection"),
-            EditCommand::SelectMoveWordLeft => write!(f, "SelectMoveWordLeft"),
-            EditCommand::SelectMoveWordRight => write!(f, "SelectMoveWordRight"),
         }
     }
 }
@@ -288,29 +336,28 @@ impl EditCommand {
     pub fn edit_type(&self) -> EditType {
         match self {
             // Cursor moves
-            EditCommand::MoveToStart
-            | EditCommand::MoveToEnd
-            | EditCommand::MoveToLineStart
-            | EditCommand::MoveToLineEnd
-            | EditCommand::MoveToPosition(_)
-            | EditCommand::MoveLeft
-            | EditCommand::MoveRight
-            | EditCommand::MoveWordLeft
-            | EditCommand::MoveBigWordLeft
-            | EditCommand::MoveWordRight
-            | EditCommand::MoveWordRightStart
-            | EditCommand::MoveBigWordRightStart
-            | EditCommand::MoveWordRightEnd
-            | EditCommand::MoveBigWordRightEnd
-            | EditCommand::MoveRightUntil(_)
-            | EditCommand::MoveRightBefore(_)
-            | EditCommand::MoveLeftUntil(_)
-            | EditCommand::MoveLeftBefore(_)
-            | EditCommand::SelectMoveLeft
-            | EditCommand::SelectMoveRight
-            | EditCommand::SelectMoveWordLeft
-            | EditCommand::SelectMoveWordRight
-            | EditCommand::SelectAll => EditType::MoveCursor,
+            EditCommand::MoveToStart { select, .. }
+            | EditCommand::MoveToEnd { select, .. }
+            | EditCommand::MoveToLineStart { select, .. }
+            | EditCommand::MoveToLineEnd { select, .. }
+            | EditCommand::MoveToPosition { select, .. }
+            | EditCommand::MoveLeft { select, .. }
+            | EditCommand::MoveRight { select, .. }
+            | EditCommand::MoveWordLeft { select, .. }
+            | EditCommand::MoveBigWordLeft { select, .. }
+            | EditCommand::MoveWordRight { select, .. }
+            | EditCommand::MoveWordRightStart { select, .. }
+            | EditCommand::MoveBigWordRightStart { select, .. }
+            | EditCommand::MoveWordRightEnd { select, .. }
+            | EditCommand::MoveBigWordRightEnd { select, .. }
+            | EditCommand::MoveRightUntil { select, .. }
+            | EditCommand::MoveRightBefore { select, .. }
+            | EditCommand::MoveLeftUntil { select, .. }
+            | EditCommand::MoveLeftBefore { select, .. } => {
+                EditType::MoveCursor { select: *select }
+            }
+
+            EditCommand::SelectAll => EditType::MoveCursor { select: true },
 
             // Text edits
             EditCommand::InsertChar(_)
@@ -363,7 +410,7 @@ impl EditCommand {
 #[derive(PartialEq, Eq)]
 pub enum EditType {
     /// Cursor movement commands
-    MoveCursor,
+    MoveCursor { select: bool },
     /// Undo/Redo commands
     UndoRedo,
     /// Text editing commands

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -196,6 +196,12 @@ pub enum EditCommand {
     /// Select and move right
     SelectMoveRight,
 
+    /// Select and move whole word left
+    SelectMoveWordLeft,
+
+    /// Select and move whole word right
+    SelectMoveWordRight,
+
     /// Select whole input buffer
     SelectAll,
 
@@ -270,6 +276,8 @@ impl Display for EditCommand {
             EditCommand::SelectAll => write!(f, "SelectAll"),
             EditCommand::CutSelection => write!(f, "CutSelection"),
             EditCommand::CopySelection => write!(f, "CopySelection"),
+            EditCommand::SelectMoveWordLeft => write!(f, "SelectMoveWordLeft"),
+            EditCommand::SelectMoveWordRight => write!(f, "SelectMoveWordRight"),
         }
     }
 }
@@ -300,6 +308,8 @@ impl EditCommand {
             | EditCommand::MoveLeftBefore(_)
             | EditCommand::SelectMoveLeft
             | EditCommand::SelectMoveRight
+            | EditCommand::SelectMoveWordLeft
+            | EditCommand::SelectMoveWordRight
             | EditCommand::SelectAll => EditType::MoveCursor,
 
             // Text edits

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -189,6 +189,21 @@ pub enum EditCommand {
 
     /// CutUntil left before char
     MoveLeftBefore(char),
+
+    /// Select and move left
+    SelectMoveLeft,
+
+    /// Select and move right
+    SelectMoveRight,
+
+    /// Select whole input buffer
+    SelectAll,
+
+    /// Cut selection
+    CutSelection,
+
+    /// Copy selection
+    CopySelection,
 }
 
 impl Display for EditCommand {
@@ -250,6 +265,11 @@ impl Display for EditCommand {
             EditCommand::CutLeftBefore(_) => write!(f, "CutLeftBefore Value: <char>"),
             EditCommand::MoveLeftUntil(_) => write!(f, "MoveLeftUntil Value: <char>"),
             EditCommand::MoveLeftBefore(_) => write!(f, "MoveLeftBefore Value: <char>"),
+            EditCommand::SelectMoveLeft => write!(f, "SelectMoveLeft"),
+            EditCommand::SelectMoveRight => write!(f, "SelectMoveRight"),
+            EditCommand::SelectAll => write!(f, "SelectAll"),
+            EditCommand::CutSelection => write!(f, "CutSelection"),
+            EditCommand::CopySelection => write!(f, "CopySelection"),
         }
     }
 }
@@ -277,7 +297,10 @@ impl EditCommand {
             | EditCommand::MoveRightUntil(_)
             | EditCommand::MoveRightBefore(_)
             | EditCommand::MoveLeftUntil(_)
-            | EditCommand::MoveLeftBefore(_) => EditType::MoveCursor,
+            | EditCommand::MoveLeftBefore(_)
+            | EditCommand::SelectMoveLeft
+            | EditCommand::SelectMoveRight
+            | EditCommand::SelectAll => EditType::MoveCursor,
 
             // Text edits
             EditCommand::InsertChar(_)
@@ -315,9 +338,12 @@ impl EditCommand {
             | EditCommand::CutRightUntil(_)
             | EditCommand::CutRightBefore(_)
             | EditCommand::CutLeftUntil(_)
-            | EditCommand::CutLeftBefore(_) => EditType::EditText,
+            | EditCommand::CutLeftBefore(_)
+            | EditCommand::CutSelection => EditType::EditText,
 
             EditCommand::Undo | EditCommand::Redo => EditType::UndoRedo,
+
+            EditCommand::CopySelection => EditType::NoOp,
         }
     }
 }
@@ -332,6 +358,8 @@ pub enum EditType {
     UndoRedo,
     /// Text editing commands
     EditText,
+    /// No effect on line buffer
+    NoOp,
 }
 
 /// Every line change should come with an `UndoBehavior` tag, which can be used to

--- a/src/painting/styled_text.rs
+++ b/src/painting/styled_text.rs
@@ -5,6 +5,7 @@ use crate::Prompt;
 use super::utils::strip_ansi;
 
 /// A representation of a buffer with styling, used for doing syntax highlighting
+#[derive(Clone)]
 pub struct StyledText {
     /// The component, styled parts of the text
     pub buffer: Vec<(Style, String)>,
@@ -25,6 +26,67 @@ impl StyledText {
     /// Add a new styled string to the buffer
     pub fn push(&mut self, styled_string: (Style, String)) {
         self.buffer.push(styled_string);
+    }
+
+    /// Style range with the provided style
+    pub fn style_range(&mut self, from: usize, to: usize, new_style: Style) {
+        let (from, to) = if from > to { (to, from) } else { (from, to) };
+        let mut current_idx = 0;
+        let mut pair_idx = 0;
+        while pair_idx < self.buffer.len() {
+            let pair = &mut self.buffer[pair_idx];
+            let end_idx = current_idx + pair.1.len();
+            enum Position {
+                Before,
+                In,
+                After,
+            }
+            let start_position = if current_idx < from {
+                Position::Before
+            } else if current_idx >= to {
+                Position::After
+            } else {
+                Position::In
+            };
+            let end_position = if end_idx < from {
+                Position::Before
+            } else if end_idx > to {
+                Position::After
+            } else {
+                Position::In
+            };
+            match (start_position, end_position) {
+                (Position::Before, Position::After) => {
+                    let mut in_range = pair.1.split_off(from - current_idx);
+                    let after_range = in_range.split_off(to - current_idx - from);
+                    let in_range = (new_style, in_range);
+                    let after_range = (pair.0, after_range);
+                    self.buffer.insert(pair_idx + 1, in_range);
+                    self.buffer.insert(pair_idx + 2, after_range);
+                    break;
+                }
+                (Position::Before, Position::In) => {
+                    let in_range = pair.1.split_off(from - current_idx);
+                    pair_idx += 1; // Additional increment for the split pair, since the new insertion is already correctly styled and can be skipped next iteration
+                    self.buffer.insert(pair_idx, (new_style, in_range));
+                }
+                (Position::In, Position::After) => {
+                    let after_range = pair.1.split_off(to - current_idx);
+                    let old_style = pair.0;
+                    pair.0 = new_style;
+                    if !after_range.is_empty() {
+                        self.buffer.insert(pair_idx + 1, (old_style, after_range));
+                    }
+                    break;
+                }
+                (Position::In, Position::In) => pair.0 = new_style,
+
+                (Position::After, _) => break,
+                _ => (),
+            }
+            current_idx = end_idx;
+            pair_idx += 1;
+        }
     }
 
     /// Render the styled string. We use the insertion point to render around so that
@@ -108,4 +170,89 @@ fn render_as_string(
         rendered.push_str(&renderable.0.paint(line).to_string());
     }
     rendered
+}
+
+#[cfg(test)]
+mod test {
+    use nu_ansi_term::{Color, Style};
+
+    use crate::StyledText;
+
+    fn get_styled_text_template() -> (super::StyledText, Style, Style) {
+        let before_style = Style::new().on(Color::Black);
+        let after_style = Style::new().on(Color::Red);
+        (
+            super::StyledText {
+                buffer: vec![
+                    (before_style, "aaa".into()),
+                    (before_style, "bbb".into()),
+                    (before_style, "ccc".into()),
+                ],
+            },
+            before_style,
+            after_style,
+        )
+    }
+    #[test]
+    fn style_range_partial_update_one_part() {
+        let (styled_text_template, before_style, after_style) = get_styled_text_template();
+        let mut styled_text = styled_text_template.clone();
+        styled_text.style_range(0, 1, after_style);
+        assert_eq!(styled_text.buffer[0], (after_style, "a".into()));
+        assert_eq!(styled_text.buffer[1], (before_style, "aa".into()));
+        assert_eq!(styled_text.buffer[2], (before_style, "bbb".into()));
+        assert_eq!(styled_text.buffer[3], (before_style, "ccc".into()));
+    }
+    #[test]
+    fn style_range_complete_update_one_part() {
+        let (styled_text_template, before_style, after_style) = get_styled_text_template();
+        let mut styled_text = styled_text_template.clone();
+        styled_text.style_range(0, 3, after_style);
+        assert_eq!(styled_text.buffer[0], (after_style, "aaa".into()));
+        assert_eq!(styled_text.buffer[1], (before_style, "bbb".into()));
+        assert_eq!(styled_text.buffer[2], (before_style, "ccc".into()));
+        assert_eq!(styled_text.buffer.len(), 3);
+    }
+    #[test]
+    fn style_range_update_over_boundary() {
+        let (styled_text_template, before_style, after_style) = get_styled_text_template();
+        let mut styled_text = styled_text_template;
+        styled_text.style_range(0, 5, after_style);
+        assert_eq!(styled_text.buffer[0], (after_style, "aaa".into()));
+        assert_eq!(styled_text.buffer[1], (after_style, "bb".into()));
+        assert_eq!(styled_text.buffer[2], (before_style, "b".into()));
+        assert_eq!(styled_text.buffer[3], (before_style, "ccc".into()));
+    }
+    #[test]
+    fn style_range_update_over_part() {
+        let (styled_text_template, before_style, after_style) = get_styled_text_template();
+        let mut styled_text = styled_text_template;
+        styled_text.style_range(1, 7, after_style);
+        assert_eq!(styled_text.buffer[0], (before_style, "a".into()));
+        assert_eq!(styled_text.buffer[1], (after_style, "aa".into()));
+        assert_eq!(styled_text.buffer[2], (after_style, "bbb".into()));
+        assert_eq!(styled_text.buffer[3], (after_style, "c".into()));
+        assert_eq!(styled_text.buffer[4], (before_style, "cc".into()));
+    }
+    #[test]
+    fn style_range_last_letter() {
+        let (_, before_style, after_style) = get_styled_text_template();
+        let mut styled_text = StyledText {
+            buffer: vec![(before_style, "asdf".into())],
+        };
+        styled_text.style_range(3, 4, after_style);
+        assert_eq!(styled_text.buffer[0], (before_style, "asd".into()));
+        assert_eq!(styled_text.buffer[1], (after_style, "f".into()));
+    }
+    #[test]
+    fn style_range_from_second_to_last() {
+        let (_, before_style, after_style) = get_styled_text_template();
+        let mut styled_text = StyledText {
+            buffer: vec![(before_style, "asdf".into())],
+        };
+        styled_text.style_range(2, 3, after_style);
+        assert_eq!(styled_text.buffer[0], (before_style, "as".into()));
+        assert_eq!(styled_text.buffer[1], (after_style, "d".into()));
+        assert_eq!(styled_text.buffer[2], (before_style, "f".into()));
+    }
 }


### PR DESCRIPTION
Addresses issue #380.

> All CutXXX commands like "CutFromStart" or "CutWordLeft" should use the OS copy/paste buffer not an internal buffer

This is already the case if the crate is compiled with the feature `system_clipboard`. This is, afaik, not (yet) done for nushell.