### PR TITLE
Print rest of line after cursor with large completion menu

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -389,6 +389,12 @@ impl Painter {
         if let Some(menu) = menu {
             // TODO: Also solve the difficult problem of displaying (parts of)
             // the content after the cursor with the completion menu
+            // This only shows the rest of the line the cursor is on
+            if let Some(newline) = lines.after_cursor.find('\n') {
+                self.stdout.queue(Print(&lines.after_cursor[0..newline]))?;
+            } else {
+                self.stdout.queue(Print(&lines.after_cursor))?;
+            }
             self.print_menu(menu, lines, use_ansi_coloring)?;
         } else {
             // Selecting lines for the hint


### PR DESCRIPTION
Currently, if the buffer is too large to display all at once and you have a completion menu, the text after the cursor isn't displayed. Apparently, it's a difficult problem to show all of the text after the cursor that isn't covered by the menu, but this PR is only for showing the rest of the text on the same line as the cursor.

This is the current behavior. You can't tell which keys I'm pressing in the video, but when I type `foo`, then place my cursor before `foo` and hit tab to activate the completion menu, the `foo` disappears while my cursor is before it. If you move the cursor one word ahead, you'll see the `foo` again (my recording doesn't actually show this, I'll make a new one later when I'm not feeling so lazy but you should be able to reproduce on your own computer).

[![asciicast](https://asciinema.org/a/wFbnH1VnALsDerE7vkMi3bT6g.svg)](https://asciinema.org/a/wFbnH1VnALsDerE7vkMi3bT6g)

This is the new behavior (you can't see the stuff on lines after the current one, but at least you can see the rest of the current line):

[![asciicast](https://asciinema.org/a/yJpKjb3YmCPyPbTAONcyTL2sd.svg)](https://asciinema.org/a/yJpKjb3YmCPyPbTAONcyTL2sd)