### PR TITLE
Add a way to disable the prompt

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -487,6 +487,12 @@ impl Reedline {
         self.transient_prompt = Some(transient_prompt);
         self
     }
+    /// Remove the current prompt
+    #[must_use]
+    pub fn disable_transient_prompt(mut self) -> Self {
+        self.transient_prompt = None;
+        self
+    }
 
     /// A builder which configures the edit mode for your instance of the Reedline engine
     #[must_use]


### PR DESCRIPTION
This is part of work to simplify [this nushell PR](https://github.com/nushell/nushell/pull/11288). Clearing out the prompt removes a reference to the stack, letting us avoid a copy