### PR TITLE
get correct cursor pos when menu indicator contains newline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ pub use validator::{DefaultValidator, ValidationResult, Validator};
 
 mod menu;
 pub use menu::{
-    menu_functions, ColumnarMenu, IdeMenu, ListMenu, Menu, MenuEvent, MenuTextStyle, ReedlineMenu,
+    menu_functions, ColumnarMenu, IdeMenu, DescriptionMode, ListMenu, Menu, MenuEvent, MenuTextStyle, ReedlineMenu,
 };
 
 mod terminal_extensions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,8 @@ pub use validator::{DefaultValidator, ValidationResult, Validator};
 
 mod menu;
 pub use menu::{
-    menu_functions, ColumnarMenu, IdeMenu, DescriptionMode, ListMenu, Menu, MenuEvent, MenuTextStyle, ReedlineMenu,
+    menu_functions, ColumnarMenu, DescriptionMode, IdeMenu, ListMenu, Menu, MenuEvent,
+    MenuTextStyle, ReedlineMenu,
 };
 
 mod terminal_extensions;

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -543,7 +543,7 @@ impl Menu for ColumnarMenu {
             // editing a multiline buffer.
             // Also, by replacing the new line character with a space, the insert
             // position is maintain in the line buffer.
-            let trimmed_buffer = editor.get_buffer().replace('\n', " ");
+            let trimmed_buffer = editor.get_buffer().replace("\r\n", "  ").replace('\n', " ");
             completer.complete(
                 &trimmed_buffer[..editor.insertion_point()],
                 editor.insertion_point(),

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -543,7 +543,7 @@ impl Menu for ColumnarMenu {
             // editing a multiline buffer.
             // Also, by replacing the new line character with a space, the insert
             // position is maintain in the line buffer.
-            let trimmed_buffer = editor.get_buffer().replace("\r\n", "  ").replace('\n', " ");
+            let trimmed_buffer = editor.get_buffer().replace('\n', " ");
             completer.complete(
                 &trimmed_buffer[..editor.insertion_point()],
                 editor.insertion_point(),

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -679,7 +679,7 @@ impl Menu for IdeMenu {
             // editing a multiline buffer.
             // Also, by replacing the new line character with a space, the insert
             // position is maintain in the line buffer.
-            let trimmed_buffer = editor.get_buffer().replace("\r\n", "  ").replace('\n', " ");
+            let trimmed_buffer = editor.get_buffer().replace('\n', " ");
             completer.complete(
                 &trimmed_buffer[..editor.insertion_point()],
                 editor.insertion_point(),

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -679,7 +679,7 @@ impl Menu for IdeMenu {
             // editing a multiline buffer.
             // Also, by replacing the new line character with a space, the insert
             // position is maintain in the line buffer.
-            let trimmed_buffer = editor.get_buffer().replace('\n', " ");
+            let trimmed_buffer = editor.get_buffer().replace("\r\n", "  ").replace('\n', " ");
             completer.complete(
                 &trimmed_buffer[..editor.insertion_point()],
                 editor.insertion_point(),

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -11,6 +11,7 @@ use nu_ansi_term::{ansi::RESET, Style};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
+/// The direction of the description box
 pub enum DescriptionMode {
     /// Description is always shown on the left
     Left,

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -8,6 +8,7 @@ use crate::History;
 use crate::{completion::history::HistoryCompleter, painting::Painter, Completer, Suggestion};
 pub use columnar_menu::ColumnarMenu;
 pub use ide_menu::IdeMenu;
+pub use ide_menu::DescriptionMode;
 pub use list_menu::ListMenu;
 use nu_ansi_term::{Color, Style};
 

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -7,8 +7,8 @@ use crate::core_editor::Editor;
 use crate::History;
 use crate::{completion::history::HistoryCompleter, painting::Painter, Completer, Suggestion};
 pub use columnar_menu::ColumnarMenu;
-pub use ide_menu::IdeMenu;
 pub use ide_menu::DescriptionMode;
+pub use ide_menu::IdeMenu;
 pub use list_menu::ListMenu;
 use nu_ansi_term::{Color, Style};
 

--- a/src/painting/prompt_lines.rs
+++ b/src/painting/prompt_lines.rs
@@ -158,3 +158,76 @@ impl<'prompt> PromptLines<'prompt> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        "~/path/",
+        "❯ ",
+        "",
+        100,
+        (9, 0)
+    )]
+    #[case(
+        "~/longer/path/\n",
+        "❯ ",
+        "test",
+        100,
+        (6, 0)
+    )]
+    #[case(
+        "~/longer/path/",
+        "\n❯ ",
+        "test",
+        100,
+        (6, 0)
+    )]
+    #[case(
+        "~/longer/path/\n",
+        "\n❯ ",
+        "test",
+        100,
+        (6, 0)
+    )]
+    #[case(
+        "~/path/",
+        "❯ ",
+        "very long input that does not fit in a single line",
+        40,
+        (19, 1)
+    )]
+    #[case(
+        "~/path/\n",
+        "\n❯\n ",
+        "very long input that does not fit in a single line",
+        10,
+        (1, 5)
+    )]
+
+    fn test_cursor_pos(
+        #[case] prompt_str_left: &str,
+        #[case] prompt_indicator: &str,
+        #[case] before_cursor: &str,
+        #[case] terminal_columns: u16,
+        #[case] expected: (u16, u16),
+    ) {
+        let prompt_lines = PromptLines {
+            prompt_str_left: Cow::Borrowed(prompt_str_left),
+            prompt_str_right: Cow::Borrowed(""),
+            prompt_indicator: Cow::Borrowed(prompt_indicator),
+            before_cursor: Cow::Borrowed(before_cursor),
+            after_cursor: Cow::Borrowed(""),
+            hint: Cow::Borrowed(""),
+            right_prompt_on_last_line: false,
+        };
+
+        let pos = prompt_lines.cursor_pos(terminal_columns);
+
+        assert_eq!(pos, expected);
+    }
+}

--- a/src/painting/prompt_lines.rs
+++ b/src/painting/prompt_lines.rs
@@ -92,8 +92,12 @@ impl<'prompt> PromptLines<'prompt> {
     /// The height is relative to the prompt
     pub(crate) fn cursor_pos(&self, terminal_columns: u16) -> (u16, u16) {
         // If we have a multiline prompt (e.g starship), we expect the cursor to be on the last line
-        let prompt_str = self.prompt_str_left.lines().last().unwrap_or_default();
-        let prompt_width = line_width(&format!("{}{}", prompt_str, self.prompt_indicator));
+        let prompt_width = line_width(
+            format!("{}{}", self.prompt_str_left, self.prompt_indicator)
+                .lines()
+                .last()
+                .unwrap_or_default(),
+        );
         let buffer_width = line_width(&self.before_cursor);
 
         let total_width = prompt_width + buffer_width;


### PR DESCRIPTION
fixes a bug from #696