### PR TITLE
Fix `OpenOptions` clippy

### DIFF
--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -231,6 +231,7 @@ impl History for FileBackedHistory {
                     .create(true)
                     .write(true)
                     .read(true)
+                    .truncate(false)
                     .open(fname)?,
             );
             let mut writer_guard = f_lock.write()?;


### PR DESCRIPTION
`truncate(false)` is the right choice as we manually truncate later. (we
want to read from the same handle first and then write, to use the
advisory lock)
