### PR TITLE
Add PWD to the `Reedline` state

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -142,9 +142,9 @@ pub struct Reedline {
     // Use ansi coloring or not
     use_ansi_coloring: bool,
 
-    // Current working directory as defined by the application, which might not
-    // be the actual working directory of the process
-    cwd: String,
+    // Current working directory as defined by the application. If set, it will
+    // override the actual working directory of the process.
+    cwd: Option<String>,
 
     // Engine Menus
     menus: Vec<ReedlineMenu>,
@@ -228,7 +228,7 @@ impl Reedline {
             hide_hints: false,
             validator,
             use_ansi_coloring: true,
-            cwd: "".to_string(),
+            cwd: None,
             menus: Vec::new(),
             buffer_editor: None,
             cursor_shapes: None,
@@ -367,7 +367,7 @@ impl Reedline {
 
     /// Update current working directory.
     #[must_use]
-    pub fn with_cwd(mut self, cwd: String) -> Self {
+    pub fn with_cwd(mut self, cwd: Option<String>) -> Self {
         self.cwd = cwd;
         self
     }
@@ -1569,7 +1569,12 @@ impl Reedline {
                         .history
                         .search(SearchQuery::last_with_prefix_and_cwd(
                             parsed.prefix.unwrap().to_string(),
-                            self.cwd.clone(),
+                            self.cwd.clone().unwrap_or_else(|| {
+                                std::env::current_dir()
+                                    .unwrap_or_default()
+                                    .to_string_lossy()
+                                    .to_string()
+                            }),
                             self.get_history_session_id(),
                         ))
                         .unwrap_or_else(|_| Vec::new())
@@ -1752,7 +1757,12 @@ impl Reedline {
                     cursor_position_in_buffer,
                     self.history.as_ref(),
                     self.use_ansi_coloring,
-                    &self.cwd,
+                    &self.cwd.clone().unwrap_or_else(|| {
+                        std::env::current_dir()
+                            .unwrap_or_default()
+                            .to_string_lossy()
+                            .to_string()
+                    }),
                 )
             })
         } else {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -142,6 +142,10 @@ pub struct Reedline {
     // Use ansi coloring or not
     use_ansi_coloring: bool,
 
+    // Current working directory as defined by the application, which might not
+    // be the actual working directory of the process
+    cwd: String,
+
     // Engine Menus
     menus: Vec<ReedlineMenu>,
 
@@ -224,6 +228,7 @@ impl Reedline {
             hide_hints: false,
             validator,
             use_ansi_coloring: true,
+            cwd: "".to_string(),
             menus: Vec::new(),
             buffer_editor: None,
             cursor_shapes: None,
@@ -357,6 +362,13 @@ impl Reedline {
     #[must_use]
     pub fn with_ansi_colors(mut self, use_ansi_coloring: bool) -> Self {
         self.use_ansi_coloring = use_ansi_coloring;
+        self
+    }
+
+    /// Update current working directory.
+    #[must_use]
+    pub fn with_cwd(mut self, cwd: String) -> Self {
+        self.cwd = cwd;
         self
     }
 
@@ -1557,6 +1569,7 @@ impl Reedline {
                         .history
                         .search(SearchQuery::last_with_prefix_and_cwd(
                             parsed.prefix.unwrap().to_string(),
+                            self.cwd.clone(),
                             self.get_history_session_id(),
                         ))
                         .unwrap_or_else(|_| Vec::new())
@@ -1739,6 +1752,7 @@ impl Reedline {
                     cursor_position_in_buffer,
                     self.history.as_ref(),
                     self.use_ansi_coloring,
+                    &self.cwd,
                 )
             })
         } else {

--- a/src/hinter/cwd_aware.rs
+++ b/src/hinter/cwd_aware.rs
@@ -22,11 +22,13 @@ impl Hinter for CwdAwareHinter {
         #[allow(unused_variables)] pos: usize,
         history: &dyn History,
         use_ansi_coloring: bool,
+        cwd: &str,
     ) -> String {
         self.current_hint = if line.chars().count() >= self.min_chars {
             let with_cwd = history
                 .search(SearchQuery::last_with_prefix_and_cwd(
                     line.to_string(),
+                    cwd.to_string(),
                     history.session(),
                 ))
                 .or_else(|err| {

--- a/src/hinter/default.rs
+++ b/src/hinter/default.rs
@@ -15,6 +15,7 @@ impl Hinter for DefaultHinter {
         #[allow(unused_variables)] pos: usize,
         history: &dyn History,
         use_ansi_coloring: bool,
+        _cwd: &str,
     ) -> String {
         self.current_hint = if line.chars().count() >= self.min_chars {
             history

--- a/src/hinter/mod.rs
+++ b/src/hinter/mod.rs
@@ -40,6 +40,7 @@ pub trait Hinter: Send {
         pos: usize,
         history: &dyn History,
         use_ansi_coloring: bool,
+        cwd: &str,
     ) -> String;
 
     /// Return the current hint unformatted to perform the completion of the full hint

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -146,24 +146,14 @@ impl SearchQuery {
         ))
     }
 
-    /// Get the most recent entry starting with the `prefix` and `cwd` same as the current cwd
+    /// Get the most recent entry starting with the `prefix` and `cwd`
     pub fn last_with_prefix_and_cwd(
         prefix: String,
+        cwd: String,
         session: Option<HistorySessionId>,
     ) -> SearchQuery {
-        let cwd = std::env::current_dir();
-        if let Ok(cwd) = cwd {
-            SearchQuery::last_with_search(SearchFilter::from_text_search_cwd(
-                cwd.to_string_lossy().to_string(),
-                CommandLineSearch::Prefix(prefix),
-                session,
-            ))
-        } else {
-            SearchQuery::last_with_search(SearchFilter::from_text_search(
-                CommandLineSearch::Prefix(prefix),
-                session,
-            ))
-        }
+        let prefix = CommandLineSearch::Prefix(prefix);
+        SearchQuery::last_with_search(SearchFilter::from_text_search_cwd(cwd, prefix, session))
     }
 
     /// Query to get all entries in the given [`SearchDirection`]


### PR DESCRIPTION
This PR adds the current working directory as part of the `Reedline` state, instead of using `std::env::current_dir()` to retrieve it from the environment. Applications should call `Reedline::with_cwd()` to update the current working directory when it changes.

This is necessary to support https://github.com/nushell/nushell/pull/12922, which causes `std::env::current_dir()` to deviate from Nushell's `$env.PWD`.
