### PR TITLE
Make menus process events before updating working details

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -515,8 +515,42 @@ impl Menu for ColumnarMenu {
         painter: &Painter,
     ) {
         if let Some(event) = self.event.take() {
-            // The working value for the menu are updated first before executing any of the
-            // menu events
+            match event {
+                MenuEvent::Activate(updated) => {
+                    self.active = true;
+                    self.reset_position();
+
+                    self.input = if self.settings.only_buffer_difference {
+                        Some(editor.get_buffer().to_string())
+                    } else {
+                        None
+                    };
+
+                    if !updated {
+                        self.update_values(editor, completer);
+                    }
+                }
+                MenuEvent::Deactivate => self.active = false,
+                MenuEvent::Edit(updated) => {
+                    self.reset_position();
+
+                    if !updated {
+                        self.update_values(editor, completer);
+                    }
+                }
+                MenuEvent::NextElement => self.move_next(),
+                MenuEvent::PreviousElement => self.move_previous(),
+                MenuEvent::MoveUp => self.move_up(),
+                MenuEvent::MoveDown => self.move_down(),
+                MenuEvent::MoveLeft => self.move_left(),
+                MenuEvent::MoveRight => self.move_right(),
+                MenuEvent::PreviousPage | MenuEvent::NextPage => {
+                    // The columnar menu doest have the concept of pages, yet
+                }
+            }
+
+            // The working value for the menu are updated only after executing the menu events,
+            // so they have the latest suggestions
             //
             // If there is at least one suggestion that contains a description, then the layout
             // is changed to one column to fit the description
@@ -570,40 +604,6 @@ impl Menu for ColumnarMenu {
                     self.working_details.columns = self.default_details.columns.max(1);
                 } else {
                     self.working_details.columns = possible_cols;
-                }
-            }
-
-            match event {
-                MenuEvent::Activate(updated) => {
-                    self.active = true;
-                    self.reset_position();
-
-                    self.input = if self.settings.only_buffer_difference {
-                        Some(editor.get_buffer().to_string())
-                    } else {
-                        None
-                    };
-
-                    if !updated {
-                        self.update_values(editor, completer);
-                    }
-                }
-                MenuEvent::Deactivate => self.active = false,
-                MenuEvent::Edit(updated) => {
-                    self.reset_position();
-
-                    if !updated {
-                        self.update_values(editor, completer);
-                    }
-                }
-                MenuEvent::NextElement => self.move_next(),
-                MenuEvent::PreviousElement => self.move_previous(),
-                MenuEvent::MoveUp => self.move_up(),
-                MenuEvent::MoveDown => self.move_down(),
-                MenuEvent::MoveLeft => self.move_left(),
-                MenuEvent::MoveRight => self.move_right(),
-                MenuEvent::PreviousPage | MenuEvent::NextPage => {
-                    // The columnar menu doest have the concept of pages, yet
                 }
             }
         }

--- a/src/menu/description_menu.rs
+++ b/src/menu/description_menu.rs
@@ -462,56 +462,6 @@ impl Menu for DescriptionMenu {
         painter: &Painter,
     ) {
         if let Some(event) = self.event.take() {
-            // Updating all working parameters from the menu before executing any of the
-            // possible event
-            let max_width = self.get_values().iter().fold(0, |acc, suggestion| {
-                let str_len = suggestion.value.len() + self.default_details.col_padding;
-                if str_len > acc {
-                    str_len
-                } else {
-                    acc
-                }
-            });
-
-            // If no default width is found, then the total screen width is used to estimate
-            // the column width based on the default number of columns
-            let default_width = if let Some(col_width) = self.default_details.col_width {
-                col_width
-            } else {
-                let col_width = painter.screen_width() / self.default_details.columns;
-                col_width as usize
-            };
-
-            // Adjusting the working width of the column based the max line width found
-            // in the menu values
-            if max_width > default_width {
-                self.working_details.col_width = max_width;
-            } else {
-                self.working_details.col_width = default_width;
-            };
-
-            // The working columns is adjusted based on possible number of columns
-            // that could be fitted in the screen with the calculated column width
-            let possible_cols = painter.screen_width() / self.working_details.col_width as u16;
-            if possible_cols > self.default_details.columns {
-                self.working_details.columns = self.default_details.columns.max(1);
-            } else {
-                self.working_details.columns = possible_cols;
-            }
-
-            // Updating the working rows to display the description
-            if self.menu_required_lines(painter.screen_width()) <= painter.remaining_lines() {
-                self.working_details.description_rows = self.default_details.description_rows;
-                self.show_examples = true;
-            } else {
-                self.working_details.description_rows = painter
-                    .remaining_lines()
-                    .saturating_sub(self.default_details.selection_rows + 1)
-                    as usize;
-
-                self.show_examples = false;
-            }
-
             match event {
                 MenuEvent::Activate(_) => {
                     self.reset_position();
@@ -577,6 +527,54 @@ impl Menu for DescriptionMenu {
                     }
                 }
                 MenuEvent::PreviousPage | MenuEvent::NextPage => {}
+            }
+
+            let max_width = self.get_values().iter().fold(0, |acc, suggestion| {
+                let str_len = suggestion.value.len() + self.default_details.col_padding;
+                if str_len > acc {
+                    str_len
+                } else {
+                    acc
+                }
+            });
+
+            // If no default width is found, then the total screen width is used to estimate
+            // the column width based on the default number of columns
+            let default_width = if let Some(col_width) = self.default_details.col_width {
+                col_width
+            } else {
+                let col_width = painter.screen_width() / self.default_details.columns;
+                col_width as usize
+            };
+
+            // Adjusting the working width of the column based the max line width found
+            // in the menu values
+            if max_width > default_width {
+                self.working_details.col_width = max_width;
+            } else {
+                self.working_details.col_width = default_width;
+            };
+
+            // The working columns is adjusted based on possible number of columns
+            // that could be fitted in the screen with the calculated column width
+            let possible_cols = painter.screen_width() / self.working_details.col_width as u16;
+            if possible_cols > self.default_details.columns {
+                self.working_details.columns = self.default_details.columns.max(1);
+            } else {
+                self.working_details.columns = possible_cols;
+            }
+
+            // Updating the working rows to display the description
+            if self.menu_required_lines(painter.screen_width()) <= painter.remaining_lines() {
+                self.working_details.description_rows = self.default_details.description_rows;
+                self.show_examples = true;
+            } else {
+                self.working_details.description_rows = painter
+                    .remaining_lines()
+                    .saturating_sub(self.default_details.selection_rows + 1)
+                    as usize;
+
+                self.show_examples = false;
             }
         }
     }

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -652,7 +652,6 @@ impl Menu for IdeMenu {
         painter: &Painter,
     ) {
         if let Some(event) = self.event.take() {
-            // The working value for the menu are updated first before executing any of the
             match event {
                 MenuEvent::Activate(updated) => {
                     self.active = true;


### PR DESCRIPTION
This PR makes the columnar and description menus update their lists of suggestions after processing events (in `update_working_details`), rather than before. Currently, these menus can be rendered with outdated working details.

The completions example in Reedline itself demonstrates this. Here's how it looks currently (I modified the default completer to add a dummy description just for this recording):
[![asciicast](https://asciinema.org/a/pd84reD58dR487a7oQ8VVV6iR.svg)](https://asciinema.org/a/pd84reD58dR487a7oQ8VVV6iR?t=2)

Here's how the columnar menu looks after this PR:
[![asciicast](https://asciinema.org/a/rwrWi6lHqTG2pUP5cGcQ8Bx6I.svg)](https://asciinema.org/a/rwrWi6lHqTG2pUP5cGcQ8Bx6I)

Description menu (before):
[![asciicast](https://asciinema.org/a/qeh6wysIoVRwdCjh7iI8JKE6S.svg)](https://asciinema.org/a/qeh6wysIoVRwdCjh7iI8JKE6S?t=6)

Description menu (after):
[![asciicast](https://asciinema.org/a/RLwikRIqaXv1moJ7igbF2nbA6.svg)](https://asciinema.org/a/RLwikRIqaXv1moJ7igbF2nbA6?t=4)

I assume there was a reason for originally updating working details before processing events, given that both the columnar and description menu have comments explicitly saying that that's what they're doing. However, reading the code, I didn't see any reason to believe that processing the events first would mess with the working details, I didn't run into any problems myself, and the new IDE menu made by maxomatic458 (which processes events before updating working details) seems to work just fine. If anyone knows of any possible problems with processing events first, do let me know, but otherwise, I think this PR is safe to merge.