### PR TITLE
Fix case-consistency searching sqlite history

### DIFF
--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -350,6 +350,24 @@ mod test {
     }
 
     #[test]
+    fn search_prefix_is_case_sensitive() -> Result<()> {
+        // Basic prefix search should preserve case
+        //
+        // https://github.com/nushell/nushell/issues/10131
+        let history = create_filled_example_history()?;
+        let res = history.search(SearchQuery {
+            filter: SearchFilter::from_text_search(
+                CommandLineSearch::Prefix("LS ".to_string()),
+                None,
+            ),
+            ..SearchQuery::everything(SearchDirection::Backward, None)
+        })?;
+        search_returned(&*history, res, vec![])?;
+
+        Ok(())
+    }
+
+    #[test]
     fn search_includes() -> Result<()> {
         let history = create_filled_example_history()?;
         let res = history.search(SearchQuery {

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -327,13 +327,20 @@ impl SqliteBackedHistory {
         };
         if let Some(command_line) = &query.filter.command_line {
             // TODO: escape %
-            let command_line_like = match command_line {
-                CommandLineSearch::Exact(e) => e.to_string(),
-                CommandLineSearch::Prefix(prefix) => format!("{prefix}*"),
-                CommandLineSearch::Substring(cont) => format!("*{cont}*"),
+            match command_line {
+                CommandLineSearch::Exact(e) => {
+                    wheres.push("command_line == :command_line");
+                    params.push((":command_line", Box::new(e)));
+                }
+                CommandLineSearch::Prefix(prefix) => {
+                    wheres.push("instr(command_line, :command_line) == 1");
+                    params.push((":command_line", Box::new(prefix)));
+                }
+                CommandLineSearch::Substring(cont) => {
+                    wheres.push("instr(command_line, :command_line) >= 1");
+                    params.push((":command_line", Box::new(cont)));
+                }
             };
-            wheres.push("command_line glob :command_line");
-            params.push((":command_line", Box::new(command_line_like)));
         }
 
         if let Some(str) = &query.filter.not_command_line {

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -326,7 +326,6 @@ impl SqliteBackedHistory {
             None => "",
         };
         if let Some(command_line) = &query.filter.command_line {
-            // TODO: escape %
             match command_line {
                 CommandLineSearch::Exact(e) => {
                     wheres.push("command_line == :command_line");

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -329,10 +329,10 @@ impl SqliteBackedHistory {
             // TODO: escape %
             let command_line_like = match command_line {
                 CommandLineSearch::Exact(e) => e.to_string(),
-                CommandLineSearch::Prefix(prefix) => format!("{prefix}%"),
-                CommandLineSearch::Substring(cont) => format!("%{cont}%"),
+                CommandLineSearch::Prefix(prefix) => format!("{prefix}*"),
+                CommandLineSearch::Substring(cont) => format!("*{cont}*"),
             };
-            wheres.push("command_line like :command_line");
+            wheres.push("command_line glob :command_line");
             params.push((":command_line", Box::new(command_line_like)));
         }
 


### PR DESCRIPTION
After merging downstream will close https://github.com/nushell/nushell/issues/10131


For the `FileBackedHistory` those operations have always been case
sensitive, do the same for `SqliteBackedHistory`. The insensitivity of
`like` in sqlite causes https://github.com/nushell/nushell/issues/10131

Replace this with exact matching via sqlite's [`instr()`](https://www.sqlite.org/lang_corefunc.html#instr), which should also fix a need for escaping of `%` (or `*` with `glob`)

