### PR TITLE
Add match_indices field to Suggestion

### DIFF
--- a/examples/fuzzy_completions.rs
+++ b/examples/fuzzy_completions.rs
@@ -1,0 +1,135 @@
+// Modifies the completions example to demonstrate highlighting of fuzzy completions
+// cargo run --example fuzzy_completions
+
+use reedline::{
+    default_emacs_keybindings, ColumnarMenu, Completer, DefaultPrompt, EditCommand, Emacs, KeyCode,
+    KeyModifiers, Keybindings, MenuBuilder, Reedline, ReedlineEvent, ReedlineMenu, Signal, Span,
+    Suggestion,
+};
+use std::io;
+
+struct HomegrownFuzzyCompleter(Vec<String>);
+
+impl Completer for HomegrownFuzzyCompleter {
+    fn complete(&mut self, line: &str, pos: usize) -> Vec<reedline::Suggestion> {
+        // Grandma's fuzzy matching recipe. She swears it's better than that crates.io-bought stuff
+        self.0
+            .iter()
+            .filter_map(|command_str| {
+                let command = command_str.chars().collect::<Vec<_>>();
+                let mut start = 0;
+                let mut match_indices = Vec::new();
+                for l in line.chars() {
+                    if start == command.len() {
+                        break;
+                    }
+                    let mut i = start;
+                    while i < command.len() && l != command[i] {
+                        i += 1;
+                    }
+                    if i < command.len() {
+                        match_indices.push(i);
+                        start = i + 1;
+                    }
+                }
+                if match_indices.is_empty() || match_indices.len() * 2 < pos {
+                    None
+                } else {
+                    Some(Suggestion {
+                        value: command_str.to_string(),
+                        description: None,
+                        style: None,
+                        extra: None,
+                        span: Span::new(pos - line.len(), pos),
+                        append_whitespace: false,
+                        match_indices: Some(match_indices),
+                    })
+                }
+            })
+            .collect()
+    }
+}
+
+fn add_menu_keybindings(keybindings: &mut Keybindings) {
+    keybindings.add_binding(
+        KeyModifiers::NONE,
+        KeyCode::Tab,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::Menu("completion_menu".to_string()),
+            ReedlineEvent::MenuNext,
+        ]),
+    );
+    keybindings.add_binding(
+        KeyModifiers::ALT,
+        KeyCode::Enter,
+        ReedlineEvent::Edit(vec![EditCommand::InsertNewline]),
+    );
+}
+
+fn main() -> io::Result<()> {
+    // Number of columns
+    let columns: u16 = 4;
+    // Column width
+    let col_width: Option<usize> = None;
+    // Column padding
+    let col_padding: usize = 2;
+
+    let commands = vec![
+        "test".into(),
+        "clear".into(),
+        "exit".into(),
+        "history 1".into(),
+        "history 2".into(),
+        "logout".into(),
+        "login".into(),
+        "hello world".into(),
+        "hello world reedline".into(),
+        "hello world something".into(),
+        "hello world another".into(),
+        "hello world 1".into(),
+        "hello world 2".into(),
+        "hello another very large option for hello word that will force one column".into(),
+        "this is the reedline crate".into(),
+        "abaaabas".into(),
+        "abaaacas".into(),
+        "ababac".into(),
+        "abacaxyc".into(),
+        "abadarabc".into(),
+    ];
+
+    let completer = Box::new(HomegrownFuzzyCompleter(commands));
+
+    // Use the interactive menu to select options from the completer
+    let columnar_menu = ColumnarMenu::default()
+        .with_name("completion_menu")
+        .with_columns(columns)
+        .with_column_width(col_width)
+        .with_column_padding(col_padding);
+
+    let completion_menu = Box::new(columnar_menu);
+
+    let mut keybindings = default_emacs_keybindings();
+    add_menu_keybindings(&mut keybindings);
+
+    let edit_mode = Box::new(Emacs::new(keybindings));
+
+    let mut line_editor = Reedline::create()
+        .with_completer(completer)
+        .with_menu(ReedlineMenu::EngineCompleter(completion_menu))
+        .with_edit_mode(edit_mode);
+
+    let prompt = DefaultPrompt::default();
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {buffer}");
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+        }
+    }
+}

--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -90,4 +90,7 @@ pub struct Suggestion {
     /// Whether to append a space after selecting this suggestion.
     /// This helps to avoid that a completer repeats the complete suggestion.
     pub append_whitespace: bool,
+    /// Indices of the characters in the suggestion that matched the typed text.
+    /// Useful if using fuzzy matching.
+    pub match_indices: Option<Vec<usize>>,
 }

--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -110,6 +110,7 @@ impl Completer for DefaultCompleter {
                                         extra: None,
                                         span,
                                         append_whitespace: false,
+                                        match_indices: None,
                                     }
                                 })
                                 .filter(|t| t.value.len() > (t.span.end - t.span.start))
@@ -384,6 +385,7 @@ mod tests {
                     extra: None,
                     span: Span { start: 0, end: 3 },
                     append_whitespace: false,
+                    match_indices: None,
                 },
                 Suggestion {
                     value: "ｎｕｍｂｅｒ".into(),
@@ -392,6 +394,7 @@ mod tests {
                     extra: None,
                     span: Span { start: 0, end: 3 },
                     append_whitespace: false,
+                    match_indices: None,
                 },
                 Suggestion {
                     value: "ｎｕｓｈｅｌｌ".into(),
@@ -400,6 +403,7 @@ mod tests {
                     extra: None,
                     span: Span { start: 0, end: 3 },
                     append_whitespace: false,
+                    match_indices: None,
                 },
             ]
         );
@@ -428,6 +432,7 @@ mod tests {
                     extra: None,
                     span: Span { start: 8, end: 9 },
                     append_whitespace: false,
+                    match_indices: None,
                 },
                 Suggestion {
                     value: "this is the reedline crate".into(),
@@ -436,6 +441,7 @@ mod tests {
                     extra: None,
                     span: Span { start: 8, end: 9 },
                     append_whitespace: false,
+                    match_indices: None,
                 },
                 Suggestion {
                     value: "this is the reedline crate".into(),
@@ -444,6 +450,7 @@ mod tests {
                     extra: None,
                     span: Span { start: 0, end: 9 },
                     append_whitespace: false,
+                    match_indices: None,
                 },
             ]
         );

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -65,6 +65,7 @@ impl<'menu> HistoryCompleter<'menu> {
             extra: None,
             span,
             append_whitespace: false,
+            match_indices: None,
         }
     }
 }

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -1,12 +1,13 @@
 use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
-    menu_functions::{can_partially_complete, completer_input, replace_in_buffer},
+    menu_functions::{
+        can_partially_complete, completer_input, replace_in_buffer, style_suggestion,
+    },
     painting::Painter,
     Completer, Suggestion,
 };
 use nu_ansi_term::ansi::RESET;
-use unicode_width::UnicodeWidthStr;
 
 /// Default values used as reference for the menu. These values are set during
 /// the initial declaration of the menu and are always kept as reference for the
@@ -301,32 +302,27 @@ impl ColumnarMenu {
         if use_ansi_coloring {
             let match_len = self.working_details.shortest_base_string.len();
 
-            // Split string so the match text can be styled
-            let (match_str, remaining_str) = suggestion.value.split_at(match_len);
-
-            let suggestion_style_prefix = suggestion
-                .style
-                .unwrap_or(self.settings.color.text_style)
-                .prefix();
+            let suggestion_style = suggestion.style.unwrap_or(self.settings.color.text_style);
 
             let left_text_size = self.longest_suggestion + self.default_details.col_padding;
             let right_text_size = self.get_width().saturating_sub(left_text_size);
 
-            let max_remaining = left_text_size.saturating_sub(match_str.width());
-            let max_match = max_remaining.saturating_sub(remaining_str.width());
+            let default_indices = (0..match_len).collect();
+            let match_indices = suggestion
+                .match_indices
+                .as_ref()
+                .unwrap_or(&default_indices);
 
             if index == self.index() {
                 if let Some(description) = &suggestion.description {
                     format!(
-                        "{}{}{}{}{}{:max_match$}{:max_remaining$}{}{}{}{}{}{}",
-                        suggestion_style_prefix,
-                        self.settings.color.selected_match_style.prefix(),
-                        match_str,
-                        RESET,
-                        suggestion_style_prefix,
-                        self.settings.color.selected_text_style.prefix(),
-                        &remaining_str,
-                        RESET,
+                        "{:left_text_size$}{}{}{}{}{}",
+                        style_suggestion(
+                            &suggestion.value,
+                            match_indices,
+                            &self.settings.color.selected_match_style,
+                            &self.settings.color.selected_text_style
+                        ),
                         self.settings.color.description_style.prefix(),
                         self.settings.color.selected_text_style.prefix(),
                         description
@@ -339,15 +335,13 @@ impl ColumnarMenu {
                     )
                 } else {
                     format!(
-                        "{}{}{}{}{}{}{}{}{:>empty$}{}",
-                        suggestion_style_prefix,
-                        self.settings.color.selected_match_style.prefix(),
-                        match_str,
-                        RESET,
-                        suggestion_style_prefix,
-                        self.settings.color.selected_text_style.prefix(),
-                        remaining_str,
-                        RESET,
+                        "{}{:>empty$}{}",
+                        style_suggestion(
+                            &suggestion.value,
+                            match_indices,
+                            &self.settings.color.selected_match_style,
+                            &self.settings.color.selected_text_style
+                        ),
                         "",
                         self.end_of_line(column),
                         empty = empty_space,
@@ -355,14 +349,13 @@ impl ColumnarMenu {
                 }
             } else if let Some(description) = &suggestion.description {
                 format!(
-                    "{}{}{}{}{:max_match$}{:max_remaining$}{}{}{}{}{}",
-                    suggestion_style_prefix,
-                    self.settings.color.match_style.prefix(),
-                    match_str,
-                    RESET,
-                    suggestion_style_prefix,
-                    remaining_str,
-                    RESET,
+                    "{:left_text_size$}{}{}{}{}",
+                    style_suggestion(
+                        &suggestion.value,
+                        match_indices,
+                        &self.settings.color.match_style,
+                        &suggestion_style
+                    ),
                     self.settings.color.description_style.prefix(),
                     description
                         .chars()
@@ -374,14 +367,13 @@ impl ColumnarMenu {
                 )
             } else {
                 format!(
-                    "{}{}{}{}{}{}{}{}{:>empty$}{}{}",
-                    suggestion_style_prefix,
-                    self.settings.color.match_style.prefix(),
-                    match_str,
-                    RESET,
-                    suggestion_style_prefix,
-                    remaining_str,
-                    RESET,
+                    "{}{}{:>empty$}{}{}",
+                    style_suggestion(
+                        &suggestion.value,
+                        match_indices,
+                        &self.settings.color.match_style,
+                        &suggestion_style
+                    ),
                     self.settings.color.description_style.prefix(),
                     "",
                     RESET,

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -750,6 +750,7 @@ mod tests {
             extra: None,
             span: Span { start: 0, end: pos },
             append_whitespace: false,
+            match_indices: None,
         }
     }
 

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -1382,6 +1382,7 @@ mod tests {
             extra: None,
             span: Span { start: 0, end: pos },
             append_whitespace: false,
+            match_indices: None,
         }
     }
 

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -1,7 +1,9 @@
 use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
-    menu_functions::{can_partially_complete, completer_input, replace_in_buffer},
+    menu_functions::{
+        can_partially_complete, completer_input, replace_in_buffer, style_suggestion,
+    },
     painting::Painter,
     Completer, Suggestion,
 };
@@ -514,41 +516,42 @@ impl IdeMenu {
         if use_ansi_coloring {
             let match_len = self.working_details.shortest_base_string.len();
 
-            // Split string so the match text can be styled
-            let (match_str, remaining_str) = string.split_at(match_len);
+            let default_indices = (0..match_len).collect();
+            let match_indices = suggestion
+                .match_indices
+                .as_ref()
+                .unwrap_or(&default_indices);
 
-            let suggestion_style_prefix = suggestion
-                .style
-                .unwrap_or(self.settings.color.text_style)
-                .prefix();
+            let suggestion_style = suggestion.style.unwrap_or(self.settings.color.text_style);
 
             if index == self.index() {
                 format!(
-                    "{}{}{}{}{}{}{}{}{}{}{}{}",
+                    "{}{}{}{}{}{}{}",
                     vertical_border,
-                    suggestion_style_prefix,
+                    suggestion_style.prefix(),
                     " ".repeat(padding),
-                    self.settings.color.selected_match_style.prefix(),
-                    match_str,
-                    RESET,
-                    suggestion_style_prefix,
-                    self.settings.color.selected_text_style.prefix(),
-                    remaining_str,
+                    style_suggestion(
+                        &suggestion.value,
+                        match_indices,
+                        &self.settings.color.selected_match_style,
+                        &self.settings.color.selected_text_style
+                    ),
                     " ".repeat(padding_right),
                     RESET,
                     vertical_border,
                 )
             } else {
                 format!(
-                    "{}{}{}{}{}{}{}{}{}{}{}",
+                    "{}{}{}{}{}{}{}",
                     vertical_border,
-                    suggestion_style_prefix,
+                    suggestion_style.prefix(),
                     " ".repeat(padding),
-                    self.settings.color.match_style.prefix(),
-                    match_str,
-                    RESET,
-                    suggestion_style_prefix,
-                    remaining_str,
+                    style_suggestion(
+                        &suggestion.value,
+                        match_indices,
+                        &self.settings.color.match_style,
+                        &suggestion_style
+                    ),
                     " ".repeat(padding_right),
                     RESET,
                     vertical_border,

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -1,4 +1,6 @@
 //! Collection of common functions that can be used to create menus
+use nu_ansi_term::{AnsiStrings, Style};
+
 use crate::{Editor, Suggestion, UndoBehavior};
 
 /// Index result obtained from parsing a string with an index marker
@@ -351,6 +353,36 @@ pub fn can_partially_complete(values: &[Suggestion], editor: &mut Editor) -> boo
     } else {
         false
     }
+}
+
+/// Style a suggestion to be shown in a completer menu
+pub fn style_suggestion(
+    suggestion: &str,
+    match_indices: &[usize],
+    match_style: &Style,
+    text_style: &Style,
+) -> String {
+    let mut parts = Vec::new();
+    let mut prev_styled = false;
+    let mut start = 0;
+    for i in 0..suggestion.len() {
+        if match_indices.contains(&i) {
+            if !prev_styled {
+                parts.push(text_style.paint(&suggestion[start..i]));
+                start = i;
+                prev_styled = true;
+            }
+        } else if prev_styled {
+            parts.push(match_style.paint(&suggestion[start..i]));
+            start = i;
+            prev_styled = false;
+        }
+    }
+
+    let last_style = if prev_styled { match_style } else { text_style };
+    parts.push(last_style.paint(&suggestion[start..]));
+
+    AnsiStrings(&parts).to_string()
 }
 
 #[cfg(test)]

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -611,6 +611,7 @@ mod tests {
                 extra: None,
                 span: Span::new(0, s.len()),
                 append_whitespace: false,
+                match_indices: None,
             })
             .collect();
         let res = find_common_string(&input);
@@ -631,6 +632,7 @@ mod tests {
                 extra: None,
                 span: Span::new(0, s.len()),
                 append_whitespace: false,
+                match_indices: None,
             })
             .collect();
         let res = find_common_string(&input);
@@ -686,6 +688,7 @@ mod tests {
                 extra: None,
                 span: Span::new(start, end),
                 append_whitespace: false,
+                match_indices: None,
             }),
             &mut editor,
         );

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -731,4 +731,15 @@ mod tests {
         assert_eq!(orig_buffer, editor.get_buffer());
         assert_eq!(orig_insertion_point, editor.insertion_point());
     }
+
+    #[test]
+    fn style_fuzzy_suggestion() {
+        let match_style = Style::new().italic();
+        let text_style = Style::new().dimmed();
+
+        assert_eq!(
+            "\u{1b}[2m\u{1b}[0m\u{1b}[3mab\u{1b}[0m\u{1b}[2mcd\u{1b}[0m\u{1b}[3me\u{1b}[0m\u{1b}[2mfg\u{1b}[0m",
+            style_suggestion("abcdefg", &[0, 1, 4], &match_style, &text_style)
+        );
+    }
 }


### PR DESCRIPTION
## Description

This PR adds a `match_indices: Vec<usize>` field to the `Suggestion` struct representing which indices of the Suggestion's `value` field were matched.

## Motivation

Currently, in Nushell, if you have fuzzy matching on, the matches are still highlighted with the assumption that you're using prefix matching:
![image](https://github.com/nushell/reedline/assets/45539777/c6493e51-6801-4716-b179-0233304c2e38)

This PR doesn't fix that, but adding `match_indices` to `Suggestion` does make it so that completers using fuzzy matching can include the indices of the matches in their returned suggestions. Here's the `fuzzy_completions` example included in this PR, which uses a columnar menu (ignore how bad the fuzzy completion algorithm is, I didn't bother using skim or Nucleo):

[![asciicast](https://asciinema.org/a/KeHlkgwdFSTrTHUIOycJ2TVzb.svg)](https://asciinema.org/a/KeHlkgwdFSTrTHUIOycJ2TVzb?t=5)

And modified to use an IDE menu with fake descriptions:

[![asciicast](https://asciinema.org/a/bOLaIbyLM8C6hasSqPGcE50Kh.svg)](https://asciinema.org/a/bOLaIbyLM8C6hasSqPGcE50Kh)

## Tests

I only added a test for the `style_suggestion` helper that I added for highlighting the matched portions of a suggestion. Other than that, I just manually tried the menu out a bit. If there are any edge cases anyone can think of to test (either through unit tests or manually), I'd appreciate that.