### PR TITLE
External printer API rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,62 +147,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
 name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,7 +665,6 @@ version = "0.28.0"
 dependencies = [
  "arboard",
  "chrono",
- "crossbeam",
  "crossterm",
  "fd-lock",
  "gethostname 0.4.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ chrono = { version = "0.4.19", default-features = false, features = [
     "clock",
     "serde",
 ] }
-crossbeam = { version = "0.8.2", optional = true }
 crossterm = { version = "0.27.0", features = ["serde"] }
 fd-lock = "3.0.3"
 itertools = "0.12.0"
@@ -41,7 +40,7 @@ tempfile = "3.3.0"
 
 [features]
 bashisms = []
-external_printer = ["crossbeam"]
+external_printer = []
 sqlite = ["rusqlite/bundled", "serde_json"]
 sqlite-dynlib = ["rusqlite", "serde_json"]
 system_clipboard = ["arboard"]

--- a/examples/external_printer.rs
+++ b/examples/external_printer.rs
@@ -3,47 +3,46 @@
 // cargo run --example external_printer --features=external_printer
 
 use {
-    reedline::{DefaultPrompt, ExternalPrinterChannel, Reedline, Signal},
+    reedline::{DefaultPrompt, ExternalPrinter, Reedline, Signal},
     std::thread,
     std::thread::sleep,
     std::time::Duration,
 };
 
 fn main() {
-    // Create a channel for the external printer.
-    let channel = ExternalPrinterChannel::default();
+    let printer = ExternalPrinter::new();
 
-    // Get a clone of the channel sender to use in a separate thread.
-    let printer = channel.sender();
+    // Get a clone of the sender to use in a separate thread.
+    let sender = printer.sender();
 
-    // Note that the senders/printers can also be cloned.
-    // let printer_clone = printer.clone();
+    // Note that the senders can also be cloned.
+    // let sender_clone = sender.clone();
 
     // external printer that prints a message every second
     thread::spawn(move || {
         let mut i = 1;
         loop {
             sleep(Duration::from_secs(1));
-            assert!(printer
-                .print(format!("Message {i} delivered.\nWith two lines!"))
+            assert!(sender
+                .send(format!("Message {i} delivered.\nWith two lines!").into())
                 .is_ok());
             i += 1;
         }
     });
 
-    let printer = channel.sender();
+    let sender = printer.sender();
 
     // external printer that prints a bunch of messages after 3 seconds
     thread::spawn(move || {
         sleep(Duration::from_secs(3));
         for _ in 0..10 {
             sleep(Duration::from_millis(1));
-            assert!(printer.print("Hello!").is_ok());
+            assert!(sender.send("Hello!".into()).is_ok());
         }
     });
 
-    // create a `Reedline` struct and assign the channel for the external printer
-    let mut line_editor = Reedline::create().with_external_printer(channel);
+    // create a `Reedline` struct and assign the external printer
+    let mut line_editor = Reedline::create().with_external_printer(printer);
     let prompt = DefaultPrompt::default();
 
     loop {

--- a/examples/external_printer.rs
+++ b/examples/external_printer.rs
@@ -3,42 +3,47 @@
 // cargo run --example external_printer --features=external_printer
 
 use {
-    reedline::ExternalPrinter,
-    reedline::{DefaultPrompt, Reedline, Signal},
+    reedline::{DefaultPrompt, ExternalPrinterChannel, Reedline, Signal},
     std::thread,
     std::thread::sleep,
     std::time::Duration,
 };
 
 fn main() {
-    let printer = ExternalPrinter::default();
-    // make a clone to use it in a different thread
-    let p_clone = printer.clone();
-    // get the Sender<String> to have full sending control
-    let p_sender = printer.sender();
+    // Create a channel for the external printer.
+    let channel = ExternalPrinterChannel::default();
+
+    // Get a clone of the channel sender to use in a separate thread.
+    let printer = channel.sender();
+
+    // Note that the senders/printers can also be cloned.
+    // let printer_clone = printer.clone();
 
     // external printer that prints a message every second
     thread::spawn(move || {
         let mut i = 1;
         loop {
             sleep(Duration::from_secs(1));
-            assert!(p_clone
+            assert!(printer
                 .print(format!("Message {i} delivered.\nWith two lines!"))
                 .is_ok());
             i += 1;
         }
     });
 
+    let printer = channel.sender();
+
     // external printer that prints a bunch of messages after 3 seconds
     thread::spawn(move || {
         sleep(Duration::from_secs(3));
         for _ in 0..10 {
             sleep(Duration::from_millis(1));
-            assert!(p_sender.send("Fast Hello !".to_string()).is_ok());
+            assert!(printer.print("Hello!").is_ok());
         }
     });
 
-    let mut line_editor = Reedline::create().with_external_printer(printer);
+    // create a `Reedline` struct and assign the channel for the external printer
+    let mut line_editor = Reedline::create().with_external_printer(channel);
     let prompt = DefaultPrompt::default();
 
     loop {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -677,10 +677,9 @@ impl Reedline {
             #[cfg(feature = "external_printer")]
             if let Some(channel) = &self.external_printer_channel {
                 // get messages from printer as crlf separated "lines"
-                let messages = channel.messages();
-                if !messages.is_empty() {
+                if !channel.receiver().is_empty() {
                     self.painter.print_external_message(
-                        messages,
+                        channel,
                         self.editor.line_buffer(),
                         prompt,
                     )?;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -676,7 +676,6 @@ impl Reedline {
 
             #[cfg(feature = "external_printer")]
             if let Some(channel) = &self.external_printer_channel {
-                // get messages from printer as crlf separated "lines"
                 if !channel.receiver().is_empty() {
                     self.painter.print_external_message(
                         channel,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -689,7 +689,11 @@ impl Reedline {
             }
 
             let mut latest_resize = None;
-            loop {
+
+            // There could be multiple events queued up!
+            // pasting text, resizes, blocking this thread (e.g. during debugging)
+            // We should be able to handle all of them as quickly as possible without causing unnecessary output steps.
+            while event::poll(Duration::from_millis(POLL_WAIT))? {
                 match event::read()? {
                     Event::Resize(x, y) => {
                         latest_resize = Some((x, y));
@@ -717,13 +721,6 @@ impl Reedline {
                             crossterm_events.push(evt);
                         }
                     }
-                }
-
-                // There could be multiple events queued up!
-                // pasting text, resizes, blocking this thread (e.g. during debugging)
-                // We should be able to handle all of them as quickly as possible without causing unnecessary output steps.
-                if !event::poll(Duration::from_millis(POLL_WAIT))? {
-                    break;
                 }
             }
 

--- a/src/external_printer.rs
+++ b/src/external_printer.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crossbeam::channel::{bounded, Receiver, SendError, Sender, TryRecvError};
+use crossbeam::channel::{bounded, Receiver, SendError, Sender};
 
 /// The channel to which external messages can be sent
 ///
@@ -43,24 +43,8 @@ impl ExternalPrinterChannel {
         ExternalPrinter(self.sender.clone())
     }
 
-    pub(crate) fn messages(&self) -> Vec<String> {
-        // TODO: refactor to use `self.receiver.try_iter()`
-        let mut messages = Vec::new();
-        loop {
-            match self.receiver.try_recv() {
-                Ok(string) => {
-                    messages.extend(string.lines().map(String::from));
-                }
-                Err(TryRecvError::Empty) => {
-                    break;
-                }
-                Err(TryRecvError::Disconnected) => {
-                    debug_assert!(false); // there is always one sender in `self`.
-                    break;
-                }
-            }
-        }
-        messages
+    pub(crate) fn receiver(&self) -> &Receiver<String> {
+        &self.receiver
     }
 }
 

--- a/src/external_printer.rs
+++ b/src/external_printer.rs
@@ -1,72 +1,80 @@
-//! To print messages while editing a line
-//!
-//! See example:
-//!
-//! ``` shell
-//! cargo run --example external_printer --features=external_printer
-//! ```
-#[cfg(feature = "external_printer")]
-use {
-    crossbeam::channel::{bounded, Receiver, SendError, Sender},
-    std::fmt::Display,
-};
+use std::fmt::Display;
 
-#[cfg(feature = "external_printer")]
-pub const EXTERNAL_PRINTER_DEFAULT_CAPACITY: usize = 20;
+use crossbeam::channel::{bounded, Receiver, SendError, Sender, TryRecvError};
 
-/// An ExternalPrinter allows to print messages of text while editing a line.
-/// The message is printed as a new line, the line-edit will continue below the
-/// output.
+/// An external printer allows one to print messages of text while editing a line.
+/// The message is printed as a new line, and the line-edit will continue below the output.
 ///
 /// ## Required feature:
 /// `external_printer`
-#[cfg(feature = "external_printer")]
-#[derive(Debug, Clone)]
-pub struct ExternalPrinter<T>
-where
-    T: Display,
-{
-    sender: Sender<T>,
-    receiver: Receiver<T>,
+#[derive(Debug)]
+pub struct ExternalPrinterChannel {
+    sender: Sender<String>,
+    receiver: Receiver<String>,
 }
 
-#[cfg(feature = "external_printer")]
-impl<T> ExternalPrinter<T>
-where
-    T: Display,
-{
-    /// Creates an ExternalPrinter to store lines with a max_cap
-    pub fn new(max_cap: usize) -> Self {
-        let (sender, receiver) = bounded::<T>(max_cap);
+impl ExternalPrinterChannel {
+    pub const DEFAULT_CAPACITY: usize = 20;
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        let (sender, receiver) = bounded(capacity);
         Self { sender, receiver }
     }
-    /// Gets a Sender to use the printer externally by sending lines to it
-    pub fn sender(&self) -> Sender<T> {
-        self.sender.clone()
-    }
-    /// Receiver to get messages if any
-    pub fn receiver(&self) -> &Receiver<T> {
-        &self.receiver
+
+    pub fn sender(&self) -> ExternalPrinter {
+        ExternalPrinter(self.sender.clone())
     }
 
-    /// Convenience method if the whole Printer is cloned, blocks if max_cap is reached.
-    ///
-    pub fn print(&self, line: T) -> Result<(), SendError<T>> {
-        self.sender.send(line)
-    }
-
-    /// Convenience method to get a line if any, doesn´t block.
-    pub fn get_line(&self) -> Option<T> {
-        self.receiver.try_recv().ok()
+    pub(crate) fn messages(&self) -> Vec<String> {
+        let mut messages = Vec::new();
+        loop {
+            match self.receiver.try_recv() {
+                Ok(string) => {
+                    messages.extend(string.lines().map(String::from));
+                }
+                Err(TryRecvError::Empty) => {
+                    break;
+                }
+                Err(TryRecvError::Disconnected) => {
+                    debug_assert!(false); // there is always one sender in `self`.
+                    break;
+                }
+            }
+        }
+        messages
     }
 }
 
-#[cfg(feature = "external_printer")]
-impl<T> Default for ExternalPrinter<T>
-where
-    T: Display,
-{
+impl Default for ExternalPrinterChannel {
     fn default() -> Self {
-        Self::new(EXTERNAL_PRINTER_DEFAULT_CAPACITY)
+        Self::with_capacity(Self::DEFAULT_CAPACITY)
+    }
+}
+
+/// An external printer allows one to print messages of text while editing a line.
+/// The message is printed as a new line, and the line-edit will continue below the output.
+///
+/// ## Required feature:
+/// `external_printer`
+#[derive(Debug, Clone)]
+pub struct ExternalPrinter(Sender<String>);
+
+impl ExternalPrinter {
+    /// Queues a string message to be printed
+    ///
+    /// This function blocks if the underlying channel is full.
+    pub fn print(&self, string: impl Into<String>) -> Result<(), String> {
+        self.0.send(string.into()).map_err(|SendError(s)| s)
+    }
+
+    /// Queues a value to be printed via its [`Display`] implementation
+    ///
+    /// This function blocks if the underlying channel is full.
+    pub fn display<T: Display>(&self, value: &T) -> Result<(), String> {
+        self.print(value.to_string())
     }
 }

--- a/src/external_printer.rs
+++ b/src/external_printer.rs
@@ -2,6 +2,10 @@ use std::fmt::Display;
 
 use crossbeam::channel::{bounded, Receiver, SendError, Sender, TryRecvError};
 
+/// The channel to which external messages can be sent
+///
+/// Use the [`sender`](Self::sender) to create [`ExternalPrinter`]s for use in other threads.
+///
 /// An external printer allows one to print messages of text while editing a line.
 /// The message is printed as a new line, and the line-edit will continue below the output.
 ///
@@ -14,22 +18,33 @@ pub struct ExternalPrinterChannel {
 }
 
 impl ExternalPrinterChannel {
+    /// The default maximum number of lines that can be queued up for printing
+    ///
+    /// If the channel is full, calls to [`ExternalPrinter::print`] will block
+    /// and wait for the channel to have spare capacity again.
     pub const DEFAULT_CAPACITY: usize = 20;
 
+    /// Create a new `ExternalPrinterChannel` with default capacity
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Create a new `ExternalPrinterChannel` with the given capacity
+    ///
+    /// The capacity determines the maximum number of lines that can be queued up for printing
+    /// before subsequent calls to [`ExternalPrinter::print`] will block.
     pub fn with_capacity(capacity: usize) -> Self {
         let (sender, receiver) = bounded(capacity);
         Self { sender, receiver }
     }
 
+    /// Returns a new [`ExternalPrinter`] which can be used in other threads to queue messages to print
     pub fn sender(&self) -> ExternalPrinter {
         ExternalPrinter(self.sender.clone())
     }
 
     pub(crate) fn messages(&self) -> Vec<String> {
+        // TODO: refactor to use `self.receiver.try_iter()`
         let mut messages = Vec::new();
         loop {
             match self.receiver.try_recv() {
@@ -55,6 +70,11 @@ impl Default for ExternalPrinterChannel {
     }
 }
 
+/// An [`ExternalPrinter`] queue messages for printing by sending them to an [`ExternalPrinterChannel`]
+///
+/// [`ExternalPrinter`] are created through [`ExternalPrinterChannel::sender`]
+/// or by cloning an existing [`ExternalPrinter`].
+///
 /// An external printer allows one to print messages of text while editing a line.
 /// The message is printed as a new line, and the line-edit will continue below the output.
 ///
@@ -66,15 +86,38 @@ pub struct ExternalPrinter(Sender<String>);
 impl ExternalPrinter {
     /// Queues a string message to be printed
     ///
-    /// This function blocks if the underlying channel is full.
+    /// This will block if the corresponding [`ExternalPrinterChannel`] is full.
+    /// Also, if the channel has been dropped,
+    /// then the `String` message that would have been sent is returned as an `Err`.
+    ///
+    /// To print any type that implements [`Display`] use [`display`](Self::display).
     pub fn print(&self, string: impl Into<String>) -> Result<(), String> {
         self.0.send(string.into()).map_err(|SendError(s)| s)
     }
 
-    /// Queues a value to be printed via its [`Display`] implementation
+    /// Queues a value to be printed, using the result of its [`Display`] implementation as the message
     ///
-    /// This function blocks if the underlying channel is full.
+    /// This will block if the corresponding [`ExternalPrinterChannel`] is full.
+    /// Also, if the channel has been dropped,
+    /// then the `String` message that would have been sent is returned as an `Err`.
+    ///
+    /// If `T` is a string-like type, use [`print`](Self::display) instead,
+    /// since it can be more efficient.
     pub fn display<T: Display>(&self, value: &T) -> Result<(), String> {
         self.print(value.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thread_safe() {
+        fn send_sync<T: Send + Sync>(_: &T) {}
+
+        let channel = ExternalPrinterChannel::new();
+        send_sync(&channel);
+        send_sync(&channel.sender())
     }
 }

--- a/src/external_printer.rs
+++ b/src/external_printer.rs
@@ -1,46 +1,39 @@
-use std::fmt::Display;
+use std::sync::mpsc::{self, Receiver, SyncSender};
 
-use crossbeam::channel::{bounded, Receiver, SendError, Sender};
-
-/// The channel to which external messages can be sent
-///
-/// Use the [`sender`](Self::sender) to create [`ExternalPrinter`]s for use in other threads.
-///
 /// An external printer allows one to print messages of text while editing a line.
 /// The message is printed as a new line, and the line-edit will continue below the output.
+///
+/// Use [`sender`](Self::sender) to receive a [`SyncSender`] for use in other threads.
 ///
 /// ## Required feature:
 /// `external_printer`
 #[derive(Debug)]
-pub struct ExternalPrinterChannel {
-    sender: Sender<Vec<u8>>,
+pub struct ExternalPrinter {
+    sender: SyncSender<Vec<u8>>,
     receiver: Receiver<Vec<u8>>,
 }
 
-impl ExternalPrinterChannel {
+impl ExternalPrinter {
     /// The default maximum number of lines that can be queued up for printing
-    ///
-    /// If the channel is full, calls to [`ExternalPrinter::print`] will block
-    /// and wait for the channel to have spare capacity again.
     pub const DEFAULT_CAPACITY: usize = 20;
 
-    /// Create a new `ExternalPrinterChannel` with default capacity
+    /// Create a new `ExternalPrinter` with the [default capacity](Self::DEFAULT_CAPACITY)
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Create a new `ExternalPrinterChannel` with the given capacity
+    /// Create a new `ExternalPrinter` with the given capacity
     ///
     /// The capacity determines the maximum number of lines that can be queued up for printing
-    /// before subsequent calls to [`ExternalPrinter::print`] will block.
+    /// before subsequent [`send`](SyncSender::send) calls on the [`sender`](Self::sender) will block.
     pub fn with_capacity(capacity: usize) -> Self {
-        let (sender, receiver) = bounded(capacity);
+        let (sender, receiver) = mpsc::sync_channel(capacity);
         Self { sender, receiver }
     }
 
-    /// Returns a new [`ExternalPrinter`] which can be used in other threads to queue messages to print
-    pub fn sender(&self) -> ExternalPrinter {
-        ExternalPrinter(self.sender.clone())
+    /// Returns a new [`SyncSender`] which can be used in other threads to queue messages to print
+    pub fn sender(&self) -> SyncSender<Vec<u8>> {
+        self.sender.clone()
     }
 
     pub(crate) fn receiver(&self) -> &Receiver<Vec<u8>> {
@@ -48,61 +41,9 @@ impl ExternalPrinterChannel {
     }
 }
 
-impl Default for ExternalPrinterChannel {
+impl Default for ExternalPrinter {
     fn default() -> Self {
         Self::with_capacity(Self::DEFAULT_CAPACITY)
-    }
-}
-
-/// An [`ExternalPrinter`] queue messages for printing by sending them to an [`ExternalPrinterChannel`]
-///
-/// [`ExternalPrinter`] are created through [`ExternalPrinterChannel::sender`]
-/// or by cloning an existing [`ExternalPrinter`].
-///
-/// An external printer allows one to print messages of text while editing a line.
-/// The message is printed as a new line, and the line-edit will continue below the output.
-///
-/// ## Required feature:
-/// `external_printer`
-#[derive(Debug, Clone)]
-pub struct ExternalPrinter(Sender<Vec<u8>>);
-
-impl ExternalPrinter {
-    /// Queues a `Vec` of bytes to be written
-    ///
-    /// This will block if the corresponding [`ExternalPrinterChannel`] is full.
-    /// Also, if the channel has been dropped,
-    /// then the `Vec` of bytes that would have been sent are returned as an `Err`.
-    ///
-    /// Sending raw bytes allows non-UTF-8 byte sequences to be printed.
-    /// To send a UTF-8 `String`, prefer [`print`](Self::print) instead.
-    pub fn write(&self, bytes: Vec<u8>) -> Result<(), Vec<u8>> {
-        self.0.send(bytes).map_err(SendError::into_inner)
-    }
-
-    /// Queues a string message to be printed
-    ///
-    /// This will block if the corresponding [`ExternalPrinterChannel`] is full.
-    /// Also, if the channel has been dropped,
-    /// then the `String` message that would have been sent is returned as an `Err`.
-    ///
-    /// To print any type that implements [`Display`] use [`display`](Self::display).
-    pub fn print(&self, string: impl Into<String>) -> Result<(), String> {
-        self.0
-            .send(string.into().into_bytes())
-            .map_err(|SendError(bytes)| String::from_utf8(bytes).expect("valid utf-8"))
-    }
-
-    /// Queues a value to be printed, using the result of its [`Display`] implementation as the message
-    ///
-    /// This will block if the corresponding [`ExternalPrinterChannel`] is full.
-    /// Also, if the channel has been dropped,
-    /// then the `String` message that would have been sent is returned as an `Err`.
-    ///
-    /// If `T` is a string-like type, use [`print`](Self::print) instead,
-    /// since it can be more efficient.
-    pub fn display<T: Display>(&self, value: &T) -> Result<(), String> {
-        self.print(value.to_string())
     }
 }
 
@@ -111,28 +52,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn thread_safe() {
-        fn send_sync<T: Send + Sync>(_: &T) {}
+    fn impls_send() {
+        fn impls_send<T: Send>(_: &T) {}
 
-        let channel = ExternalPrinterChannel::new();
-        send_sync(&channel);
-        send_sync(&channel.sender())
+        let printer = ExternalPrinter::new();
+        impls_send(&printer);
+        impls_send(&printer.sender())
     }
 
     #[test]
     fn receives_message() {
-        let channel = ExternalPrinterChannel::new();
-        let sender = channel.sender();
-        assert!(sender.print("some text").is_ok());
-        assert_eq!(channel.receiver().recv(), Ok("some text".into()))
-    }
-
-    #[test]
-    fn print_error_does_not_panic() {
-        let channel = ExternalPrinterChannel::new();
-        let sender = channel.sender();
-        drop(channel);
-        let res = sender.print("some text");
-        assert_eq!(res, Err("some text".into()))
+        let printer = ExternalPrinter::new();
+        let sender = printer.sender();
+        assert!(sender.send(b"some text".into()).is_ok());
+        assert_eq!(printer.receiver().recv(), Ok(b"some text".into()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,9 +284,12 @@ pub use menu::{
 mod terminal_extensions;
 pub use terminal_extensions::kitty_protocol_available;
 
-mod utils;
-
+#[cfg(feature = "external_printer")]
 mod external_printer;
+#[cfg(feature = "external_printer")]
+pub use external_printer::{ExternalPrinter, ExternalPrinterChannel};
+
+mod utils;
 pub use utils::{
     get_reedline_default_keybindings, get_reedline_edit_commands,
     get_reedline_keybinding_modifiers, get_reedline_keycodes, get_reedline_prompt_edit_modes,
@@ -298,5 +301,3 @@ pub use crossterm::{
     event::{KeyCode, KeyModifiers},
     style::Color,
 };
-#[cfg(feature = "external_printer")]
-pub use external_printer::ExternalPrinter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,7 @@ pub use terminal_extensions::kitty_protocol_available;
 #[cfg(feature = "external_printer")]
 mod external_printer;
 #[cfg(feature = "external_printer")]
-pub use external_printer::{ExternalPrinter, ExternalPrinterChannel};
+pub use external_printer::ExternalPrinter;
 
 mod utils;
 pub use utils::{

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -527,7 +527,11 @@ impl Painter {
         }
 
         let erase_line = format!("\r{}\r", " ".repeat(self.screen_width().into()));
-        for message in channel.receiver().try_iter() {
+        for mut message in channel.receiver().try_iter() {
+            // add a new line for next message
+            // messages that already end in '\n' will have a blank line between it and the next message.
+            message.push(b'\n');
+
             for line in message.split_inclusive(|&b| b == b'\n') {
                 let line = line
                     .strip_suffix(&[b'\n'])
@@ -540,7 +544,7 @@ impl Painter {
                 // The subsequent repaint of the prompt will cause immediate flush anyways.
                 // And if we flush here, every external print causes visible flicker.
                 //
-                // crossterm's `Print` command return true for `is_ansi_code_supported`.
+                // crossterm's `Print` command returns true for `is_ansi_code_supported`.
                 // This means crossterm will use `Print`'s implementation of `Command::write_ansi`
                 // without doing any special handling for ANSI sequences.
                 // So, it's ok for us to do something similar by calling `write_all` directly


### PR DESCRIPTION
This PR brushes up the external printer feature and is motivated by [this nushell PR](https://github.com/nushell/nushell/pull/11696). Notable changes include:
- Uses `std::sync::mpsc` instead of `crossbeam-channel`, since `crossbeam-channel` was merged into `std::sync::mpsc` in Rust 1.67.
- Users can send/print raw bytes instead of only `String`s.
- Reduced intermediate allocations using `Receiver::try_iter`.