### PR TITLE
suggestion: added style

### DIFF
--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -1,3 +1,4 @@
+use nu_ansi_term::Style;
 use std::ops::Range;
 
 /// A span of source code, with positions in bytes
@@ -79,6 +80,8 @@ pub struct Suggestion {
     pub value: String,
     /// Optional description for the replacement
     pub description: Option<String>,
+    /// Optional style for the replacement
+    pub style: Option<Style>,
     /// Optional vector of strings in the suggestion. These can be used to
     /// represent examples coming from a suggestion
     pub extra: Option<Vec<String>>,

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -419,6 +419,7 @@ mod tests {
                 Suggestion {
                     value: "test".into(),
                     description: None,
+                    style: None,
                     extra: None,
                     span: Span { start: 8, end: 9 },
                     append_whitespace: false,
@@ -426,6 +427,7 @@ mod tests {
                 Suggestion {
                     value: "this is the reedline crate".into(),
                     description: None,
+                    style: None,
                     extra: None,
                     span: Span { start: 8, end: 9 },
                     append_whitespace: false,
@@ -433,6 +435,7 @@ mod tests {
                 Suggestion {
                     value: "this is the reedline crate".into(),
                     description: None,
+                    style: None,
                     extra: None,
                     span: Span { start: 0, end: 9 },
                     append_whitespace: false,

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -55,17 +55,17 @@ impl Completer for DefaultCompleter {
     /// assert_eq!(
     ///     completions.complete("bat",3),
     ///     vec![
-    ///         Suggestion {value: "batcave".into(), description: None, extra: None, span: Span { start: 0, end: 3 }, append_whitespace: false},
-    ///         Suggestion {value: "batman".into(), description: None, extra: None, span: Span { start: 0, end: 3 }, append_whitespace: false},
-    ///         Suggestion {value: "batmobile".into(), description: None, extra: None, span: Span { start: 0, end: 3 }, append_whitespace: false},
+    ///         Suggestion {value: "batcave".into(), description: None, style: None, extra: None, span: Span { start: 0, end: 3 }, append_whitespace: false},
+    ///         Suggestion {value: "batman".into(), description: None, style: None, extra: None, span: Span { start: 0, end: 3 }, append_whitespace: false},
+    ///         Suggestion {value: "batmobile".into(), description: None, style: None, extra: None, span: Span { start: 0, end: 3 }, append_whitespace: false},
     ///     ]);
     ///
     /// assert_eq!(
     ///     completions.complete("to the bat",10),
     ///     vec![
-    ///         Suggestion {value: "batcave".into(), description: None, extra: None, span: Span { start: 7, end: 10 }, append_whitespace: false},
-    ///         Suggestion {value: "batman".into(), description: None, extra: None, span: Span { start: 7, end: 10 }, append_whitespace: false},
-    ///         Suggestion {value: "batmobile".into(), description: None, extra: None, span: Span { start: 7, end: 10 }, append_whitespace: false},
+    ///         Suggestion {value: "batcave".into(), description: None, style: None, extra: None, span: Span { start: 7, end: 10 }, append_whitespace: false},
+    ///         Suggestion {value: "batman".into(), description: None, style: None, extra: None, span: Span { start: 7, end: 10 }, append_whitespace: false},
+    ///         Suggestion {value: "batmobile".into(), description: None, style: None, extra: None, span: Span { start: 7, end: 10 }, append_whitespace: false},
     ///     ]);
     /// ```
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
@@ -102,6 +102,7 @@ impl Completer for DefaultCompleter {
                                     Suggestion {
                                         value: format!("{span_line}{ext}"),
                                         description: None,
+                                        style: None,
                                         extra: None,
                                         span,
                                         append_whitespace: false,
@@ -176,15 +177,15 @@ impl DefaultCompleter {
     /// completions.insert(vec!["test-hyphen","test_underscore"].iter().map(|s| s.to_string()).collect());
     /// assert_eq!(
     ///     completions.complete("te",2),
-    ///     vec![Suggestion {value: "test".into(), description: None, extra: None, span: Span { start: 0, end: 2 }, append_whitespace: false}]);
+    ///     vec![Suggestion {value: "test".into(), description: None, style: None, extra: None, span: Span { start: 0, end: 2 }, append_whitespace: false}]);
     ///
     /// let mut completions = DefaultCompleter::with_inclusions(&['-', '_']);
     /// completions.insert(vec!["test-hyphen","test_underscore"].iter().map(|s| s.to_string()).collect());
     /// assert_eq!(
     ///     completions.complete("te",2),
     ///     vec![
-    ///         Suggestion {value: "test-hyphen".into(), description: None, extra: None, span: Span { start: 0, end: 2 }, append_whitespace: false},
-    ///         Suggestion {value: "test_underscore".into(), description: None, extra: None, span: Span { start: 0, end: 2 }, append_whitespace: false},
+    ///         Suggestion {value: "test-hyphen".into(), description: None, style: None, extra: None, span: Span { start: 0, end: 2 }, append_whitespace: false},
+    ///         Suggestion {value: "test_underscore".into(), description: None, style: None, extra: None, span: Span { start: 0, end: 2 }, append_whitespace: false},
     ///     ]);
     /// ```
     pub fn with_inclusions(incl: &[char]) -> Self {
@@ -374,6 +375,7 @@ mod tests {
                 Suggestion {
                     value: "ｎｕｌｌ".into(),
                     description: None,
+                    style: None,
                     extra: None,
                     span: Span { start: 0, end: 3 },
                     append_whitespace: false,
@@ -381,6 +383,7 @@ mod tests {
                 Suggestion {
                     value: "ｎｕｍｂｅｒ".into(),
                     description: None,
+                    style: None,
                     extra: None,
                     span: Span { start: 0, end: 3 },
                     append_whitespace: false,
@@ -388,6 +391,7 @@ mod tests {
                 Suggestion {
                     value: "ｎｕｓｈｅｌｌ".into(),
                     description: None,
+                    style: None,
                     extra: None,
                     span: Span { start: 0, end: 3 },
                     append_whitespace: false,

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -59,6 +59,7 @@ impl<'menu> HistoryCompleter<'menu> {
         Suggestion {
             value: value.to_string(),
             description: None,
+            style: None,
             extra: None,
             span,
             append_whitespace: false,

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -344,7 +344,7 @@ impl ColumnarMenu {
                     let left_text_size = self.longest_suggestion + self.default_details.col_padding;
                     let right_text_size = self.get_width().saturating_sub(left_text_size);
                     format!(
-                        "{}{}{:max$}{}{}{}{}{}",
+                        "{}{}{:max$}{}{}{}{}{}{}",
                         suggestion
                             .style
                             .unwrap_or(self.color.text_style)
@@ -352,6 +352,7 @@ impl ColumnarMenu {
                             .prefix(),
                         self.color.selected_text_style.prefix(),
                         &suggestion.value,
+                        RESET,
                         self.color.description_style.reverse().prefix(),
                         self.color.selected_text_style.prefix(),
                         description

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -344,9 +344,16 @@ impl ColumnarMenu {
                     let left_text_size = self.longest_suggestion + self.default_details.col_padding;
                     let right_text_size = self.get_width().saturating_sub(left_text_size);
                     format!(
-                        "{}{:max$}{}{}{}",
+                        "{}{}{:max$}{}{}{}{}{}",
+                        suggestion
+                            .style
+                            .unwrap_or(self.color.text_style)
+                            .reverse()
+                            .prefix(),
                         self.color.selected_text_style.prefix(),
                         &suggestion.value,
+                        self.color.description_style.reverse().prefix(),
+                        self.color.selected_text_style.prefix(),
                         description
                             .chars()
                             .take(right_text_size)
@@ -358,7 +365,12 @@ impl ColumnarMenu {
                     )
                 } else {
                     format!(
-                        "{}{}{}{:>empty$}{}",
+                        "{}{}{}{}{:>empty$}{}",
+                        suggestion
+                            .style
+                            .unwrap_or(self.color.text_style)
+                            .reverse()
+                            .prefix(),
                         self.color.selected_text_style.prefix(),
                         &suggestion.value,
                         RESET,
@@ -372,7 +384,7 @@ impl ColumnarMenu {
                 let right_text_size = self.get_width().saturating_sub(left_text_size);
                 format!(
                     "{}{:max$}{}{}{}{}{}",
-                    self.color.text_style.prefix(),
+                    suggestion.style.unwrap_or(self.color.text_style).prefix(),
                     &suggestion.value,
                     RESET,
                     self.color.description_style.prefix(),
@@ -388,7 +400,7 @@ impl ColumnarMenu {
             } else {
                 format!(
                     "{}{}{}{}{:>empty$}{}{}",
-                    self.color.text_style.prefix(),
+                    suggestion.style.unwrap_or(self.color.text_style).prefix(),
                     &suggestion.value,
                     RESET,
                     self.color.description_style.prefix(),
@@ -813,6 +825,7 @@ mod tests {
         Suggestion {
             value: name.to_string(),
             description: None,
+            style: None,
             extra: None,
             span: Span { start: 0, end: pos },
             append_whitespace: false,

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -1473,6 +1473,7 @@ mod tests {
         Suggestion {
             value: name.to_string(),
             description: None,
+            style: None,
             extra: None,
             span: Span { start: 0, end: pos },
             append_whitespace: false,

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -497,6 +497,7 @@ mod tests {
             .map(|s| Suggestion {
                 value: s.into(),
                 description: None,
+                style: None,
                 extra: None,
                 span: Span::new(0, s.len()),
                 append_whitespace: false,
@@ -516,6 +517,7 @@ mod tests {
             .map(|s| Suggestion {
                 value: s.into(),
                 description: None,
+                style: None,
                 extra: None,
                 span: Span::new(0, s.len()),
                 append_whitespace: false,


### PR DESCRIPTION
![image](https://github.com/nushell/reedline/assets/9090290/70ddd829-a936-42cc-833c-4f70f44a2bd5)

Reverse highlighting with config "record" for reverse:
```nushell
style: {
    text: white
    selected_text: {
        attr: r
    }
    description_text: white_dimmed
}
```

related https://github.com/nushell/nushell/issues/5292
related https://github.com/rsteube/carapace/pull/546