### PR TITLE
[WIP] History API rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,8 @@ dependencies = [
  "crossbeam",
  "crossterm",
  "fd-lock",
+ "gethostname",
+ "indexmap",
  "itertools",
  "nu-ansi-term",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -707,6 +718,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,9 +754,11 @@ dependencies = [
  "crossterm",
  "fd-lock",
  "gethostname 0.4.3",
+ "indexmap",
  "itertools",
  "nu-ansi-term",
  "pretty_assertions",
+ "rand",
  "rstest",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "reedline"
 repository = "https://github.com/nushell/reedline"
 rust-version = "1.62.1"
-version = "0.28.0"
+version = "0.29.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,11 @@ strum_macros = "0.25"
 thiserror = "1.0.31"
 unicode-segmentation = "1.9.0"
 unicode-width = "0.1.9"
+rand = { version = "0.8.5", default-features = false, features = [
+    "small_rng",
+    "getrandom",
+] }
+indexmap = "2.2.1"
 
 [dev-dependencies]
 gethostname = "0.4.0"

--- a/examples/cwd_aware_hinter.rs
+++ b/examples/cwd_aware_hinter.rs
@@ -6,14 +6,21 @@
 // pressing "a" hints to abc.
 // Up/Down or Ctrl p/n, to select next/previous match
 
-use std::io;
+use std::{
+    io,
+    sync::atomic::{AtomicI64, Ordering},
+};
+
+use reedline::HistoryItemId;
+
+static COUNTER: AtomicI64 = AtomicI64::new(0);
 
 fn create_item(cwd: &str, cmd: &str, exit_status: i64) -> reedline::HistoryItem {
     use std::time::Duration;
 
     use reedline::HistoryItem;
     HistoryItem {
-        id: None,
+        id: HistoryItemId(COUNTER.fetch_add(1, Ordering::SeqCst)),
         start_timestamp: None,
         command_line: cmd.to_string(),
         session_id: None,
@@ -32,13 +39,13 @@ fn create_filled_example_history(home_dir: &str, orig_dir: &str) -> Box<dyn reed
     #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
     let mut history = Box::new(reedline::SqliteBackedHistory::in_memory().unwrap());
 
-    history.save(create_item(orig_dir, "dummy", 0)).unwrap(); // add dummy item so ids start with 1
-    history.save(create_item(orig_dir, "ls /usr", 0)).unwrap();
-    history.save(create_item(orig_dir, "pwd", 0)).unwrap();
+    history.save(&create_item(orig_dir, "dummy", 0)).unwrap(); // add dummy item so ids start with 1
+    history.save(&create_item(orig_dir, "ls /usr", 0)).unwrap();
+    history.save(&create_item(orig_dir, "pwd", 0)).unwrap();
 
-    history.save(create_item(home_dir, "cat foo", 0)).unwrap();
-    history.save(create_item(home_dir, "ls bar", 0)).unwrap();
-    history.save(create_item(home_dir, "rm baz", 0)).unwrap();
+    history.save(&create_item(home_dir, "cat foo", 0)).unwrap();
+    history.save(&create_item(home_dir, "ls bar", 0)).unwrap();
+    history.save(&create_item(home_dir, "rm baz", 0)).unwrap();
 
     history
 }

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -105,7 +105,7 @@ mod tests {
         let expected_history_size = command_line_history.len();
         let mut history = FileBackedHistory::new(command_line_history.len())?;
         for command_line in command_line_history {
-            history.save(new_history_item(command_line))?;
+            history.save(&new_history_item(command_line))?;
         }
         let input = "git s";
         let mut sut = HistoryCompleter::new(&history);
@@ -144,7 +144,7 @@ mod tests {
     ) -> Result<()> {
         let mut history = FileBackedHistory::new(history_items.len())?;
         for history_item in history_items {
-            history.save(new_history_item(history_item))?;
+            history.save(&new_history_item(history_item))?;
         }
         let mut sut = HistoryCompleter::new(&history);
         let actual: Vec<String> = sut

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -71,14 +71,18 @@ impl<'menu> HistoryCompleter<'menu> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicI64, Ordering};
+
     use rstest::rstest;
 
     use super::*;
     use crate::*;
 
+    static COUNTER: AtomicI64 = AtomicI64::new(0);
+
     fn new_history_item(command_line: &str) -> HistoryItem {
         HistoryItem {
-            id: None,
+            id: HistoryItemId(COUNTER.fetch_add(1, Ordering::SeqCst)),
             start_timestamp: None,
             command_line: command_line.to_string(),
             session_id: None,

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -255,8 +255,8 @@ mod test {
 
         hist.save(&item)?;
 
-        // Ensure the item was correctly inserted
-        assert_eq!(hist.count_all()?, id);
+        // // Ensure the item was correctly inserted
+        // assert_eq!(hist.count_all()?, id);
 
         Ok(())
     }
@@ -452,7 +452,7 @@ mod test {
     #[test]
     fn history_size_zero() -> Result<()> {
         let mut history = crate::FileBackedHistory::new(0)?;
-        history.save(create_item(1, "/home/me", "cd ~/Downloads", 0))?;
+        create_item(&mut history, 1, "/home/me", "cd ~/Downloads", 0)?;
         assert_eq!(history.count_all()?, 0);
         let _ = history.sync();
         history.clear()?;

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -198,8 +198,6 @@ pub trait History: Send {
     /// load a history item by its id
     fn load(&self, id: HistoryItemId) -> Result<HistoryItem>;
 
-    /// retrieves the next unused session id
-
     /// count the results of a query
     fn count(&self, query: SearchQuery) -> Result<u64>;
 
@@ -207,6 +205,7 @@ pub trait History: Send {
     fn count_all(&self) -> Result<u64> {
         self.count(SearchQuery::everything(SearchDirection::Forward, None))
     }
+
     /// return the results of a query
     fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>>;
 
@@ -216,12 +215,16 @@ pub trait History: Send {
         id: HistoryItemId,
         updater: &dyn Fn(HistoryItem) -> HistoryItem,
     ) -> Result<()>;
+
     /// delete all history items
     fn clear(&mut self) -> Result<()>;
+
     /// remove an item from this history
     fn delete(&mut self, h: HistoryItemId) -> Result<()>;
+
     /// ensure that this history is written to disk
     fn sync(&mut self) -> std::io::Result<()>;
+
     /// get the history session id
     fn session(&self) -> Option<HistorySessionId>;
 }

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -42,7 +42,7 @@ pub struct SearchFilter {
     /// Query for the command line content
     pub command_line: Option<CommandLineSearch>,
     /// Considered implementation detail for now
-    pub(crate) not_command_line: Option<String>, // to skip the currently shown value in up-arrow navigation
+    pub not_command_line: Option<String>, // to skip the currently shown value in up-arrow navigation
     /// Filter based on the executing systems hostname
     pub hostname: Option<String>,
     /// Exact filter for the working directory

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -468,27 +468,35 @@ mod tests {
         let expected_truncated_entries = vec!["test 4", "test 5", "test 6", "test 7", "test 8"];
 
         {
+            println!("> Creating writing history...");
             let (mut writing_hist, _) = create_history_at(capacity, &histfile);
             add_text_entries(writing_hist.as_mut(), &initial_entries);
             // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+            println!("> Flushing writing history...");
         }
 
         {
+            println!("> Creating appending history...");
             let (mut appending_hist, _) = create_history_at(capacity, &histfile);
             add_text_entries(appending_hist.as_mut(), &appending_entries);
             // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
             let actual: Vec<_> = get_all_entry_texts(appending_hist.as_ref());
             assert_eq!(expected_appended_entries, actual);
+            println!("> Flushing appending history...");
         }
 
         {
+            println!("> Creating truncating history...");
             let (mut truncating_hist, _) = create_history_at(capacity, &histfile);
             add_text_entries(truncating_hist.as_mut(), &truncating_entries);
             let actual: Vec<_> = get_all_entry_texts(truncating_hist.as_ref());
             assert_eq!(expected_truncated_entries, actual);
             // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
+
+            println!("> Flushing truncating history...");
         }
 
+        println!("> Creating reading history...");
         let (reading_hist, _) = create_history_at(capacity, &histfile);
 
         let actual: Vec<_> = get_all_entry_texts(reading_hist.as_ref());

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -322,6 +322,7 @@ mod tests {
     #[test]
     fn prefix_search_ignores_consecutive_equivalent_entries_going_forwards() -> Result<()> {
         let (mut hist, _) = create_history();
+
         save_from_command_line(hist.as_mut(), "find me once")?;
         save_from_command_line(hist.as_mut(), "test")?;
         save_from_command_line(hist.as_mut(), "find me once")?;
@@ -331,21 +332,26 @@ mod tests {
             HistoryNavigationQuery::PrefixSearch("find".to_string()),
             None,
         );
+
         cursor.back(&*hist)?;
         assert_eq!(
             cursor.string_at_cursor(),
             Some("find me as well".to_string())
         );
+
         cursor.back(&*hist)?;
         cursor.back(&*hist)?;
         assert_eq!(cursor.string_at_cursor(), Some("find me once".to_string()));
+
         cursor.forward(&*hist)?;
         assert_eq!(
             cursor.string_at_cursor(),
             Some("find me as well".to_string())
         );
+
         cursor.forward(&*hist)?;
         assert_eq!(cursor.string_at_cursor(), None);
+
         Ok(())
     }
 

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -549,12 +549,17 @@ mod tests {
         {
             let (mut hist_a, _) = create_history_at(capacity, &histfile);
 
+            assert_eq!(get_all_entry_texts(hist_a.as_ref()), initial_entries);
+
             {
                 let (mut hist_b, _) = create_history_at(capacity, &histfile);
+
+                assert_eq!(get_all_entry_texts(hist_b.as_ref()), initial_entries);
 
                 add_text_entries(hist_b.as_mut(), &entries_b);
                 // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
             }
+
             add_text_entries(hist_a.as_mut(), &entries_a);
             // As `hist` goes out of scope and get's dropped, its contents are flushed to disk
         }

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -58,6 +58,7 @@ impl HistoryCursor {
             filter
         }
     }
+
     fn navigate_in_direction(
         &mut self,
         history: &dyn History,
@@ -67,7 +68,9 @@ impl HistoryCursor {
             // if searching forward but we don't have a starting point, assume we are at the end
             return Ok(());
         }
+
         let start_id = self.current.as_ref().map(|e| e.id);
+
         let mut next = history.search(SearchQuery {
             start_id,
             end_id: None,
@@ -77,12 +80,18 @@ impl HistoryCursor {
             limit: Some(1),
             filter: self.get_search_filter(),
         })?;
+
         if next.len() == 1 {
+            // NOTE: .swap_remove() does not preserve the vector's order
+            // But is *is* faster than .remove() as it completes in O(1)
+            // And given we won't use this vector of results afterwards,
+            // we can use this function without worrying here
             self.current = Some(next.swap_remove(0));
         } else if direction == SearchDirection::Forward {
             // no result and searching forward: we are at the end
             self.current = None;
         }
+
         Ok(())
     }
 
@@ -400,6 +409,7 @@ mod tests {
         }
 
         let (reading_hist, _) = create_history_at(5, &histfile);
+
         let actual = get_all_entry_texts(reading_hist.as_ref());
         assert_eq!(entries, actual);
 

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -1,5 +1,4 @@
 use indexmap::IndexMap;
-use itertools::Itertools;
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 
 use super::{
@@ -360,9 +359,6 @@ impl History for FileBackedHistory {
         }
 
         self.entries = foreign_entries;
-
-        println!("|- Result         : {}", self.entries.values().join(" ; "));
-        println!();
 
         self.last_on_disk = self.entries.last().map(|(id, _)| *id);
 

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -90,7 +90,7 @@ impl History for FileBackedHistory {
             if self.entries.len() == self.capacity {
                 // History is "full", so we delete the oldest entry first,
                 // before adding a new one.
-                self.entries.remove(&HistoryItemId(0));
+                self.entries.shift_remove(&HistoryItemId(0));
             }
 
             self.entries.insert(h.id, entry.to_string());

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -292,6 +292,7 @@ impl History for FileBackedHistory {
         let mut f_lock = fd_lock::RwLock::new(
             OpenOptions::new()
                 .create(true)
+                .truncate(false)
                 .write(true)
                 .read(true)
                 .open(fname)?,

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -62,7 +62,10 @@ fn decode_entry(s: &str) -> std::result::Result<(HistoryItemId, String), &'stati
 
     let id = s[..sep].parse().map_err(|_| "Invalid history item ID")?;
 
-    Ok((HistoryItemId(id), s.replace(NEWLINE_ESCAPE, "\n")))
+    Ok((
+        HistoryItemId(id),
+        s[sep + 1..].replace(NEWLINE_ESCAPE, "\n"),
+    ))
 }
 
 impl History for FileBackedHistory {
@@ -150,57 +153,61 @@ impl History for FileBackedHistory {
             }
         };
 
-        let filter = |(_, (id, cmd)): (usize, (&HistoryItemId, &String))| {
-            if !match &query.filter.command_line {
-                Some(CommandLineSearch::Prefix(p)) => cmd.starts_with(p),
-                Some(CommandLineSearch::Substring(p)) => cmd.contains(p),
-                Some(CommandLineSearch::Exact(p)) => cmd == p,
-                None => true,
-            } {
-                return None;
-            }
-            if let Some(str) = &query.filter.not_command_line {
-                if cmd == str {
-                    return None;
-                }
-            }
-            Some(FileBackedHistory::construct_entry(
-                *id,
-                cmd.to_string(), // todo: this copy might be a perf bottleneck
-            ))
-        };
-
         let from_index = match from_id {
-            Some(from_id) => self.entries.binary_search_keys(&from_id).expect("todo"),
+            Some(from_id) => self.entries.get_index_of(&from_id).expect("todo"),
             None => 0,
         };
 
         let to_index = match to_id {
-            Some(to_id) => self.entries.binary_search_keys(&to_id).expect("todo"),
+            Some(to_id) => self.entries.get_index_of(&to_id).expect("todo"),
             None => self.entries.len().saturating_sub(1),
         };
 
-        if from_index >= to_index {
+        if from_index == to_index {
             return Ok(vec![]);
         }
+
+        assert!(from_index < to_index);
 
         let iter = self
             .entries
             .iter()
-            .enumerate()
             .skip(from_index)
-            .take(to_index - from_index);
+            .take(1 + to_index - from_index);
 
         let limit = match query.limit {
             Some(limit) => usize::try_from(limit).unwrap(),
             None => usize::MAX,
         };
 
-        if let SearchDirection::Backward = query.direction {
-            Ok(iter.rev().filter_map(filter).take(limit).collect())
-        } else {
-            Ok(iter.filter_map(filter).take(limit).collect())
-        }
+        let filter = |(id, cmd): (&HistoryItemId, &String)| {
+            let str_matches = match &query.filter.command_line {
+                Some(CommandLineSearch::Prefix(p)) => cmd.starts_with(p),
+                Some(CommandLineSearch::Substring(p)) => cmd.contains(p),
+                Some(CommandLineSearch::Exact(p)) => cmd == p,
+                None => true,
+            };
+
+            if !str_matches {
+                return None;
+            }
+
+            if let Some(str) = &query.filter.not_command_line {
+                if cmd == str {
+                    return None;
+                }
+            }
+
+            Some(FileBackedHistory::construct_entry(
+                *id,
+                cmd.clone(), // todo: this cloning might be a perf bottleneck
+            ))
+        };
+
+        Ok(match query.direction {
+            SearchDirection::Backward => iter.rev().filter_map(filter).take(limit).collect(),
+            SearchDirection::Forward => iter.filter_map(filter).take(limit).collect(),
+        })
     }
 
     fn update(
@@ -242,87 +249,102 @@ impl History for FileBackedHistory {
     ///
     /// If file would exceed `capacity` truncates the oldest entries.
     fn sync(&mut self) -> std::io::Result<()> {
-        if let Some(fname) = &self.file {
-            // The unwritten entries
-            let last_index_on_disk = match self.last_on_disk {
-                Some(last_id) => self.entries.binary_search_keys(&last_id).unwrap(),
-                None => 0,
-            };
+        let Some(fname) = &self.file else {
+            return Ok(());
+        };
 
-            if last_index_on_disk == self.entries.len() {
-                return Ok(());
+        // The unwritten entries
+        let last_index_on_disk = self
+            .last_on_disk
+            .map(|id| self.entries.get_index_of(&id).unwrap());
+
+        let range_start = match last_index_on_disk {
+            Some(index) => index + 1,
+            None => 0,
+        };
+
+        let own_entries = self.entries.get_range(range_start..).unwrap();
+
+        if let Some(base_dir) = fname.parent() {
+            std::fs::create_dir_all(base_dir)?;
+        }
+
+        let mut f_lock = fd_lock::RwLock::new(
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .read(true)
+                .open(fname)?,
+        );
+
+        let mut writer_guard = f_lock.write()?;
+
+        let (mut foreign_entries, truncate) = {
+            let reader = BufReader::new(writer_guard.deref());
+
+            let mut from_file = reader
+                .lines()
+                .map(|o| o.map(|i| decode_entry(&i).expect("todo: error handling")))
+                .collect::<std::io::Result<IndexMap<_, _>>>()?;
+
+            if from_file.len() + own_entries.len() > self.capacity {
+                (
+                    from_file.split_off(from_file.len() - (self.capacity - own_entries.len())),
+                    true,
+                )
+            } else {
+                (from_file, false)
             }
+        };
 
-            let own_entries = self.entries.get_range(last_index_on_disk..).unwrap();
+        {
+            let mut writer = BufWriter::new(writer_guard.deref_mut());
 
-            if let Some(base_dir) = fname.parent() {
-                std::fs::create_dir_all(base_dir)?;
-            }
+            // In case of truncation, we first write every foreign entry (replacing existing content)
+            if truncate {
+                writer.rewind()?;
 
-            let mut f_lock = fd_lock::RwLock::new(
-                OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .read(true)
-                    .open(fname)?,
-            );
-            let mut writer_guard = f_lock.write()?;
-
-            let (mut foreign_entries, truncate) = {
-                let reader = BufReader::new(writer_guard.deref());
-
-                let mut from_file = reader
-                    .lines()
-                    .map(|o| o.map(|i| decode_entry(&i).expect("todo: error handling")))
-                    .collect::<std::io::Result<IndexMap<_, _>>>()?;
-
-                if from_file.len() + own_entries.len() > self.capacity {
-                    (
-                        from_file.split_off(
-                            from_file.len() - (self.capacity.saturating_sub(own_entries.len())),
-                        ),
-                        true,
-                    )
-                } else {
-                    (from_file, false)
-                }
-            };
-
-            {
-                let mut writer = BufWriter::new(writer_guard.deref_mut());
-
-                if truncate {
-                    writer.rewind()?;
-
-                    for (id, line) in &foreign_entries {
-                        writer.write_all(encode_entry(*id, line).as_bytes())?;
-                        writer.write_all("\n".as_bytes())?;
-                    }
-                } else {
-                    writer.seek(SeekFrom::End(0))?;
-                }
-
-                for (id, line) in own_entries {
+                for (id, line) in &foreign_entries {
                     writer.write_all(encode_entry(*id, line).as_bytes())?;
                     writer.write_all("\n".as_bytes())?;
                 }
-
-                writer.flush()?;
+            } else {
+                // Otherwise we directly jump at the end of the file
+                writer.seek(SeekFrom::End(0))?;
             }
 
-            if truncate {
-                let file = writer_guard.deref_mut();
-                let file_len = file.stream_position()?;
-                file.set_len(file_len)?;
+            // Then we write new entries (that haven't been synced to the file yet)
+            for (id, line) in own_entries {
+                writer.write_all(encode_entry(*id, line).as_bytes())?;
+                writer.write_all("\n".as_bytes())?;
             }
 
-            let own_entries = self.entries.drain(last_index_on_disk + 1..);
-            foreign_entries.extend(own_entries);
-            self.entries = foreign_entries;
-
-            let last_entry = self.entries.last().unwrap();
-            self.last_on_disk = Some(*last_entry.0);
+            writer.flush()?;
         }
+
+        // If truncation is needed, we then remove everything after the cursor's current location
+        if truncate {
+            let file = writer_guard.deref_mut();
+            let file_len = file.stream_position()?;
+            file.set_len(file_len)?;
+        }
+
+        match last_index_on_disk {
+            Some(last_index_on_disk) => {
+                if last_index_on_disk + 1 < self.entries.len() {
+                    foreign_entries.extend(self.entries.drain(last_index_on_disk + 1..));
+                }
+            }
+
+            None => {
+                foreign_entries.extend(self.entries.drain(..));
+            }
+        }
+
+        self.entries = foreign_entries;
+
+        self.last_on_disk = self.entries.last().map(|(id, _)| *id);
+
         Ok(())
     }
 
@@ -358,13 +380,21 @@ impl FileBackedHistory {
     ///
     /// **Side effects:** creates all nested directories to the file
     ///
+<<<<<<< HEAD
     pub fn with_file(capacity: usize, file: PathBuf) -> Result<Self> {
         let mut hist = Self::new(capacity)?;
+=======
+    pub fn with_file(capacity: usize, file: PathBuf) -> std::io::Result<Self> {
+        let mut hist = Self::new(capacity);
+
+>>>>>>> d0d27e8 (Fix: ranges and truncation)
         if let Some(base_dir) = file.parent() {
             std::fs::create_dir_all(base_dir)?;
         }
+
         hist.file = Some(file);
         hist.sync()?;
+
         Ok(hist)
     }
 

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -59,16 +59,30 @@ fn encode_entry(id: HistoryItemId, s: &str) -> String {
     format!("{id}{ID_SEP}{}", s.replace('\n', NEWLINE_ESCAPE))
 }
 
+/// Decode an entry
+///
+/// Legacy format: ls /
+/// New format   : 182535<id>:ls /
+///
+/// If a line can't be parsed using the new format, it will fallback to the legacy one.
+///
+/// This allows this function to support decoding for both legacy and new histories,
+/// as well as mixing both of them.
 fn decode_entry(s: &str, counter: &mut i64) -> (HistoryItemId, String) {
+    let mut parsed = None;
+
     if let Some(sep) = s.find(ID_SEP) {
-        if let Ok(id) = s[..sep].parse() {
-            return (HistoryItemId(id), s[sep + ID_SEP.len()..].to_owned());
+        if let Ok(parsed_id) = s[..sep].parse() {
+            parsed = Some((parsed_id, &s[sep + ID_SEP.len()..]));
         }
     }
 
-    *counter += 1;
+    let (id, content) = parsed.unwrap_or_else(|| {
+        *counter += 1;
+        (*counter - 1, s)
+    });
 
-    (HistoryItemId(*counter - 1), s.to_owned())
+    (HistoryItemId(id), content.replace(NEWLINE_ESCAPE, "\n"))
 }
 
 impl History for FileBackedHistory {

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -1,4 +1,5 @@
 use indexmap::IndexMap;
+use itertools::Itertools;
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 
 use super::{
@@ -87,10 +88,12 @@ impl History for FileBackedHistory {
             && !entry.is_empty()
             && self.capacity > 0
         {
-            if self.entries.len() == self.capacity {
+            if self.entries.len() >= self.capacity {
                 // History is "full", so we delete the oldest entry first,
                 // before adding a new one.
-                self.entries.shift_remove(&HistoryItemId(0));
+                let first_id = *(self.entries.first().unwrap().0);
+                let prev = self.entries.shift_remove(&first_id);
+                assert!(prev.is_some());
             }
 
             self.entries.insert(h.id, entry.to_string());
@@ -105,6 +108,8 @@ impl History for FileBackedHistory {
     }
 
     fn load(&self, id: HistoryItemId) -> Result<HistoryItem> {
+        println!("{:?}", self.entries);
+
         Ok(FileBackedHistory::construct_entry(
             id,
             self.entries
@@ -116,9 +121,9 @@ impl History for FileBackedHistory {
         ))
     }
 
-    fn count(&self, query: SearchQuery) -> Result<i64> {
+    fn count(&self, query: SearchQuery) -> Result<u64> {
         // todo: this could be done cheaper
-        Ok(self.search(query)?.len() as i64)
+        Ok(self.search(query)?.len() as u64)
     }
 
     fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>> {
@@ -165,11 +170,7 @@ impl History for FileBackedHistory {
             None => self.entries.len().saturating_sub(1),
         };
 
-        if from_index == to_index {
-            return Ok(vec![]);
-        }
-
-        assert!(from_index < to_index);
+        assert!(from_index <= to_index);
 
         let iter = self
             .entries
@@ -343,6 +344,9 @@ impl History for FileBackedHistory {
         }
 
         self.entries = foreign_entries;
+
+        println!("|- Result         : {}", self.entries.values().join(" ; "));
+        println!();
 
         self.last_on_disk = self.entries.last().map(|(id, _)| *id);
 

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexMap;
-use rand::{rngs::SmallRng, RngCore, SeedableRng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 use super::{
     base::CommandLineSearch, History, HistoryItem, HistoryItemId, SearchDirection, SearchQuery,
@@ -86,7 +86,7 @@ fn decode_entry(s: &str, counter: &mut i64) -> (HistoryItemId, String) {
 
 impl History for FileBackedHistory {
     fn generate_id(&mut self) -> HistoryItemId {
-        HistoryItemId(self.rng.next_u64() as i64)
+        HistoryItemId(self.rng.gen())
     }
 
     /// only saves a value if it's different than the last value

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -53,22 +53,22 @@ impl Default for FileBackedHistory {
     }
 }
 
+static ID_SEP: &str = "<id>:";
+
 fn encode_entry(id: HistoryItemId, s: &str) -> String {
-    format!("{id}:{}", s.replace('\n', NEWLINE_ESCAPE))
+    format!("{id}{ID_SEP}{}", s.replace('\n', NEWLINE_ESCAPE))
 }
 
-fn decode_entry(s: &str) -> std::result::Result<(HistoryItemId, String), &'static str> {
-    let sep = s
-        .bytes()
-        .position(|b| b == b':')
-        .ok_or("History item ID is missing")?;
+fn decode_entry(s: &str, counter: &mut i64) -> (HistoryItemId, String) {
+    if let Some(sep) = s.find(ID_SEP) {
+        if let Ok(id) = s[..sep].parse() {
+            return (HistoryItemId(id), s[sep + ID_SEP.len()..].to_owned());
+        }
+    }
 
-    let id = s[..sep].parse().map_err(|_| "Invalid history item ID")?;
+    *counter += 1;
 
-    Ok((
-        HistoryItemId(id),
-        s[sep + 1..].replace(NEWLINE_ESCAPE, "\n"),
-    ))
+    (HistoryItemId(*counter - 1), s.to_owned())
 }
 
 impl History for FileBackedHistory {
@@ -285,9 +285,11 @@ impl History for FileBackedHistory {
         let (mut foreign_entries, truncate) = {
             let reader = BufReader::new(writer_guard.deref());
 
+            let mut counter = 0;
+
             let mut from_file = reader
                 .lines()
-                .map(|o| o.map(|i| decode_entry(&i).expect("todo: error handling")))
+                .map(|o| o.map(|i| decode_entry(&i, &mut counter)))
                 .collect::<std::io::Result<IndexMap<_, _>>>()?;
 
             if from_file.len() + own_entries.len() > self.capacity {

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -59,7 +59,7 @@ fn decode_entry(s: &str) -> String {
 
 impl History for FileBackedHistory {
     fn generate_id(&mut self) -> HistoryItemId {
-        HistoryItemId((self.entries.len() - 1) as i64)
+        HistoryItemId((self.entries.len() + 1) as i64)
     }
 
     /// only saves a value if it's different than the last value

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -85,7 +85,7 @@ impl HistoryItemExtraInfo for IgnoreAllExtraInfo {}
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = IgnoreAllExtraInfo> {
     /// primary key, unique across one history
-    pub id: Option<HistoryItemId>,
+    pub id: HistoryItemId,
     /// date-time when this command was started
     pub start_timestamp: Option<chrono::DateTime<Utc>>,
     /// the full command line as text
@@ -111,9 +111,9 @@ pub struct HistoryItem<ExtraInfo: HistoryItemExtraInfo = IgnoreAllExtraInfo> {
 
 impl HistoryItem {
     /// create a history item purely from the command line with everything else set to None
-    pub fn from_command_line(cmd: impl Into<String>) -> HistoryItem {
+    pub fn from_command_line(cmd: impl Into<String>, id: HistoryItemId) -> HistoryItem {
         HistoryItem {
-            id: None,
+            id,
             start_timestamp: None,
             command_line: cmd.into(),
             session_id: None,

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -4,7 +4,10 @@ use rusqlite::ToSql;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{fmt::Display, time::Duration};
 
-/// Unique ID for the [`HistoryItem`]. More recent items have higher ids than older ones.
+/// Unique ID for the [`HistoryItem`].
+/// These are generated pseudo-randomly.
+/// Note that the ID of a given item may change between program executions.
+/// These IDs only aim to uniquely identify a single item *for the program's execution*.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct HistoryItemId(pub i64);
 impl HistoryItemId {

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -25,9 +25,10 @@ impl Display for HistoryItemId {
 
 /// Unique ID for the session in which reedline was run to disambiguate different sessions
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct HistorySessionId(pub(crate) i64);
+pub struct HistorySessionId(pub i64);
 impl HistorySessionId {
-    pub(crate) const fn new(i: i64) -> HistorySessionId {
+    /// Create a new `HistorySessionId`
+    pub const fn new(i: i64) -> HistorySessionId {
         HistorySessionId(i)
     }
 }

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -247,7 +247,7 @@ impl SqliteBackedHistory {
 
             // Get the user version
             // By default, it is set to 0
-            let db_version: i32 = db.query_row(
+            let mut db_version: i32 = db.query_row(
                 "SELECT user_version FROM pragma_user_version",
                 params![],
                 |r| r.get(0),
@@ -319,6 +319,7 @@ impl SqliteBackedHistory {
 
                 // Update the version to indicate the DB is up-to-date
                 statements.push("pragma user_version = 1;");
+                db_version = 1;
 
                 // We use a transaction to ensure consistency, given we're doing multiple operations
                 let transaction = db.transaction()?;
@@ -475,10 +476,13 @@ impl SqliteBackedHistory {
                 Box::new(session_timestamp.timestamp_millis()),
             ));
         }
+
         let mut wheres = wheres.join(" and ");
+
         if wheres.is_empty() {
             wheres = "true".to_string();
         }
+
         let query = format!(
             "SELECT {select_expression} \
              FROM history \
@@ -486,6 +490,7 @@ impl SqliteBackedHistory {
              ORDER BY idx {asc} \
              {limit}"
         );
+
         (query, params)
     }
 }

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -233,63 +233,111 @@ impl SqliteBackedHistory {
     }
     /// initialize a new database / migrate an existing one
     fn from_connection(
-        db: Connection,
+        mut db: Connection,
         session: Option<HistorySessionId>,
         session_timestamp: Option<chrono::DateTime<Utc>>,
     ) -> Result<Self> {
-        // https://phiresky.github.io/blog/2020/sqlite-performance-tuning/
-        db.pragma_update(None, "journal_mode", "wal")
-            .map_err(map_sqlite_err)?;
-        db.pragma_update(None, "synchronous", "normal")
-            .map_err(map_sqlite_err)?;
-        db.pragma_update(None, "mmap_size", "1000000000")
-            .map_err(map_sqlite_err)?;
-        db.pragma_update(None, "foreign_keys", "on")
-            .map_err(map_sqlite_err)?;
-        db.pragma_update(None, "application_id", SQLITE_APPLICATION_ID)
-            .map_err(map_sqlite_err)?;
-        let db_version: i32 = db
-            .query_row(
+        let inner = || -> rusqlite::Result<(i32, Self)> {
+            // https://phiresky.github.io/blog/2020/sqlite-performance-tuning/
+            db.pragma_update(None, "journal_mode", "wal")?;
+            db.pragma_update(None, "synchronous", "normal")?;
+            db.pragma_update(None, "mmap_size", "1000000000")?;
+            db.pragma_update(None, "foreign_keys", "on")?;
+            db.pragma_update(None, "application_id", SQLITE_APPLICATION_ID)?;
+
+            let db_version: i32 = db.query_row(
                 "SELECT user_version FROM pragma_user_version",
                 params![],
                 |r| r.get(0),
-            )
-            .map_err(map_sqlite_err)?;
-        if db_version != 0 {
+            )?;
+
+            if db_version == 0 {
+                let existing_history = db.query_row(
+                    "select count(*) from pragma_table_list() where name = 'history';",
+                    (),
+                    |result| Ok(result.get::<_, usize>("count(*)")? > 0),
+                )?;
+
+                let mut statements = vec![];
+
+                if existing_history {
+                    statements.push(
+                        "
+                        alter table history rename to history_old;
+
+                        drop index if exists idx_history_cwd;
+                        drop index if exists idx_history_exit_status;
+                        drop index if exists idx_history_cmd;
+                        drop index if exists idx_history_cmd;
+                        ",
+                    );
+                }
+
+                statements.push(
+                    "
+                    create table history (
+                        idx integer primary key autoincrement,
+                        id integer unique not null,
+                        command_line text not null,
+                        start_timestamp integer,
+                        session_id integer,
+                        hostname text,
+                        cwd text,
+                        duration_ms integer,
+                        exit_status integer,
+                        more_info text
+                    ) strict;
+                    
+                    create index if not exists idx_history_time on history(start_timestamp);
+                    create index if not exists idx_history_cwd on history(cwd); -- suboptimal for many hosts
+                    create index if not exists idx_history_exit_status on history(exit_status);
+                    create index if not exists idx_history_cmd on history(command_line);
+                    create index if not exists idx_history_cmd on history(session_id);
+                    ",
+                )
+                ;
+
+                if existing_history {
+                    statements.push(
+                        "
+                        insert into history (id, command_line, start_timestamp, session_id, hostname, cwd, duration_ms, exit_status, more_info)
+                        select id as idx, command_line, start_timestamp, session_id, hostname, cwd, duration_ms, exit_status, more_info
+                        from history_old;
+
+                        drop table history_old;
+                        ",
+                    );
+                }
+
+                statements.push("pragma user_version = 1;");
+
+                // TODO: update db version to 1
+
+                let transaction = db.transaction()?;
+                transaction.execute_batch(&statements.join("\n"))?;
+                transaction.commit()?;
+            }
+
+            Ok((
+                db_version,
+                SqliteBackedHistory {
+                    db,
+                    session,
+                    session_timestamp,
+                    rng: SmallRng::from_entropy(),
+                },
+            ))
+        };
+
+        let (db_version, history) = inner().map_err(map_sqlite_err)?;
+
+        if db_version > 1 {
             return Err(ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(
                 format!("Unknown database version {db_version}"),
             )));
         }
-        db.execute_batch(
-            "
-        create table if not exists history (
-            idx integer primary key autoincrement,
-            id integer unique not null,
-            command_line text not null,
-            start_timestamp integer,
-            session_id integer,
-            hostname text,
-            cwd text,
-            duration_ms integer,
-            exit_status integer,
-            more_info text
-        ) strict;
-        
-        create index if not exists idx_history_time on history(start_timestamp);
-        create index if not exists idx_history_cwd on history(cwd); -- suboptimal for many hosts
-        create index if not exists idx_history_exit_status on history(exit_status);
-        create index if not exists idx_history_cmd on history(command_line);
-        create index if not exists idx_history_cmd on history(session_id);
-        ",
-        )
-        .map_err(map_sqlite_err)?;
 
-        Ok(SqliteBackedHistory {
-            db,
-            session,
-            session_timestamp,
-            rng: SmallRng::from_entropy(),
-        })
+        Ok(history)
     }
 
     fn construct_query<'a>(

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -7,7 +7,7 @@ use crate::{
     Result,
 };
 use chrono::{TimeZone, Utc};
-use rand::{rngs::SmallRng, RngCore, SeedableRng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use rusqlite::{named_params, params, Connection, ToSql};
 use std::{path::PathBuf, time::Duration};
 const SQLITE_APPLICATION_ID: i32 = 1151497937;
@@ -63,7 +63,7 @@ fn deserialize_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem
 
 impl History for SqliteBackedHistory {
     fn generate_id(&mut self) -> HistoryItemId {
-        HistoryItemId(self.rng.next_u64() as i64)
+        HistoryItemId(self.rng.gen())
     }
 
     fn save(&mut self, entry: &HistoryItem) -> Result<()> {

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -113,24 +113,30 @@ impl History for SqliteBackedHistory {
             .map_err(map_sqlite_err)?
             .query_row(named_params! { ":id": id.0 }, deserialize_history_item)
             .map_err(map_sqlite_err)?;
+
         Ok(entry)
     }
 
-    fn count(&self, query: SearchQuery) -> Result<i64> {
+    fn count(&self, query: SearchQuery) -> Result<u64> {
         let (query, params) = self.construct_query(&query, "coalesce(count(*), 0)");
+
         let params_borrow: Vec<(&str, &dyn ToSql)> = params.iter().map(|e| (e.0, &*e.1)).collect();
-        let result: i64 = self
+
+        let result: u64 = self
             .db
             .prepare(&query)
             .unwrap()
             .query_row(&params_borrow[..], |r| r.get(0))
             .map_err(map_sqlite_err)?;
+
         Ok(result)
     }
 
     fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>> {
         let (query, params) = self.construct_query(&query, "*");
+
         let params_borrow: Vec<(&str, &dyn ToSql)> = params.iter().map(|e| (e.0, &*e.1)).collect();
+
         let results: Vec<HistoryItem> = self
             .db
             .prepare(&query)

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -271,9 +271,9 @@ impl SqliteBackedHistory {
                         "
                         alter table history rename to history_old;
 
+                        drop index if exists idx_history_time;
                         drop index if exists idx_history_cwd;
                         drop index if exists idx_history_exit_status;
-                        drop index if exists idx_history_cmd;
                         drop index if exists idx_history_cmd;
                         ",
                     );
@@ -299,7 +299,7 @@ impl SqliteBackedHistory {
                     create index if not exists idx_history_cwd on history(cwd); -- suboptimal for many hosts
                     create index if not exists idx_history_exit_status on history(exit_status);
                     create index if not exists idx_history_cmd on history(command_line);
-                    create index if not exists idx_history_cmd on history(session_id);
+                    create index if not exists idx_history_session_id on history(session_id);
                     ",
                 );
 

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -6,6 +6,7 @@ use crate::{
     Completer, Suggestion,
 };
 use nu_ansi_term::ansi::RESET;
+use unicode_width::UnicodeWidthStr;
 
 /// Default values used as reference for the menu. These values are set during
 /// the initial declaration of the menu and are always kept as reference for the
@@ -308,12 +309,16 @@ impl ColumnarMenu {
                 .unwrap_or(self.settings.color.text_style)
                 .prefix();
 
+            let left_text_size = self.longest_suggestion + self.default_details.col_padding;
+            let right_text_size = self.get_width().saturating_sub(left_text_size);
+
+            let max_remaining = left_text_size.saturating_sub(match_str.width());
+            let max_match = max_remaining.saturating_sub(remaining_str.width());
+
             if index == self.index() {
                 if let Some(description) = &suggestion.description {
-                    let left_text_size = self.longest_suggestion + self.default_details.col_padding;
-                    let right_text_size = self.get_width().saturating_sub(left_text_size);
                     format!(
-                        "{}{}{}{}{}{}{:max$}{}{}{}{}{}{}",
+                        "{}{}{}{}{}{:max_match$}{:max_remaining$}{}{}{}{}{}{}",
                         suggestion_style_prefix,
                         self.settings.color.selected_match_style.prefix(),
                         match_str,
@@ -331,7 +336,6 @@ impl ColumnarMenu {
                             .replace('\n', " "),
                         RESET,
                         self.end_of_line(column),
-                        max = left_text_size,
                     )
                 } else {
                     format!(
@@ -350,10 +354,8 @@ impl ColumnarMenu {
                     )
                 }
             } else if let Some(description) = &suggestion.description {
-                let left_text_size = self.longest_suggestion + self.default_details.col_padding;
-                let right_text_size = self.get_width().saturating_sub(left_text_size);
                 format!(
-                    "{}{}{}{}{}{:max$}{}{}{}{}{}",
+                    "{}{}{}{}{:max_match$}{:max_remaining$}{}{}{}{}{}",
                     suggestion_style_prefix,
                     self.settings.color.match_style.prefix(),
                     match_str,
@@ -369,7 +371,6 @@ impl ColumnarMenu {
                         .replace('\n', " "),
                     RESET,
                     self.end_of_line(column),
-                    max = left_text_size,
                 )
             } else {
                 format!(


### PR DESCRIPTION
**NOTE:** This PR is a work-in-progress, and is not ready to be merged as-is. There are ongoing discussions about the new API design.

This PR aims to overhaul the history API of reedline in order to make it usable outside of the crate. It also aims to make it more robust, more intuitive and less error-prone.

Following discussions in #680 (original PR), #735 (discussion), also embedding future discussions for #746.

For newcomers in the discussion, please read #680 first, as it will help you understand the motivations and existing discussion behind this PR.

TODO list (includes unvoted tasks):

- [ ] Global API rewrite
- [ ] Introduce a new, fast history backend with all available features (e.g. `sled`-backed?)
- [ ] Remove the `sync` API (see #746)
- [ ] Add new documentation and add integration examples
- [ ] Move the `History::session` method someplace else (to move session detection logic outside of the history implementation)

cc @stormasm @fdncred @sholderbach 