### PR TITLE
Move left when exiting insert mode

### DIFF
--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -136,8 +136,17 @@ impl EditMode for Vi {
                 }
                 (_, KeyModifiers::NONE, KeyCode::Esc) => {
                     self.cache.clear();
-                    self.mode = ViMode::Normal;
-                    ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint])
+
+                    ReedlineEvent::Multiple(vec![
+                        if self.mode == ViMode::Insert {
+                            self.mode = ViMode::Normal;
+                            ReedlineEvent::Left
+                        } else {
+                            ReedlineEvent::None
+                        },
+                        ReedlineEvent::Esc,
+                        ReedlineEvent::Repaint,
+                    ])
                 }
                 (_, KeyModifiers::NONE, KeyCode::Enter) => {
                     self.mode = ViMode::Insert;
@@ -188,7 +197,11 @@ mod test {
 
         assert_eq!(
             result,
-            ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint])
+            ReedlineEvent::Multiple(vec![
+                ReedlineEvent::Left,
+                ReedlineEvent::Esc,
+                ReedlineEvent::Repaint
+            ])
         );
         assert!(matches!(vi.mode, ViMode::Normal));
     }


### PR DESCRIPTION
As mentioned in #694 using the `vi` editor mode does not match the behavior of the `vim/vi` CLI editors.
