### PR TITLE
Don't slice line in DefaultCompleter

### DIFF
--- a/examples/completions.rs
+++ b/examples/completions.rs
@@ -29,7 +29,7 @@ fn main() -> io::Result<()> {
     ];
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands, 2));
     // Use the interactive menu to select options from the completer
-    let completion_menu = Box::new(ColumnarMenu::default().with_name("completion_menu"));
+    let completion_menu = Box::new(ColumnarMenu::default().with_name("completion_menu").with_only_buffer_difference(true));
 
     let mut keybindings = default_emacs_keybindings();
     add_menu_keybindings(&mut keybindings);

--- a/examples/completions.rs
+++ b/examples/completions.rs
@@ -29,7 +29,7 @@ fn main() -> io::Result<()> {
     ];
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands, 2));
     // Use the interactive menu to select options from the completer
-    let completion_menu = Box::new(ColumnarMenu::default().with_name("completion_menu").with_only_buffer_difference(true));
+    let completion_menu = Box::new(ColumnarMenu::default().with_name("completion_menu"));
 
     let mut keybindings = default_emacs_keybindings();
     add_menu_keybindings(&mut keybindings);

--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -24,7 +24,8 @@ impl Span {
     }
 }
 
-/// A trait that defines how to convert a line and position to a list of potential completions in that position.
+/// A trait that defines how to convert some text and a position to a list of potential completions in that position.
+/// The text could be a part of the whole line, and the position is the index of the end of the text in the original line.
 pub trait Completer: Send {
     /// the action that will take the line and position and convert it to a vector of completions, which include the
     /// span to replace and the contents of that replacement

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -71,6 +71,9 @@ impl Completer for DefaultCompleter {
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
         let mut span_line_whitespaces = 0;
         let mut completions = vec![];
+        // TODO trimming here is only necessary if someone passes in text containing
+        // stuff after the cursor with `only_buffer_difference: false`
+        let line = if line.len() > pos { &line[..pos] } else { line };
         if !line.is_empty() {
             let mut split = line.split(' ').rev();
             let mut span_line: String = String::new();

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -72,7 +72,7 @@ impl Completer for DefaultCompleter {
         let mut span_line_whitespaces = 0;
         let mut completions = vec![];
         if !line.is_empty() {
-            let mut split = line[0..pos].split(' ').rev();
+            let mut split = line.split(' ').rev();
             let mut span_line: String = String::new();
             for _ in 0..split.clone().count() {
                 if let Some(s) = split.next() {

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -71,8 +71,8 @@ impl Completer for DefaultCompleter {
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
         let mut span_line_whitespaces = 0;
         let mut completions = vec![];
-        // TODO trimming here is only necessary if someone passes in text containing
-        // stuff after the cursor with `only_buffer_difference: false`
+        // Trimming in case someone passes in text containing stuff after the cursor, if
+        // `only_buffer_difference` is false
         let line = if line.len() > pos { &line[..pos] } else { line };
         if !line.is_empty() {
             let mut split = line.split(' ').rev();

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -52,8 +52,8 @@ impl<'menu> HistoryCompleter<'menu> {
 
     fn create_suggestion(&self, line: &str, pos: usize, value: &str) -> Suggestion {
         let span = Span {
-            start: pos,
-            end: pos + line.len(),
+            start: pos - line.len(),
+            end: pos,
         };
 
         Suggestion {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1538,7 +1538,7 @@ impl Reedline {
                         self.get_history_session_id(),
                     )))
                     .unwrap_or_else(|_| Vec::new())
-                    .get(0)
+                    .first()
                     .and_then(|history| history.command_line.split_whitespace().next_back())
                     .map(|token| (parsed.remainder.len(), indicator.len(), token.to_string())),
             });

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -530,7 +530,7 @@ impl Menu for ColumnarMenu {
             if let Some(old_string) = &self.input {
                 let (start, input) = string_difference(editor.get_buffer(), old_string);
                 if !input.is_empty() {
-                    self.values = completer.complete(input, start);
+                    self.values = completer.complete(input, start + input.len());
                     self.reset_position();
                 }
             }
@@ -541,7 +541,10 @@ impl Menu for ColumnarMenu {
             // Also, by replacing the new line character with a space, the insert
             // position is maintain in the line buffer.
             let trimmed_buffer = editor.get_buffer().replace('\n', " ");
-            self.values = completer.complete(trimmed_buffer.as_str(), editor.insertion_point());
+            self.values = completer.complete(
+                &trimmed_buffer[..editor.insertion_point()],
+                editor.insertion_point(),
+            );
             self.reset_position();
         }
     }

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -526,29 +526,31 @@ impl Menu for ColumnarMenu {
 
     /// Updates menu values
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
-        if self.only_buffer_difference {
+        self.values = if self.only_buffer_difference {
             if let Some(old_string) = &self.input {
                 let (start, input) = string_difference(editor.get_buffer(), old_string);
                 if !input.is_empty() {
-                    self.values = completer.complete(input, start + input.len());
-                    self.reset_position();
+                    completer.complete(input, start + input.len())
+                } else {
+                    completer.complete("", editor.insertion_point())
                 }
             } else {
-                self.values = completer.complete("", editor.insertion_point());
+                completer.complete("", editor.insertion_point())
             }
         } else {
             // If there is a new line character in the line buffer, the completer
             // doesn't calculate the suggested values correctly. This happens when
             // editing a multiline buffer.
-            // Also, by replacing the new line character with a space, the insert
+            // Also, by replacing the new line character with a space, the insertF
             // position is maintain in the line buffer.
             let trimmed_buffer = editor.get_buffer().replace('\n', " ");
-            self.values = completer.complete(
+            completer.complete(
                 &trimmed_buffer[..editor.insertion_point()],
                 editor.insertion_point(),
-            );
-            self.reset_position();
-        }
+            )
+        };
+
+        self.reset_position();
     }
 
     /// The working details for the menu changes based on the size of the lines

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -533,6 +533,8 @@ impl Menu for ColumnarMenu {
                     self.values = completer.complete(input, start + input.len());
                     self.reset_position();
                 }
+            } else {
+                self.values = completer.complete("", editor.insertion_point());
             }
         } else {
             // If there is a new line character in the line buffer, the completer

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -541,7 +541,7 @@ impl Menu for ColumnarMenu {
             // If there is a new line character in the line buffer, the completer
             // doesn't calculate the suggested values correctly. This happens when
             // editing a multiline buffer.
-            // Also, by replacing the new line character with a space, the insertF
+            // Also, by replacing the new line character with a space, the insert
             // position is maintain in the line buffer.
             let trimmed_buffer = editor.get_buffer().replace('\n', " ");
             completer.complete(

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -395,7 +395,7 @@ impl Menu for ListMenu {
     /// Collecting the value from the completer to be shown in the menu
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
         let line_buffer = editor.line_buffer();
-        let (start, input) = if self.only_buffer_difference {
+        let (pos, input) = if self.only_buffer_difference {
             match &self.input {
                 Some(old_string) => {
                     let (start, input) = string_difference(line_buffer.get_buffer(), old_string);
@@ -424,7 +424,7 @@ impl Menu for ListMenu {
         }
 
         self.values = if parsed.remainder.is_empty() {
-            self.query_size = Some(completer.total_completions(parsed.remainder, start));
+            self.query_size = Some(completer.total_completions(parsed.remainder, pos));
 
             let skip = self.pages.iter().take(self.page).sum::<Page>().size;
             let take = self
@@ -433,10 +433,10 @@ impl Menu for ListMenu {
                 .map(|page| page.size)
                 .unwrap_or(self.page_size);
 
-            completer.partial_complete(input, start, skip, take)
+            completer.partial_complete(input, pos, skip, take)
         } else {
             self.query_size = None;
-            completer.complete(input, start)
+            completer.complete(input, pos)
         }
     }
 

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -402,13 +402,16 @@ impl Menu for ListMenu {
                     if input.is_empty() {
                         (line_buffer.insertion_point(), "")
                     } else {
-                        (start, input)
+                        (start + input.len(), input)
                     }
                 }
                 None => (line_buffer.insertion_point(), ""),
             }
         } else {
-            (line_buffer.insertion_point(), line_buffer.get_buffer())
+            (
+                line_buffer.insertion_point(),
+                &line_buffer.get_buffer()[..line_buffer.insertion_point()],
+            )
         };
 
         let parsed = parse_selection_char(input, SELECTION_CHAR);

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -209,7 +209,7 @@ pub fn string_difference<'a>(new_string: &'a str, old_string: &str) -> (usize, &
                     false
                 }
             } else {
-                *c == old_chars[old_char_index].1
+                old_char_index == new_char_index && *c == old_chars[old_char_index].1
             };
 
             if equal {
@@ -477,6 +477,15 @@ mod tests {
 
         let res = string_difference(new_string, old_string);
         assert_eq!(res, (6, "ｓｈｅ"));
+    }
+
+    #[test]
+    fn string_difference_with_repeat() {
+        let new_string = "ee";
+        let old_string = "e";
+
+        let res = string_difference(new_string, old_string);
+        assert_eq!(res, (1, "e"));
     }
 
     #[test]


### PR DESCRIPTION
Goes towards fixing https://github.com/nushell/nushell/issues/8091. https://github.com/nushell/nushell/pull/11488 (which should finish the job) relies on this PR to make `only_buffer_difference: true` work with the columnar and list menus.

I don't know what exactly the old behavior was supposed to be (I looked at the history of the relevant files but couldn't find any recent commits that seemed to change behavior), so maybe this PR has different behavior for the user (it also changes the contract of `Completer::complete`). But I think I've narrowed down the issue, so someone else can at least make a new PR based on that.

It seems like the problem was in `DefaultCompleter::complete`, where it does `line[0..pos]`:

https://github.com/nushell/reedline/blob/f3962232bad6124f41a3725d026468615e31a646/src/completion/default.rs#L71-L75

`DefaultCompleter::complete` assumes that the line given to it is the whole line and that `pos` is the cursor position. It also assumes that the content to complete begins at the start of the line and ends at `pos`. However, with `only_buffer_difference` set to true, the line passed to the completer is only the changed portion of the buffer, and the argument to `pos` is the start of the changed portion of the buffer rather than the cursor position. So when you type `cd <TAB>c`, `line` is `"c"` and `pos` is `3`, so `line[0..pos]` fails.

Although there's a check for the line being empty, there isn't one for `pos` being out of bounds. I figured it'd be easier to have the menus slice the line before sending it over to be completed so they can decide which portion of the text to complete. `pos` would then be used solely to determine the spans of the returned `Suggestion`s.

One problem is that although the `DefaultCompleter` assumes that the argument to `pos` is the *end* of the content to complete, as far as I can tell, `HistoryCompleter` seems to assume that `pos` is the *start* of the content's span (edit: I've now changed it to use the end instead of the start, for consistency):

https://github.com/nushell/reedline/blob/f3962232bad6124f41a3725d026468615e31a646/src/completion/history.rs#L53-L57

On the one hand, making `pos` the start is nice because you add the input's length to get the end. On the other hand, making `pos` the end is nice because that's the cursor position (unless you have `only_buffer_difference` set to true). Either way, the doc comment on `Completer::complete` doesn't seem detailed enough (edit: I've now changed it to say that `pos` must be the end of the text):

https://github.com/nushell/reedline/blob/f3962232bad6124f41a3725d026468615e31a646/src/completion/base.rs#L29-L31

(these permalink snippet things are so cool)

I guess it doesn't really matter because the `HistoryCompleter` isn't used the same way as the `DefaultCompleter`, but it'd still be nice to have consistency.

Here's a recording of the changes using the columnar menu and `only_buffer_difference` set to true:

[![asciicast](https://asciinema.org/a/L1mbnBOk6c3bFfQ5s0GCN3WST.svg)](https://asciinema.org/a/L1mbnBOk6c3bFfQ5s0GCN3WST)

and with the list menu:

[![asciicast](https://asciinema.org/a/x46ylB59qNlFSPmP5yTE8Dr7t.svg)](https://asciinema.org/a/x46ylB59qNlFSPmP5yTE8Dr7t)

There was also a small bug in `string_difference` where, if the old buffer was of length `n` and the new buffer was longer than that (say `n+1`), `old_buffer[0..n] == new_buffer[0..n]`, and `old_buffer[n] == new_buffer[n+1]`, then no difference would be detected. That seems to be fixed now (added one test).