### PR TITLE
Typed text style

### DIFF
--- a/examples/completions.rs
+++ b/examples/completions.rs
@@ -36,10 +36,27 @@ fn main() -> io::Result<()> {
 
     let commands = vec![
         "test".into(),
+        "clear".into(),
+        "exit".into(),
+        "history 1".into(),
+        "history 2".into(),
+        "logout".into(),
+        "login".into(),
         "hello world".into(),
         "hello world reedline".into(),
+        "hello world something".into(),
+        "hello world another".into(),
+        "hello world 1".into(),
+        "hello world 2".into(),
+        "hello another very large option for hello word that will force one column".into(),
         "this is the reedline crate".into(),
+        "abaaabas".into(),
+        "abaaacas".into(),
+        "ababac".into(),
+        "abacaxyc".into(),
+        "abadarabc".into(),
     ];
+    
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands, 2));
 
     // Use the interactive menu to select options from the completer

--- a/examples/completions.rs
+++ b/examples/completions.rs
@@ -56,7 +56,7 @@ fn main() -> io::Result<()> {
         "abacaxyc".into(),
         "abadarabc".into(),
     ];
-    
+
     let completer = Box::new(DefaultCompleter::new_with_wordlen(commands, 2));
 
     // Use the interactive menu to select options from the completer

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -37,6 +37,8 @@ struct ColumnDetails {
     pub columns: u16,
     /// Column width
     pub col_width: usize,
+    /// The shortest of the strings, which the suggestions are based on
+    pub shortest_base_string: String,
 }
 
 /// Menu to present suggestions in a columnar fashion
@@ -296,18 +298,31 @@ impl ColumnarMenu {
         use_ansi_coloring: bool,
     ) -> String {
         if use_ansi_coloring {
+            let match_len = self.working_details.shortest_base_string.len();
+
+            // Split string so the match text can be styled
+            let (match_str, remaining_str) = suggestion.value
+                .split_at(match_len);
+
+            let suggestion_style_prefix = suggestion
+                .style
+                .unwrap_or(self.settings.color.text_style)
+                .prefix();
+
             if index == self.index() {
                 if let Some(description) = &suggestion.description {
                     let left_text_size = self.longest_suggestion + self.default_details.col_padding;
                     let right_text_size = self.get_width().saturating_sub(left_text_size);
                     format!(
-                        "{}{}{:max$}{}{}{}{}{}{}",
-                        suggestion
-                            .style
-                            .unwrap_or(self.settings.color.text_style)
-                            .prefix(),
+                        "{}{}{}{}{}{}{:max$}{}{}{}{}{}{}",
+                        suggestion_style_prefix,
+                        self.settings.color.selected_match_style.prefix(),
+                        match_str,
+                        RESET,
+             
+                        suggestion_style_prefix,
                         self.settings.color.selected_text_style.prefix(),
-                        &suggestion.value,
+                        &remaining_str,
                         RESET,
                         self.settings.color.description_style.prefix(),
                         self.settings.color.selected_text_style.prefix(),
@@ -322,13 +337,15 @@ impl ColumnarMenu {
                     )
                 } else {
                     format!(
-                        "{}{}{}{}{:>empty$}{}",
-                        suggestion
-                            .style
-                            .unwrap_or(self.settings.color.text_style)
-                            .prefix(),
+                        "{}{}{}{}{}{}{}{}{:>empty$}{}",
+                        suggestion_style_prefix,
+                        self.settings.color.selected_match_style.prefix(),
+                        match_str,
+                        RESET,
+
+                        suggestion_style_prefix,
                         self.settings.color.selected_text_style.prefix(),
-                        &suggestion.value,
+                        remaining_str,
                         RESET,
                         "",
                         self.end_of_line(column),
@@ -339,12 +356,14 @@ impl ColumnarMenu {
                 let left_text_size = self.longest_suggestion + self.default_details.col_padding;
                 let right_text_size = self.get_width().saturating_sub(left_text_size);
                 format!(
-                    "{}{:max$}{}{}{}{}{}",
-                    suggestion
-                        .style
-                        .unwrap_or(self.settings.color.text_style)
-                        .prefix(),
-                    &suggestion.value,
+                    "{}{}{}{}{}{:max$}{}{}{}{}{}",
+                    suggestion_style_prefix,
+                    self.settings.color.match_style.prefix(),
+                    match_str,
+                    RESET,
+
+                    suggestion_style_prefix,
+                    remaining_str,
                     RESET,
                     self.settings.color.description_style.prefix(),
                     description
@@ -358,12 +377,14 @@ impl ColumnarMenu {
                 )
             } else {
                 format!(
-                    "{}{}{}{}{:>empty$}{}{}",
-                    suggestion
-                        .style
-                        .unwrap_or(self.settings.color.text_style)
-                        .prefix(),
-                    &suggestion.value,
+                    "{}{}{}{}{}{}{}{}{:>empty$}{}{}",
+                    suggestion_style_prefix,
+                    self.settings.color.match_style.prefix(),
+                    match_str,
+                    RESET,
+
+                    suggestion_style_prefix,
+                    remaining_str,
                     RESET,
                     self.settings.color.description_style.prefix(),
                     "",
@@ -476,7 +497,15 @@ impl Menu for ColumnarMenu {
             self.input.as_deref(),
             self.settings.only_buffer_difference,
         );
-        self.values = completer.complete(&input, pos);
+
+        let (values, base_ranges) = completer.complete_with_base_ranges(&input, pos);
+        
+        self.values = values;
+        self.working_details.shortest_base_string = base_ranges
+            .iter()
+            .map(|range| editor.get_buffer()[range.clone()].to_string())
+            .min_by_key(|s| s.len())
+            .unwrap_or_default();
 
         self.reset_position();
     }

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -301,8 +301,7 @@ impl ColumnarMenu {
             let match_len = self.working_details.shortest_base_string.len();
 
             // Split string so the match text can be styled
-            let (match_str, remaining_str) = suggestion.value
-                .split_at(match_len);
+            let (match_str, remaining_str) = suggestion.value.split_at(match_len);
 
             let suggestion_style_prefix = suggestion
                 .style
@@ -319,7 +318,6 @@ impl ColumnarMenu {
                         self.settings.color.selected_match_style.prefix(),
                         match_str,
                         RESET,
-             
                         suggestion_style_prefix,
                         self.settings.color.selected_text_style.prefix(),
                         &remaining_str,
@@ -342,7 +340,6 @@ impl ColumnarMenu {
                         self.settings.color.selected_match_style.prefix(),
                         match_str,
                         RESET,
-
                         suggestion_style_prefix,
                         self.settings.color.selected_text_style.prefix(),
                         remaining_str,
@@ -361,7 +358,6 @@ impl ColumnarMenu {
                     self.settings.color.match_style.prefix(),
                     match_str,
                     RESET,
-
                     suggestion_style_prefix,
                     remaining_str,
                     RESET,
@@ -382,7 +378,6 @@ impl ColumnarMenu {
                     self.settings.color.match_style.prefix(),
                     match_str,
                     RESET,
-
                     suggestion_style_prefix,
                     remaining_str,
                     RESET,
@@ -499,7 +494,7 @@ impl Menu for ColumnarMenu {
         );
 
         let (values, base_ranges) = completer.complete_with_base_ranges(&input, pos);
-        
+
         self.values = values;
         self.working_details.shortest_base_string = base_ranges
             .iter()

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -513,10 +513,9 @@ impl IdeMenu {
 
         if use_ansi_coloring {
             let match_len = self.working_details.shortest_base_string.len();
-            
+
             // Split string so the match text can be styled
-            let (match_str, remaining_str) = string
-                .split_at(match_len);
+            let (match_str, remaining_str) = string.split_at(match_len);
 
             let suggestion_style_prefix = suggestion
                 .style
@@ -532,7 +531,6 @@ impl IdeMenu {
                     self.settings.color.selected_match_style.prefix(),
                     match_str,
                     RESET,
-
                     suggestion_style_prefix,
                     self.settings.color.selected_text_style.prefix(),
                     remaining_str,
@@ -549,7 +547,6 @@ impl IdeMenu {
                     self.settings.color.match_style.prefix(),
                     match_str,
                     RESET,
-
                     suggestion_style_prefix,
                     self.settings.color.text_style.prefix(),
                     remaining_str,
@@ -700,9 +697,7 @@ impl Menu for IdeMenu {
             let mut cursor_pos = self.working_details.cursor_col;
 
             if self.default_details.correct_cursor_pos {
-                let base_string = &self
-                    .working_details
-                    .shortest_base_string;
+                let base_string = &self.working_details.shortest_base_string;
 
                 cursor_pos = cursor_pos.saturating_sub(base_string.width() as u16);
             }

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -540,7 +540,7 @@ impl IdeMenu {
                 )
             } else {
                 format!(
-                    "{}{}{}{}{}{}{}{}{}{}{}{}",
+                    "{}{}{}{}{}{}{}{}{}{}{}",
                     vertical_border,
                     suggestion_style_prefix,
                     " ".repeat(padding),
@@ -548,7 +548,6 @@ impl IdeMenu {
                     match_str,
                     RESET,
                     suggestion_style_prefix,
-                    self.settings.color.text_style.prefix(),
                     remaining_str,
                     " ".repeat(padding_right),
                     RESET,

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -36,13 +36,8 @@ impl Default for MenuTextStyle {
             selected_text_style: Color::Green.bold().reverse(),
             text_style: Color::DarkGray.normal(),
             description_style: Color::Yellow.normal(),
-            selected_match_style: {
-                let mut style = Color::Green.bold().reverse().underline();
-                // LightBlue text color
-                style.background = Some(Color::LightBlue);
-                style
-            },
-            match_style: Color::DarkGray.normal().underline(),
+            selected_match_style: Color::Green.bold().reverse().underline(),
+            match_style: Style::default().underline(),
         }
     }
 }

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -22,6 +22,12 @@ pub struct MenuTextStyle {
     pub text_style: Style,
     /// Text style for the item description
     pub description_style: Style,
+    /// Text style of the parts of the suggestions that match the
+    /// typed text when the suggestion is selected
+    pub selected_match_style: Style,
+    /// Text style of the parts of the suggestions that match the
+    /// typed text
+    pub match_style: Style,
 }
 
 impl Default for MenuTextStyle {
@@ -30,6 +36,13 @@ impl Default for MenuTextStyle {
             selected_text_style: Color::Green.bold().reverse(),
             text_style: Color::DarkGray.normal(),
             description_style: Color::Yellow.normal(),
+            selected_match_style: {
+                let mut style = Color::Green.bold().reverse().underline();
+                // LightBlue text color
+                style.background = Some(Color::LightBlue);
+                style
+            },
+            match_style: Color::DarkGray.normal().underline(),
         }
     }
 }


### PR DESCRIPTION
closes #724

Adds ``selected_match_style`` and ``match_style`` to ``MenuTextStyle``.

IdeMenu
![grafik](https://github.com/nushell/reedline/assets/104733404/375c7b90-89f0-4fdf-9e7d-9f9357c7574d)

ColumnarMenu
![grafik](https://github.com/nushell/reedline/assets/104733404/9167f8dc-345f-401e-8ea0-5127e63001b9)
