### PR TITLE
 Don't panic when creating `FileBackedHistory` with `usize::MAX` capacity 

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -18,7 +18,7 @@ use reedline::CursorConfig;
 #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
 use reedline::FileBackedHistory;
 
-fn main() -> std::io::Result<()> {
+fn main() -> reedline::Result<()> {
     println!("Ctrl-D to quit");
     // quick command like parameter handling
     let vi_mode = matches!(std::env::args().nth(1), Some(x) if x == "--vi");

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -431,7 +431,7 @@ mod test {
     #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
     #[test]
     fn history_size_zero() -> Result<()> {
-        let mut history = crate::FileBackedHistory::new(0);
+        let mut history = crate::FileBackedHistory::new(0)?;
         history.save(create_item(1, "/home/me", "cd ~/Downloads", 0))?;
         assert_eq!(history.count_all()?, 0);
         let _ = history.sync();
@@ -439,5 +439,13 @@ mod test {
         drop(history);
 
         Ok(())
+    }
+
+    #[test]
+    fn create_file_backed_history() {
+        use crate::HISTORY_SIZE;
+
+        assert!(crate::FileBackedHistory::new(usize::MAX).is_err());
+        assert!(crate::FileBackedHistory::new(HISTORY_SIZE).is_ok());
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -33,6 +33,12 @@ pub enum ReedlineErrorVariants {
 #[derive(Debug)]
 pub struct ReedlineError(pub ReedlineErrorVariants);
 
+impl From<std::io::Error> for ReedlineError {
+    fn from(err: std::io::Error) -> Self {
+        Self(ReedlineErrorVariants::IOError(err))
+    }
+}
+
 impl Display for ReedlineError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)


### PR DESCRIPTION
This pr makes `FileBackedHistory::new()` return `Result<FileBackedHistory>` and it will not panic when passing `usize::MAX` as capacity.

When setting `$env.config.history.max_size = -1`,  nushell returns an error instead of panicking.

```console
❯ ./target/debug/nu
Error:   × error within history: History capacity too large to be addressed safely
```