### PR TITLE
Try fix prompt_start_row reset to 0 when opening a file without newline in Nushell 

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -6,5 +6,3 @@ extend-exclude = ["src/core_editor/line_buffer.rs"]
 iterm = "iterm"
 # For testing completion of the word build
 bui = "bui"
-# For sqlite backend
-wheres = "wheres"

--- a/.typos.toml
+++ b/.typos.toml
@@ -6,3 +6,5 @@ extend-exclude = ["src/core_editor/line_buffer.rs"]
 iterm = "iterm"
 # For testing completion of the word build
 bui = "bui"
+# For sqlite backend
+wheres = "wheres"

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -153,7 +153,10 @@ impl Painter {
 
         // This might not be terribly performant. Testing it out
         let is_reset = || match cursor::position() {
-            Ok(position) => position.1.abs_diff(self.prompt_start_row) > 1,
+            // when output something without newline, the cursor position is at current line.
+            // but the prompt_start_row is next line.
+            // in this case we don't want to reset, need to `add 1` to handle for such case.
+            Ok(position) => position.1 + 1 < self.prompt_start_row,
             Err(_) => false,
         };
 


### PR DESCRIPTION
This pr is going to apply one of solution that @nibon7 attempted: https://github.com/nushell/nushell/issues/11399#issuecomment-1867921387

Relative: https://github.com/nushell/nushell/issues/11399