### PR TITLE
Use empty history if search query fails

### DIFF
--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -23,7 +23,7 @@ impl<'menu> Completer for HistoryCompleter<'menu> {
             .search(SearchQuery::all_that_contain_rev(
                 parsed.remainder.to_string(),
             ))
-            .expect("todo: error handling");
+            .unwrap_or(vec![]);
 
         values
             .into_iter()
@@ -40,7 +40,7 @@ impl<'menu> Completer for HistoryCompleter<'menu> {
             .count(SearchQuery::all_that_contain_rev(
                 parsed.remainder.to_string(),
             ))
-            .expect("todo: error handling");
+            .unwrap_or(0);
         count as usize
     }
 }

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -23,7 +23,7 @@ impl<'menu> Completer for HistoryCompleter<'menu> {
             .search(SearchQuery::all_that_contain_rev(
                 parsed.remainder.to_string(),
             ))
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
 
         values
             .into_iter()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1753,8 +1753,8 @@ impl Reedline {
                 entry.id = Some(Self::FILTERED_ITEM_ID);
                 self.history_last_run_id = entry.id;
                 self.history_excluded_item = Some(entry);
-            } else {
-                entry = self.history.save(entry).expect("todo: error handling");
+            } else if let Ok(saved_entry) = self.history.save(entry) {
+                entry = saved_entry;
                 self.history_last_run_id = entry.id;
                 self.history_excluded_item = None;
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -521,7 +521,7 @@ impl Reedline {
         let history: Vec<_> = self
             .history
             .search(SearchQuery::everything(SearchDirection::Forward, None))
-            .expect("todo: error handling");
+            .unwrap_or(vec![]);
 
         for (i, entry) in history.iter().enumerate() {
             self.print_line(&format!("{}\t{}", i, entry.command_line))?;
@@ -537,7 +537,7 @@ impl Reedline {
                 SearchDirection::Forward,
                 self.get_history_session_id(),
             ))
-            .expect("todo: error handling");
+            .unwrap_or(vec![]);
 
         for (i, entry) in history.iter().enumerate() {
             self.print_line(&format!("{}\t{}", i, entry.command_line))?;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -521,7 +521,7 @@ impl Reedline {
         let history: Vec<_> = self
             .history
             .search(SearchQuery::everything(SearchDirection::Forward, None))
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
 
         for (i, entry) in history.iter().enumerate() {
             self.print_line(&format!("{}\t{}", i, entry.command_line))?;
@@ -537,7 +537,7 @@ impl Reedline {
                 SearchDirection::Forward,
                 self.get_history_session_id(),
             ))
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
 
         for (i, entry) in history.iter().enumerate() {
             self.print_line(&format!("{}\t{}", i, entry.command_line))?;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -845,20 +845,14 @@ impl Reedline {
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::PreviousHistory | ReedlineEvent::Up | ReedlineEvent::SearchHistory => {
-                self.history_cursor
-                    .back(self.history.as_ref())
-                    .expect("todo: error handling");
+                let _ = self.history_cursor.back(self.history.as_ref());
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::NextHistory | ReedlineEvent::Down => {
-                self.history_cursor
-                    .forward(self.history.as_ref())
-                    .expect("todo: error handling");
+                let _ = self.history_cursor.forward(self.history.as_ref());
                 // Hacky way to ensure that we don't fall of into failed search going forward
                 if self.history_cursor.string_at_cursor().is_none() {
-                    self.history_cursor
-                        .back(self.history.as_ref())
-                        .expect("todo: error handling");
+                    let _ = self.history_cursor.back(self.history.as_ref());
                 }
                 Ok(EventStatus::Handled)
             }
@@ -1243,9 +1237,7 @@ impl Reedline {
         }
 
         if !self.history_cursor_on_excluded {
-            self.history_cursor
-                .back(self.history.as_ref())
-                .expect("todo: error handling");
+            let _ = self.history_cursor.back(self.history.as_ref());
         }
         self.update_buffer_from_history();
         self.editor.move_to_start(UndoBehavior::HistoryNavigation);
@@ -1266,9 +1258,7 @@ impl Reedline {
             self.history_cursor_on_excluded = false;
         } else {
             let cursor_was_on_item = self.history_cursor.string_at_cursor().is_some();
-            self.history_cursor
-                .forward(self.history.as_ref())
-                .expect("todo: error handling");
+            let _ = self.history_cursor.forward(self.history.as_ref());
 
             if cursor_was_on_item
                 && self.history_cursor.string_at_cursor().is_none()
@@ -1337,9 +1327,7 @@ impl Reedline {
                             self.get_history_session_id(),
                         );
                     }
-                    self.history_cursor
-                        .back(self.history.as_mut())
-                        .expect("todo: error handling");
+                    let _ = self.history_cursor.back(self.history.as_mut());
                 }
                 EditCommand::Backspace => {
                     let navigation = self.history_cursor.get_navigation();
@@ -1351,9 +1339,7 @@ impl Reedline {
                             HistoryNavigationQuery::SubstringSearch(new_substring.to_string()),
                             self.get_history_session_id(),
                         );
-                        self.history_cursor
-                            .back(self.history.as_mut())
-                            .expect("todo: error handling");
+                        let _ = self.history_cursor.back(self.history.as_mut());
                     }
                 }
                 _ => {

--- a/src/hinter/default.rs
+++ b/src/hinter/default.rs
@@ -22,7 +22,7 @@ impl Hinter for DefaultHinter {
                     line.to_string(),
                     history.session(),
                 ))
-                .expect("todo: error handling")
+                .unwrap_or(vec![])
                 .first()
                 .map_or_else(String::new, |entry| {
                     entry

--- a/src/hinter/default.rs
+++ b/src/hinter/default.rs
@@ -22,7 +22,7 @@ impl Hinter for DefaultHinter {
                     line.to_string(),
                     history.session(),
                 ))
-                .unwrap_or(vec![])
+                .unwrap_or_default()
                 .first()
                 .map_or_else(String::new, |entry| {
                     entry


### PR DESCRIPTION
There's a bunch of places with `.expect("todo: error handling")`, and this PR tries to remove most of them. Here's the four different kinds:

- There are a couple inside `examples/demo.rs` that I didn't bother with.
- Some of these are for unwrapping the result of running a search query to look through the history. I figured that instead of panicking, it may be better to silently treat `Err`s as the history being empty.
- One of them comes after [`history.save(entry)`](https://github.com/nushell/reedline/blob/main/src/engine.rs#L1757), in `engine.rs`. This has been edited to silently ignore an `Err`.
- The rest of the `.expect`s are all inside `engine.rs` and are for handling the result of moving the `history_cursor` forward or backward. Unfortunately, all of them appear inside methods that return either `()` or an `io::Result`. These have also been edited to silently ignore `Err`s.

A disadvantage of silently handling `Err`s is that users won't know that something went wrong, but if the `.expect`s are to be kept, they should at least be changed to have more useful messages to help users file bug reports.

There shouldn't be any user-facing changes from this.