### PR TITLE
Add `History::delete` for `FileBackedHistory`

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -176,7 +176,7 @@ fn main() -> reedline::Result<()> {
                     continue;
                 }
                 // Delete history entry of a certain id
-                if buffer.trim().starts_with("history delete-item") {
+                if buffer.trim().starts_with("history remove-item") {
                     let parts: Vec<&str> = buffer.split_whitespace().collect();
                     if parts.len() == 3 {
                         if let Ok(id) = parts[2].parse::<i64>() {
@@ -184,7 +184,7 @@ fn main() -> reedline::Result<()> {
                             continue;
                         }
                     }
-                    println!("Invalid command. Use: history delete <id>");
+                    println!("Invalid command. Use: history remove-item <id>");
                     continue;
                 }
                 // Get this history session identifier

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -16,7 +16,7 @@ use {
 
 #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
 use reedline::FileBackedHistory;
-use reedline::{CursorConfig, MenuBuilder};
+use reedline::{CursorConfig, HistoryItemId, MenuBuilder};
 
 fn main() -> reedline::Result<()> {
     println!("Ctrl-D to quit");
@@ -173,6 +173,18 @@ fn main() -> reedline::Result<()> {
                 // Get the history only pertinent to the current session
                 if buffer.trim() == "history session" {
                     line_editor.print_history_session()?;
+                    continue;
+                }
+                // Delete history entry of a certain id
+                if buffer.trim().starts_with("history delete-item") {
+                    let parts: Vec<&str> = buffer.split_whitespace().collect();
+                    if parts.len() == 3 {
+                        if let Ok(id) = parts[2].parse::<i64>() {
+                            line_editor.history_mut().delete(HistoryItemId::new(id))?;
+                            continue;
+                        }
+                    }
+                    println!("Invalid command. Use: history delete <id>");
                     continue;
                 }
                 // Get this history session identifier

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -536,8 +536,9 @@ impl Reedline {
             .search(SearchQuery::everything(SearchDirection::Forward, None))
             .expect("todo: error handling");
 
-        for (i, entry) in history.iter().enumerate() {
-            self.print_line(&format!("{}\t{}", i, entry.command_line))?;
+        for entry in history.iter() {
+            let Some(id) = entry.id else { continue };
+            self.print_line(&format!("{}\t{}", id, entry.command_line))?;
         }
         Ok(())
     }

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -223,9 +223,11 @@ impl History for FileBackedHistory {
         Ok(())
     }
 
-    /// Writes unwritten history contents to disk.
+    /// Syncs current state with disk.
     ///
+    /// Normally, that means reading entries from the file and appending new entries to it.
     /// If file would exceed `capacity` truncates the oldest entries.
+    /// If necessary, the whole file is overwritten.
     fn sync(&mut self) -> std::io::Result<()> {
         if let Some(fname) = &self.file {
             if let Some(base_dir) = fname.parent() {

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -205,13 +205,20 @@ impl History for FileBackedHistory {
         Ok(())
     }
 
-    fn delete(&mut self, _h: super::HistoryItemId) -> Result<()> {
-        Err(ReedlineError(
-            ReedlineErrorVariants::HistoryFeatureUnsupported {
-                history: "FileBackedHistory",
-                feature: "removing entries",
-            },
-        ))
+    fn delete(&mut self, h: super::HistoryItemId) -> Result<()> {
+        let id = h.0 as usize;
+        let num_entries = self.entries.len();
+        // Check if the id is valid
+        if id >= num_entries {
+            return Err(ReedlineError(ReedlineErrorVariants::OtherHistoryError(
+                "Given id is out of range.",
+            )));
+        }
+
+        // Remove the item with the specified id
+        self.entries.remove(id);
+
+        Ok(())
     }
 
     /// Writes unwritten history contents to disk.


### PR DESCRIPTION
- Add `History::delete` for `FileBackedHistory`
- Adapt `history` to print id rather than just consecutive numbers
- Add `history remove-item <id>` to demo

See also https://github.com/nushell/nushell/pull/11629