### PR TITLE
Use the OS clipboard only for explicit cut/copy/paste operations

### DIFF
--- a/src/core_editor/clip_buffer.rs
+++ b/src/core_editor/clip_buffer.rs
@@ -113,7 +113,9 @@ mod system_clipboard {
 
 #[cfg(test)]
 mod tests {
-    use super::{get_local_clipboard, get_system_clipboard, ClipboardMode};
+    #[cfg(feature = "system_clipboard")]
+    use super::get_system_clipboard;
+    use super::{get_local_clipboard, ClipboardMode};
     #[test]
     fn reads_back_local() {
         let mut cb = get_local_clipboard();
@@ -132,6 +134,7 @@ mod tests {
         cb.set(&previous_state, ClipboardMode::Normal);
     }
 
+    #[cfg(feature = "system_clipboard")]
     #[test]
     fn reads_back_system() {
         let mut cb = get_system_clipboard();

--- a/src/core_editor/mod.rs
+++ b/src/core_editor/mod.rs
@@ -3,6 +3,8 @@ mod edit_stack;
 mod editor;
 mod line_buffer;
 
-pub(crate) use clip_buffer::{get_default_clipboard, Clipboard, ClipboardMode};
+#[cfg(feature = "system_clipboard")]
+pub(crate) use clip_buffer::get_system_clipboard;
+pub(crate) use clip_buffer::{get_local_clipboard, Clipboard, ClipboardMode};
 pub use editor::Editor;
 pub use line_buffer::LineBuffer;

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -217,17 +217,23 @@ pub fn add_common_edit_bindings(kb: &mut Keybindings) {
     kb.add_binding(
         KM::CONTROL | KM::SHIFT,
         KC::Char('x'),
-        edit_bind(EC::CutSelection),
+        edit_bind(EC::CutSelection {
+            system_clipboard: true,
+        }),
     );
     kb.add_binding(
         KM::CONTROL | KM::SHIFT,
         KC::Char('c'),
-        edit_bind(EC::CopySelection),
+        edit_bind(EC::CopySelection {
+            system_clipboard: true,
+        }),
     );
     kb.add_binding(
         KM::CONTROL | KM::SHIFT,
         KC::Char('v'),
-        edit_bind(EC::PasteCutBufferBefore),
+        edit_bind(EC::Paste {
+            system_clipboard: true,
+        }),
     );
 }
 

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -214,26 +214,23 @@ pub fn add_common_edit_bindings(kb: &mut Keybindings) {
     // Base commands should not affect cut buffer
     kb.add_binding(KM::CONTROL, KC::Char('h'), edit_bind(EC::Backspace));
     kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::BackspaceWord));
+    #[cfg(feature = "system_clipboard")]
     kb.add_binding(
         KM::CONTROL | KM::SHIFT,
         KC::Char('x'),
-        edit_bind(EC::CutSelection {
-            system_clipboard: true,
-        }),
+        edit_bind(EC::CutSelectionSystem),
     );
+    #[cfg(feature = "system_clipboard")]
     kb.add_binding(
         KM::CONTROL | KM::SHIFT,
         KC::Char('c'),
-        edit_bind(EC::CopySelection {
-            system_clipboard: true,
-        }),
+        edit_bind(EC::CopySelectionSystem),
     );
+    #[cfg(feature = "system_clipboard")]
     kb.add_binding(
         KM::CONTROL | KM::SHIFT,
         KC::Char('v'),
-        edit_bind(EC::Paste {
-            system_clipboard: true,
-        }),
+        edit_bind(EC::PasteSystem),
     );
 }
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -257,11 +257,23 @@ pub enum EditCommand {
     /// Select whole input buffer
     SelectAll,
 
-    /// Cut selection
-    CutSelection,
+    /// Cut selection to local buffer or system clipboard
+    CutSelection {
+        /// Should the system clipboard be used as the destination of the content?
+        system_clipboard: bool,
+    },
 
-    /// Copy selection
-    CopySelection,
+    /// Copy selection to local buffer or system clipboard
+    CopySelection {
+        /// Should the system clipboard be used as the destination of the content?
+        system_clipboard: bool,
+    },
+
+    /// Paste content from local buffer or system clipboard at the current cursor position
+    Paste {
+        /// Is the system clipboard the source of the paste operation?
+        system_clipboard: bool,
+    },
 }
 
 impl Display for EditCommand {
@@ -346,8 +358,13 @@ impl Display for EditCommand {
             EditCommand::CutLeftUntil(_) => write!(f, "CutLeftUntil Value: <char>"),
             EditCommand::CutLeftBefore(_) => write!(f, "CutLeftBefore Value: <char>"),
             EditCommand::SelectAll => write!(f, "SelectAll"),
-            EditCommand::CutSelection => write!(f, "CutSelection"),
-            EditCommand::CopySelection => write!(f, "CopySelection"),
+            EditCommand::CutSelection { .. } => {
+                write!(f, "CutSelectionToSystem system_clipboard: <bool>")
+            }
+            EditCommand::CopySelection { .. } => {
+                write!(f, "CopySelectionToSystem system_clipboard: <bool>")
+            }
+            EditCommand::Paste { .. } => write!(f, "PasteSystemClipboard system_clipboard: <bool>"),
         }
     }
 }
@@ -418,11 +435,12 @@ impl EditCommand {
             | EditCommand::CutRightBefore(_)
             | EditCommand::CutLeftUntil(_)
             | EditCommand::CutLeftBefore(_)
-            | EditCommand::CutSelection => EditType::EditText,
+            | EditCommand::CutSelection { .. }
+            | EditCommand::Paste { .. } => EditType::EditText,
 
             EditCommand::Undo | EditCommand::Redo => EditType::UndoRedo,
 
-            EditCommand::CopySelection => EditType::NoOp,
+            EditCommand::CopySelection { .. } => EditType::NoOp,
         }
     }
 }


### PR DESCRIPTION
This PR addresses https://github.com/nushell/reedline/issues/759. 

This PR reverts most commands to using the local cut buffer for cut/copy/paste operations except for `CutSelection` and `CopySelection`. Those two commands now have a parameter to specify which clipboard to use. Current keybindings for those commands (`CutSelection`: `Ctrl+Shift+X`, `CopySelection`: `Ctrl+Shift+V`) still use the system clipboard. Currently, no keybindings are defaulted for these commands and the cut buffer. 

We can't statically compile everything related to the `system_clipboard` feature out, as that would include the parametrized commands mentioned above. Activating the feature would not be purely additive anymore. Therefore those parameters have to stay even when the feature is disabled and the commands have to do _something_ when the feature is not enabled. Currently, there is no facility in place for `EditCommand`s to fail in a recoverable manner or indicate failure to the user. A few possibilities how to handle this situation that come to mind:

1. Panic if the OS clipboard would have to be used. The user of the crate would be responsible to ensure commands using the OS clipboard are only used when the feature is enabled.
2. Silently do nothing when the OS clipboard would have to be used
3. Silently use the local clipboard, even when the command explicitly requests the OS clipboard

Of these options, I currently implement panicking. I think it is the least surprising thing to do for users of `reedline`. Requesting to use the OS clipboard while not having `system_clipboard` enabled is surely a logic bug. But I am open to discussion if someone sees it another way.

The changes can be used with [this nushell branch](https://github.com/Tastaturtaste/nushell), where I use this reedline branch to test things out.