### PR TITLE
Clipboard graceful handling

### DIFF
--- a/src/core_editor/clip_buffer.rs
+++ b/src/core_editor/clip_buffer.rs
@@ -62,10 +62,7 @@ pub use system_clipboard::SystemClipboard;
 /// Disabled -> [`LocalClipboard`], which supports cutting and pasting limited to the [`crate::Reedline`] instance
 pub fn get_default_clipboard() -> Box<dyn Clipboard> {
     SystemClipboard::new().map_or_else(
-        |_e| {
-            eprintln!("Defaulting to local clipboard!");
-            Box::new(LocalClipboard::new()) as Box<dyn Clipboard>
-        },
+        |_e| Box::new(LocalClipboard::new()) as Box<dyn Clipboard>,
         |cb| Box::new(cb),
     )
 }

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -18,7 +18,7 @@ impl Default for Editor {
     fn default() -> Self {
         Editor {
             line_buffer: LineBuffer::new(),
-            cut_buffer: Box::new(get_default_clipboard()),
+            cut_buffer: get_default_clipboard(),
             edit_stack: EditStack::new(),
             last_undo_behavior: UndoBehavior::CreateUndoPoint,
             selection_anchor: None,


### PR DESCRIPTION
If the `system_clipboard` feature is enabled, gracefully handle the case where the system clipboard can't be accessed and default to `LocalClipboard` in that case instead of panicking. This should help with running nu scripts in a docker container for instance.