### PR TITLE
[Feature] new history backend 'rqlite' implmentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +72,12 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -139,6 +151,15 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam"
@@ -318,10 +339,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "gethostname"
@@ -331,6 +371,17 @@ checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
 dependencies = [
  "libc",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -374,6 +425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +451,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -429,6 +496,12 @@ checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -499,6 +572,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -621,6 +703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +783,7 @@ dependencies = [
  "itertools",
  "nu-ansi-term",
  "pretty_assertions",
+ "rqlite_client",
  "rstest",
  "rusqlite",
  "serde",
@@ -706,6 +795,7 @@ dependencies = [
  "thiserror",
  "unicode-segmentation",
  "unicode-width",
+ "url",
 ]
 
 [[package]]
@@ -742,6 +832,35 @@ name = "relative-path"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rqlite_client"
+version = "0.0.1-alpha.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f71ec02d5d94b0c22ad049d5e540dc81758c0dff42a9df9ea55dfa047c8b5b51"
+dependencies = [
+ "httpdate",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "ureq",
+ "url",
+]
 
 [[package]]
 name = "rstest"
@@ -804,6 +923,37 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -904,6 +1054,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "strip-ansi-escapes"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +1086,12 @@ dependencies = [
  "rustversion",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -975,6 +1137,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tree_magic_mini"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,10 +1166,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1005,6 +1197,42 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8parse"
@@ -1175,6 +1403,15 @@ dependencies = [
  "dlib",
  "log",
  "pkg-config",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1402,3 +1639,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ fd-lock = "4.0.2"
 itertools = "0.12.0"
 nu-ansi-term = "0.50.0"
 rusqlite = { version = "0.31.0", optional = true }
+rqlite_client = { version = "0.0.1-alpha.15", optional = true }
+url = { version = "2.5.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true }
 strip-ansi-escapes = "0.2.0"
@@ -46,6 +48,7 @@ bashisms = []
 external_printer = ["crossbeam"]
 sqlite = ["rusqlite/bundled", "serde_json"]
 sqlite-dynlib = ["rusqlite", "serde_json"]
+rqlite = ["rqlite_client", "serde_json", "url"]
 system_clipboard = ["arboard"]
 
 [[example]]
@@ -59,4 +62,4 @@ required-features = ["external_printer"]
 [package.metadata.docs.rs]
 # Whether to pass `--all-features` to Cargo (default: false)
 all-features = false
-features = ["bashisms", "external_printer", "sqlite"]
+features = ["bashisms", "external_printer", "sqlite", "rqlite"]

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -38,7 +38,8 @@ fn main() -> reedline::Result<()> {
             "http://localhost:4001".into(),
             history_session_id,
             Some(chrono::Utc::now()),
-        ).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
+        )
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
     );
 
     #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -32,6 +32,15 @@ fn main() -> reedline::Result<()> {
         None
     };
 
+    #[cfg(feature = "rqlite")]
+    let history = Box::new(
+        reedline::RqliteBackedHistory::with_url(
+            "http://localhost:4001".into(),
+            history_session_id,
+            Some(chrono::Utc::now()),
+        ).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
+    );
+
     #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
     let history = Box::new(
         reedline::SqliteBackedHistory::with_file(
@@ -41,7 +50,7 @@ fn main() -> reedline::Result<()> {
         )
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
     );
-    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib", feature = "rqlite")))]
     let history = Box::new(FileBackedHistory::with_file(50, "history.txt".into())?);
     let commands = vec![
         "test".into(),

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -1,8 +1,8 @@
-use std::fmt::{Debug, Display, Formatter};
-use std::path::PathBuf;
 use super::HistoryItemId;
 use crate::{core_editor::LineBuffer, HistoryItem, HistorySessionId, Result};
 use chrono::Utc;
+use std::fmt::{Debug, Display, Formatter};
+use std::path::PathBuf;
 
 #[cfg(feature = "url")]
 use url::Url;
@@ -273,9 +273,9 @@ mod test {
 
     fn create_filled_example_history() -> Result<Box<dyn History>> {
         #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
-            let mut history = crate::SqliteBackedHistory::in_memory()?;
+        let mut history = crate::SqliteBackedHistory::in_memory()?;
         #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
-            let mut history = crate::FileBackedHistory::default();
+        let mut history = crate::FileBackedHistory::default();
         #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
         history.save(create_item(1, "/", "dummy", 0))?; // add dummy item so ids start with 1
         history.save(create_item(1, "/home/me", "cd ~/Downloads", 0))?; // 1

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -62,6 +62,25 @@ impl Display for HistoryStorageDest {
     }
 }
 
+impl From<&str> for HistoryStorageDest {
+    fn from(value: &str) -> Self {
+        HistoryStorageDest::Path(value.into())
+    }
+}
+
+impl From<PathBuf> for HistoryStorageDest {
+    fn from(value: PathBuf) -> Self {
+        HistoryStorageDest::Path(value)
+    }
+}
+
+#[cfg(feature = "rqlite")]
+impl From<Url> for HistoryStorageDest {
+    fn from(value: Url) -> Self {
+        HistoryStorageDest::Url(value)
+    }
+}
+
 /// Defines additional filters for querying the [`History`]
 pub struct SearchFilter {
     /// Query for the command line content

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -56,6 +56,7 @@ impl Display for HistoryStorageDest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             HistoryStorageDest::Path(path) => Display::fmt(&path.display(), f),
+            #[cfg(feature = "rqlite")]
             HistoryStorageDest::Url(uri) => Display::fmt(uri, f),
         }
     }

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -119,7 +119,7 @@ mod tests {
         )
     }
     fn create_history_at(cap: usize, path: &Path) -> (Box<dyn History>, HistoryCursor) {
-        let hist = Box::new(FileBackedHistory::with_file(cap, path.to_owned()).unwrap());
+        let hist = Box::new(FileBackedHistory::with_file(cap, path.to_owned().into()).unwrap());
         (
             hist,
             HistoryCursor::new(HistoryNavigationQuery::Normal(LineBuffer::default()), None),

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -330,7 +330,7 @@ impl FileBackedHistory {
                 hist.sync()?;
                 Ok(hist)
             }
-            #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib", feature = "rqlite"))]
+            #[cfg(feature = "rqlite")]
             HistoryStorageDest::Url(url) => {
                 Err(ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(
                     format!("Expect file path, got Url: {}", url.to_string()),

--- a/src/history/file_backed.rs
+++ b/src/history/file_backed.rs
@@ -6,6 +6,7 @@ use crate::{
     HistorySessionId, Result,
 };
 
+use crate::history::base::HistoryStorageDest;
 use std::{
     collections::VecDeque,
     fs::OpenOptions,
@@ -13,7 +14,6 @@ use std::{
     ops::{Deref, DerefMut},
     path::PathBuf,
 };
-use crate::history::base::HistoryStorageDest;
 
 /// Default size of the [`FileBackedHistory`] used when calling [`FileBackedHistory::default()`]
 pub const HISTORY_SIZE: usize = 1000;
@@ -331,9 +331,11 @@ impl FileBackedHistory {
                 Ok(hist)
             }
             #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib", feature = "rqlite"))]
-            HistoryStorageDest::Url(url) => Err(ReedlineError(
-                ReedlineErrorVariants::HistoryDatabaseError(format!("Expect file path, got Url: {}", url.to_string()))
-            )),
+            HistoryStorageDest::Url(url) => {
+                Err(ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(
+                    format!("Expect file path, got Url: {}", url.to_string()),
+                )))
+            }
         }
     }
 

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -7,9 +7,9 @@ mod sqlite_backed;
 #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
 pub use sqlite_backed::SqliteBackedHistory;
 
-#[cfg(any(feature = "rqlite"))]
+#[cfg(feature = "rqlite")]
 mod rqlite_backed;
-#[cfg(any(feature = "rqlite"))]
+#[cfg(feature = "rqlite")]
 pub use rqlite_backed::RqliteBackedHistory;
 
 pub use base::{

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -13,7 +13,7 @@ mod rqlite_backed;
 pub use rqlite_backed::RqliteBackedHistory;
 
 pub use base::{
-    CommandLineSearch, History, HistoryNavigationQuery, SearchDirection, SearchFilter, SearchQuery,
+    CommandLineSearch, History, HistoryNavigationQuery, SearchDirection, SearchFilter, SearchQuery, HistoryStorageDest
 };
 pub use cursor::HistoryCursor;
 pub use item::{HistoryItem, HistoryItemId, HistorySessionId};

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -7,6 +7,11 @@ mod sqlite_backed;
 #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
 pub use sqlite_backed::SqliteBackedHistory;
 
+#[cfg(any(feature = "rqlite"))]
+mod rqlite_backed;
+#[cfg(any(feature = "rqlite"))]
+pub use rqlite_backed::RqliteBackedHistory;
+
 pub use base::{
     CommandLineSearch, History, HistoryNavigationQuery, SearchDirection, SearchFilter, SearchQuery,
 };

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -13,7 +13,8 @@ mod rqlite_backed;
 pub use rqlite_backed::RqliteBackedHistory;
 
 pub use base::{
-    CommandLineSearch, History, HistoryNavigationQuery, SearchDirection, SearchFilter, SearchQuery, HistoryStorageDest
+    CommandLineSearch, History, HistoryNavigationQuery, HistoryStorageDest, SearchDirection,
+    SearchFilter, SearchQuery,
 };
 pub use cursor::HistoryCursor;
 pub use item::{HistoryItem, HistoryItemId, HistorySessionId};

--- a/src/history/rqlite_backed.rs
+++ b/src/history/rqlite_backed.rs
@@ -1,0 +1,525 @@
+use std::collections::HashMap;
+use std::fmt::{Debug};
+use std::marker::PhantomData;
+use std::time::Duration;
+
+use chrono::{LocalResult, TimeZone, Utc};
+use itertools::Itertools;
+use rqlite_client::Mapping;
+use serde_json::{json, Value};
+
+use crate::{CommandLineSearch, result::{ReedlineError, ReedlineErrorVariants}, Result, SearchDirection};
+
+use super::{
+    base::SearchQuery,
+    History, HistoryItem, HistoryItemId, HistorySessionId,
+};
+
+/// A history that stores the values to a Rqlite database.
+/// In addition to storing the command, the history can store an additional arbitrary HistoryEntryContext,
+/// to add information such as a timestamp, running directory, result...
+///
+/// ## Required feature:
+/// `rqlite`
+pub struct RqliteBackedHistory {
+    db: rqlite_client::Connection,
+    session: Option<HistorySessionId>,
+    session_timestamp: Option<chrono::DateTime<Utc>>,
+}
+
+fn json_value_into_string(val: &Value) -> Option<String> {
+    Some(val.as_str().map(|i| i.to_string()).unwrap_or("".into()))
+}
+
+fn deserialize_history_item(row: RqliteIterItem) -> Option<HistoryItem> {
+    let more_info = row.get_col("more_info", |val| Some(serde_json::from_value(val.to_owned())))
+        .transpose();
+    Some(HistoryItem {
+        id: row.get_col("id", |i| i.as_i64().map(|i| HistoryItemId::new(i))),
+        start_timestamp: row.get_col("start_timestamp", |e| e.as_i64()
+            .map(|i| match Utc.timestamp_millis_opt(i) {
+                LocalResult::Single(e) => e,
+                _ => chrono::Utc::now(),
+            })),
+        command_line: row.get_col("command_line", json_value_into_string).unwrap(),
+        session_id: row.get_col("session_id", |val| val.as_i64().map(HistorySessionId::new)),
+        hostname: row.get_col("hostname", json_value_into_string),
+        cwd: row.get_col("cwd", json_value_into_string),
+        duration: row.get_col("duration_ms", |val| val.as_u64().map(Duration::from_millis)),
+        exit_status: row.get_col("exit_status", |val| val.as_i64()),
+        more_info: more_info.unwrap_or(None),
+    })
+}
+
+impl History for RqliteBackedHistory {
+    fn save(&mut self, mut entry: HistoryItem) -> Result<HistoryItem> {
+        let payload = json!([
+            "insert into history
+                       (id,  start_timestamp,  command_line,  session_id,  hostname,  cwd,  duration_ms,  exit_status,  more_info)
+                values (:id, :start_timestamp, :command_line, :session_id, :hostname, :cwd, :duration_ms, :exit_status, :more_info)
+            on conflict (history.id) do update set
+                start_timestamp = excluded.start_timestamp,
+                command_line = excluded.command_line,
+                session_id = excluded.session_id,
+                hostname = excluded.hostname,
+                cwd = excluded.cwd,
+                duration_ms = excluded.duration_ms,
+                exit_status = excluded.exit_status,
+                more_info = excluded.more_info
+            returning id",
+            entry.id.map(|id| id.0),
+            entry.start_timestamp.map(|e| e.timestamp_millis()),
+            entry.command_line,
+            entry.session_id.map(|e| e.0),
+            entry.hostname,
+            entry.cwd,
+            entry.duration.map(|e| e.as_millis() as i64),
+            entry.exit_status,
+            entry.more_info.as_ref().map(|e| serde_json::to_string(e).unwrap_or("".into())),
+        ]);
+        let ret = self.db.execute()
+            .push_sql(payload)
+            .execute_run()
+            .map_err(map_rqlite_err)?
+            .next();
+        entry.id = if let Some(Mapping::Execute(ret)) = ret {
+            Some(HistoryItemId::new(ret.last_insert_id as i64))
+        } else { None };
+
+        Ok(entry)
+    }
+
+    fn load(&self, id: HistoryItemId) -> Result<HistoryItem> {
+        let entry = self.db.query()
+            .push_sql_str_slice(&["select * from history where id = :id", id.0.to_string().as_str()])
+            .query_run()
+            .map_err(map_rqlite_err)?
+            .next().unwrap()
+            .into_rqlite_iter(deserialize_history_item)
+            .map_err(map_rqlite_err)?
+            .next().unwrap();
+        Ok(entry)
+    }
+
+    fn count(&self, query: SearchQuery) -> Result<i64> {
+        let sql = self.construct_query(&query, "coalesce(count(*), 0)");
+        let result = self.db.query()
+            .set_sql(sql)
+            .query_run()
+            .map_err(map_rqlite_err)?
+            .next().unwrap()
+            .into_rqlite_iter(|row| row.get_idx(0, |val| val.as_i64()))
+            .map_err(map_rqlite_err)?
+            .next().unwrap();
+
+        Ok(result)
+    }
+
+    fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>> {
+        let sql = self.construct_query(&query, "*");
+        let mapping = self.db.query()
+            .set_sql(sql)
+            .query_run()
+            .map_err(map_rqlite_err)?
+            .next().unwrap()
+            ;
+        Ok(RqliteIter::new(mapping, deserialize_history_item)
+            .map_err(map_rqlite_err)?
+            .collect()
+        )
+    }
+
+    fn update(
+        &mut self,
+        id: HistoryItemId,
+        updater: &dyn Fn(HistoryItem) -> HistoryItem,
+    ) -> Result<()> {
+        // in theory this should run in a transaction
+        let item = self.load(id)?;
+        self.save(updater(item))?;
+        Ok(())
+    }
+
+    fn clear(&mut self) -> Result<()> {
+        self.db.execute()
+            .push_sql_str("delete from history")
+            .execute_run()
+            .map_err(map_rqlite_err)?;
+
+        self.db.execute()
+            .push_sql_str("VACUUM ")
+            .execute_run()
+            .map_err(map_rqlite_err)?;
+
+        Ok(())
+    }
+
+    fn delete(&mut self, entry: HistoryItemId) -> Result<()> {
+        self.db.execute()
+            .push_sql_str_slice(&["delete from history where id = ?", &entry.0.to_string()])
+            .execute_run()
+            .map_err(map_rqlite_err)?;
+
+        Ok(())
+    }
+
+    fn sync(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn session(&self) -> Option<HistorySessionId> {
+        self.session
+    }
+}
+
+impl RqliteBackedHistory {
+    /// Create rqlite backed history with url
+    ///
+    /// # Arguments 
+    ///
+    /// * `url`: The url of reachable rqlite instance
+    /// * `session`: Identify of history session
+    /// * `session_timestamp`: Shell session started time
+    ///
+    /// returns: Result<RqliteBackedHistory, ReedlineError> 
+    ///
+    /// # Examples 
+    ///
+    /// ```
+    /// use reedline::{Reedline, RqliteBackedHistory};
+    /// let history = RqliteBackedHistory::with_url(
+    ///   "http://localhost:4001",
+    ///   Reedline::create_history_session_id(),
+    ///   Some(chrono::Utc::now())
+    /// );
+    /// ```
+    pub fn with_url(
+        url: &str,
+        session: Option<HistorySessionId>,
+        session_timestamp: Option<chrono::DateTime<Utc>>,
+    ) -> Result<Self> {
+        let db = rqlite_client::Connection::new(url)
+            .map_err(map_rqlite_err)?;
+        Self::from_connection(db, session, session_timestamp)
+    }
+
+    /// initialize a new database / migrate an existing one
+    fn from_connection(
+        db: rqlite_client::Connection,
+        session: Option<HistorySessionId>,
+        session_timestamp: Option<chrono::DateTime<Utc>>,
+    ) -> Result<Self> {
+        let db_version = db.query()
+            .set_sql_str("SELECT user_version FROM pragma_user_version")
+            .query_run()
+            .map_err(map_rqlite_err)?
+            .next().unwrap()
+            .into_rqlite_iter(|row| row.get_idx(0, |val| val.as_i64()))
+            .map_err(map_rqlite_err)?
+            .next().unwrap();
+
+        if db_version != 0 {
+            return Err(ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(
+                format!("Unknown database version {db_version}"),
+            )));
+        }
+
+        let query = db.execute().push_sql_str("
+            create table if not exists history (
+                id integer primary key autoincrement,
+                command_line text not null,
+                start_timestamp integer,
+                session_id integer,
+                hostname text,
+                cwd text,
+                duration_ms integer,
+                exit_status integer,
+                more_info text
+            ) strict;
+            create index if not exists idx_history_time on history(start_timestamp);
+            create index if not exists idx_history_cwd on history(cwd); -- suboptimal for many hosts
+            create index if not exists idx_history_exit_status on history(exit_status);
+            create index if not exists idx_history_cmd on history(command_line);
+            create index if not exists idx_history_cmd on history(session_id);
+            -- todo: better indexes
+            ",
+        ).execute_run().map_err(map_rqlite_err)?;
+        if let Some(err) = query.first_error()
+        {
+            return Err(map_rqlite_err(err));
+        }
+
+        Ok(RqliteBackedHistory {
+            db,
+            session,
+            session_timestamp,
+        })
+    }
+
+    fn construct_query<'a>(
+        &self,
+        query: &'a SearchQuery,
+        select_expression: &str,
+    ) -> serde_json::Value {
+        let mut wheres = vec![];
+        let mut params = vec![];
+
+        let (is_asc, asc) = match query.direction {
+            SearchDirection::Forward => (true, "asc"),
+            SearchDirection::Backward => (false, "desc"),
+        };
+
+        if let Some(start_time) = query.start_time {
+            wheres.push(if is_asc { "timestamp_start > :start_time" } else { "timestamp_start < :start_time" });
+            params.push(json!(start_time.timestamp_millis()));
+        }
+        if let Some(end_time) = query.end_time {
+            wheres.push(if is_asc { ":end_time >= timestamp_start" } else { ":end_time <= timestamp_start" });
+            params.push(json!(end_time.timestamp_millis()));
+        }
+        if let Some(start_id) = query.start_id {
+            wheres.push(if is_asc { "id > :start_id" } else { "id < :start_id" });
+            params.push(json!(start_id));
+        }
+        if let Some(end_id) = query.end_id {
+            wheres.push(if is_asc { ":end_id >= id" } else { ":end_id <= id" });
+            params.push(json!(end_id));
+        }
+        if let Some(command_line) = &query.filter.command_line {
+            // TODO: escape %
+            let command_line_like = match command_line {
+                CommandLineSearch::Exact(e) => e.to_string(),
+                CommandLineSearch::Prefix(prefix) => format!("{prefix}%"),
+                CommandLineSearch::Substring(cont) => format!("%{cont}%"),
+            };
+            wheres.push("command_line like :command_line");
+            params.push(json!(command_line_like));
+        }
+        if let Some(str) = &query.filter.not_command_line {
+            wheres.push("command_line != :not_cmd");
+            params.push(json!(str));
+        }
+        if let Some(hostname) = &query.filter.hostname {
+            wheres.push("hostname = :hostname");
+            params.push(json!(hostname));
+        }
+        if let Some(cwd_exact) = &query.filter.cwd_exact {
+            wheres.push("cwd = :cwd");
+            params.push(json!(cwd_exact));
+        }
+        if let Some(cwd_prefix) = &query.filter.cwd_prefix {
+            wheres.push("cwd like :cwd_like");
+            params.push(json!(format!("{cwd_prefix}%")));
+        }
+        if let Some(exit_successful) = query.filter.exit_successful {
+            wheres.push(if exit_successful { " exit_status != 0" } else { " exit_status != 0" });
+        }
+        if let (Some(session_id), Some(session_timestamp)) = (query.filter.session, self.session_timestamp)
+        {
+            wheres.push("(session_id = :session_id OR start_timestamp < :session_timestamp)");
+            params.push(json!(session_id));
+            params.push(json!(session_timestamp.timestamp_millis()));
+        }
+        let limit = match query.limit {
+            Some(l) => {
+                params.push(json!(l));
+                "limit :limit"
+            }
+            None => "",
+        };
+
+        let wheres = if wheres.is_empty() { "true".into() } else { wheres.join(" and ") };
+        let query = format!(
+            "SELECT {select_expression}\
+             FROM history \
+             WHERE ({wheres}) \
+             ORDER BY id {asc} \
+             {limit}"
+        );
+        params.insert(0, json!(query));
+        json!(params)
+    }
+}
+
+trait AsStrVec {
+    fn as_str_vec(&self) -> Vec<&str>;
+}
+
+impl AsStrVec for Vec<String> {
+    fn as_str_vec(&self) -> Vec<&str> {
+        self.iter().map(|s| s.as_str()).collect()
+    }
+}
+
+fn map_rqlite_err<E>(err: E) -> ReedlineError where E: Debug {
+    // TODO: better error mapping
+    ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(format!(
+        "{err:?}"
+    )))
+}
+
+enum CarriedMapping {
+    Associative(rqlite_client::response::mapping::Associative),
+    Standard(rqlite_client::response::mapping::Standard),
+    Execute(rqlite_client::response::mapping::Execute),
+    Empty(rqlite_client::response::mapping::Empty),
+}
+
+enum RqliteIterRow<'a> {
+    HashMap(&'a HashMap<String, Value>),
+    Table { column: &'a [String], values: &'a Vec<Value> },
+}
+
+struct RqliteIterItem<'a>(RqliteIterRow<'a>);
+
+
+trait GetItem<T, F: Fn(&Value) -> Option<T>> {
+    fn get_idx(&self, idx: usize, f: F) -> Option<T>;
+    fn get_col(&self, col: &str, f: F) -> Option<T>;
+}
+
+impl<'a, T, F: Fn(&Value) -> Option<T>> GetItem<T, F> for RqliteIterItem<'a> {
+    fn get_idx(&self, idx: usize, f: F) -> Option<T> {
+        match &self.0 {
+            RqliteIterRow::HashMap(map) => map.values().skip(idx).next(),
+            RqliteIterRow::Table { values, .. } => values.get(idx)
+        }.and_then(f)
+    }
+
+    fn get_col(&self, col: &str, f: F) -> Option<T> {
+        match &self.0 {
+            RqliteIterRow::HashMap(map) => map.get(col),
+            RqliteIterRow::Table { column, values } => column.iter()
+                .find_position(|e| ***e == *col)
+                .and_then(|i| values.get(i.0))
+        }.and_then(f)
+    }
+}
+
+struct RqliteIter<T, F: Fn(RqliteIterItem) -> Option<T>> {
+    carried: CarriedMapping,
+    map_fn: F,
+    cur_row: usize,
+    row_count: usize,
+    _marker: PhantomData<T>,
+}
+
+impl<T, F: Fn(RqliteIterItem) -> Option<T>> RqliteIter<T, F> {
+    fn new(mapping: rqlite_client::Mapping, f: F) -> std::result::Result<RqliteIter<T, F>, rqlite_client::Error> {
+        match mapping {
+            Mapping::Associative(res) => Ok(RqliteIter {
+                row_count: res.rows.len(),
+                carried: CarriedMapping::Associative(res),
+                map_fn: f,
+                cur_row: 0,
+                _marker: PhantomData,
+            }),
+            Mapping::Standard(std) => Ok(RqliteIter {
+                row_count: std.values.as_ref().map(|i| i.len()).unwrap_or(0),
+                carried: CarriedMapping::Standard(std),
+                map_fn: f,
+                cur_row: 0,
+                _marker: PhantomData,
+            }),
+            Mapping::Execute(res) => Ok(RqliteIter {
+                row_count: res.rows.as_ref().map(|i| i.len()).unwrap_or(0),
+                carried: CarriedMapping::Execute(res),
+                map_fn: f,
+                cur_row: 0,
+                _marker: PhantomData,
+            }),
+            Mapping::Empty(res) => Ok(RqliteIter {
+                carried: CarriedMapping::Empty(res),
+                map_fn: f,
+                cur_row: 0,
+                row_count: 0,
+                _marker: PhantomData,
+            }),
+            Mapping::Error(e) => Err(rqlite_client::Error::ResultError(e.error.clone())),
+        }
+    }
+}
+
+trait IntoRqliteIter<T, F: Fn(RqliteIterItem) -> Option<T>> {
+    fn into_rqlite_iter(self, f: F) -> std::result::Result<RqliteIter<T, F>, rqlite_client::Error>;
+}
+
+impl<T, F: Fn(RqliteIterItem) -> Option<T>> IntoRqliteIter<T, F> for rqlite_client::Mapping {
+    fn into_rqlite_iter(self, f: F) -> std::result::Result<RqliteIter<T, F>, rqlite_client::Error> {
+        RqliteIter::new(self, f)
+    }
+}
+
+impl<T, F: Fn(RqliteIterItem) -> Option<T>> Iterator for RqliteIter<T, F> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cur_row >= self.row_count { return None; }
+        let item = match &self.carried {
+            CarriedMapping::Associative(res) => RqliteIterItem(RqliteIterRow::HashMap(&res.rows[self.cur_row])),
+            CarriedMapping::Execute(res) => {
+                let map = &res.rows.as_ref()
+                    .map(|i| &i[self.cur_row]);
+                match map {
+                    Some(map) => RqliteIterItem(RqliteIterRow::HashMap(map)),
+                    None => return None,
+                }
+            }
+            CarriedMapping::Standard(res) => RqliteIterItem(RqliteIterRow::Table {
+                column: res.columns.as_slice(),
+                values: res.values.as_ref().map(|i| &i[self.cur_row]).unwrap(),
+            }),
+            CarriedMapping::Empty(_) => return None,
+        };
+        self.cur_row += 1;
+
+        (self.map_fn)(item)
+    }
+}
+
+trait FirstError {
+    fn first_error(&self) -> Option<&rqlite_client::response::mapping::Error>;
+}
+
+impl FirstError for rqlite_client::response::Query {
+    fn first_error(&self) -> Option<&rqlite_client::response::mapping::Error> {
+        for map in self.results() {
+            if let Mapping::Error(err) = map {
+                return Some(err);
+            }
+        }
+        None
+    }
+}
+
+trait ExecuteRun {
+    fn execute_run(self) -> std::result::Result<rqlite_client::response::query::Query, rqlite_client::Error>;
+}
+
+trait QueryRun {
+    fn query_run(self) -> std::result::Result<rqlite_client::response::query::Query, rqlite_client::Error>;
+}
+
+impl<'a, T> ExecuteRun for rqlite_client::Query<'a, T>
+    where T: rqlite_client::state::State,
+{
+    fn execute_run(self) -> std::result::Result<rqlite_client::response::query::Query, rqlite_client::Error> {
+        let res = self.request_run()?;
+        let query = rqlite_client::response::query::Query::try_from(res).unwrap();
+        for map in query.results() {
+            if let Mapping::Error(err) = map {
+                return Err(rqlite_client::Error::ResultError(err.error.clone()));
+            }
+        }
+        Ok(query)
+    }
+}
+
+impl<'a, T> QueryRun for rqlite_client::Query<'a, T>
+    where T: rqlite_client::state::State,
+{
+    fn query_run(self) -> std::result::Result<rqlite_client::response::query::Query, rqlite_client::Error> {
+        let res = self.request_run()?;
+        Ok(rqlite_client::response::query::Query::try_from(res).unwrap())
+    }
+}

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -2,6 +2,7 @@ use super::{
     base::{CommandLineSearch, SearchDirection, SearchQuery},
     History, HistoryItem, HistoryItemId, HistorySessionId,
 };
+use crate::history::base::HistoryStorageDest;
 use crate::{
     result::{ReedlineError, ReedlineErrorVariants},
     Result,
@@ -9,7 +10,6 @@ use crate::{
 use chrono::{TimeZone, Utc};
 use rusqlite::{named_params, params, Connection, ToSql};
 use std::time::Duration;
-use crate::history::base::HistoryStorageDest;
 
 const SQLITE_APPLICATION_ID: i32 = 1151497937;
 
@@ -214,9 +214,11 @@ impl SqliteBackedHistory {
                 Self::from_connection(db, session, session_timestamp)
             }
             #[cfg(feature = "rqlite")]
-            HistoryStorageDest::Url(url) => Err(ReedlineError(
-                ReedlineErrorVariants::HistoryDatabaseError(format!("Expect file path, got Url: {}", url.to_string()))
-            )),
+            HistoryStorageDest::Url(url) => {
+                Err(ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(
+                    format!("Expect file path, got Url: {}", url.to_string()),
+                )))
+            }
         }
     }
     /// Creates a new history in memory
@@ -277,7 +279,7 @@ impl SqliteBackedHistory {
         -- todo: better indexes
         ",
         )
-            .map_err(map_sqlite_err)?;
+        .map_err(map_sqlite_err)?;
         Ok(SqliteBackedHistory {
             db,
             session,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,14 +242,14 @@ mod result;
 pub use result::{ReedlineError, ReedlineErrorVariants, Result};
 
 mod history;
-#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
-pub use history::SqliteBackedHistory;
 #[cfg(feature = "rqlite")]
 pub use history::RqliteBackedHistory;
+#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+pub use history::SqliteBackedHistory;
 pub use history::{
     CommandLineSearch, FileBackedHistory, History, HistoryItem, HistoryItemId,
-    HistoryNavigationQuery, HistorySessionId, SearchDirection, SearchFilter, SearchQuery,
-    HISTORY_SIZE, HistoryStorageDest,
+    HistoryNavigationQuery, HistorySessionId, HistoryStorageDest, SearchDirection, SearchFilter,
+    SearchQuery, HISTORY_SIZE,
 };
 
 mod prompt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,8 @@ pub use result::{ReedlineError, ReedlineErrorVariants, Result};
 mod history;
 #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
 pub use history::SqliteBackedHistory;
+#[cfg(feature = "rqlite")]
+pub use history::RqliteBackedHistory;
 pub use history::{
     CommandLineSearch, FileBackedHistory, History, HistoryItem, HistoryItemId,
     HistoryNavigationQuery, HistorySessionId, SearchDirection, SearchFilter, SearchQuery,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ pub use history::RqliteBackedHistory;
 pub use history::{
     CommandLineSearch, FileBackedHistory, History, HistoryItem, HistoryItemId,
     HistoryNavigationQuery, HistorySessionId, SearchDirection, SearchFilter, SearchQuery,
-    HISTORY_SIZE,
+    HISTORY_SIZE, HistoryStorageDest,
 };
 
 mod prompt;

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum ReedlineErrorVariants {
     // todo: we should probably be more specific here
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib", feature = "rqlite"))]
     /// Error within history database
     #[error("error within history database: {0}")]
     HistoryDatabaseError(String),


### PR DESCRIPTION
Hello theres.
This PR make Reedline and Nushell can storage command history into Rqlite, a distributed SQLite database. details [here](https://github.com/rqlite/rqlite?tab=readme-ov-file#why-run-rqlite).  
The new `RqliteBackedHistory` can connect to an Rqlite instance and storage history entries like sqlite.  
Support for nushell will be another PR, commits on [vcup/nushell#feat/rqlite](https://github.com/vcup/nushell/tree/feat/rqlite).  


## Motivation / Benefits
I have multiple machines and some "shell snippet" can exec across them. Using Rqlite can sync command history across multiple machines. Heres some tricks to make history commands completion more handy by adding a tag before command like this
```
❯ #shorthand
<some command here>
```
Syncing history across multiple machines can greatly enhance this trick.  

**Also:** 
- Search all history whenever they are typed on which machines. also enhanced the trick: leaving tags after commands makes them easier to search.

- When Nushell's history `file_format` is `"sqlite"`, it stores "hostname" into database. maybe we can use it to get nushell more intelligent? idk, but if we already save it, then synching history over multiple machines is natural.  

I have tried use some file [synching application](https://syncthing.net/) to sync my history files. However, if I open multiple instance of Nushell in difference machine at same time, syncing will conflict because sqlite's auxiliary files(they also host-specific). Not syncing them is not a option because network will randomlly lags.  

Thanks for considering this PR. Please let me know what you think.