### PR TITLE
update history error message

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -11,7 +11,7 @@ pub enum ReedlineErrorVariants {
     HistoryDatabaseError(String),
 
     /// Error within history
-    #[error("error within history: {0}")]
+    #[error("error in Reedline history: {0}")]
     OtherHistoryError(&'static str),
 
     /// History does not support a feature


### PR DESCRIPTION

This makes the history error message much clearer that it is coming from *Reedline*...

Since Reedline is used by many different applications where the end user does not
even know that Reedline is used in the product it gives a better hint to both the developers
of Reedline who are embedding Reedline in their application and the end user who is reporting
back to someone what error message they are seeing...


