### PR TITLE
Print foreground color for indicator and right prompt in large buffers

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -342,12 +342,21 @@ impl Painter {
         self.stdout.queue(Print(&coerce_crlf(prompt_skipped)))?;
 
         if extra_rows == 0 {
+            if use_ansi_coloring {
+                self.stdout
+                    .queue(SetForegroundColor(prompt.get_prompt_right_color()))?;
+            }
+
             self.print_right_prompt(lines)?;
         }
 
         // Adjusting extra_rows base on the calculated prompt line size
         let extra_rows = extra_rows.saturating_sub(prompt_lines);
 
+        if use_ansi_coloring {
+            self.stdout
+                .queue(SetForegroundColor(prompt.get_indicator_color()))?;
+        }
         let indicator_skipped = skip_buffer_lines(&lines.prompt_indicator, extra_rows, None);
         self.stdout.queue(Print(&coerce_crlf(indicator_skipped)))?;
 


### PR DESCRIPTION
Fixes #727

Previously, when printing large buffers, the foreground color for the prompt indicator and right prompt wasn't printed.

Below is the original behavior. You can see that with a small buffer that doesn't fill up the whole screen, the menu indicator (`|`) is blue and the right prompt is purple, as expected. But with a large buffer, both become green.

[![asciicast](https://asciinema.org/a/D9bu9pnpHYziMyUsrAe8Azmoz.svg)](https://asciinema.org/a/D9bu9pnpHYziMyUsrAe8Azmoz)

Below is the new behavior. The menu marker and right prompt are the expected colors even with a large buffer.

[![asciicast](https://asciinema.org/a/RHfh4dfkZttJ3VTAHekk69KND.svg)](https://asciinema.org/a/RHfh4dfkZttJ3VTAHekk69KND)