### PR TITLE
Feature: vi visual mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,13 +222,13 @@ Reedline has now all the basic features to become the primary line editor for [n
 - Undo support.
 - Clipboard integration
 - Line completeness validation for seamless entry of multiline command sequences.
+- Visual selection
 
 ### Areas for future improvements
 
 - [ ] Support for Unicode beyond simple left-to-right scripts
 - [ ] Easier keybinding configuration
 - [ ] Support for more advanced vi commands
-- [ ] Visual selection
 - [ ] Smooth experience if completion or prompt content takes long to compute
 - [ ] Support for a concurrent output stream from background tasks to be displayed, while the input prompt is active. ("Full duplex" mode)
 

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -147,8 +147,9 @@ impl Command {
             Self::SubstituteCharWithInsert => vec![ReedlineOption::Edit(EditCommand::CutChar)],
             Self::HistorySearch => vec![ReedlineOption::Event(ReedlineEvent::SearchHistory)],
             Self::Switchcase => vec![ReedlineOption::Edit(EditCommand::SwitchcaseChar)],
-            // Mark a command as incomplete whenever a motion is required to finish the command
-            Self::Delete | Self::Change | Self::Incomplete => vec![ReedlineOption::Incomplete],
+            // Whenever a motion is required to finish the command we must be in visual mode
+            Self::Delete | Self::Change => vec![ReedlineOption::Edit(EditCommand::CutSelection)],
+            Self::Incomplete => vec![ReedlineOption::Incomplete],
             Command::RepeatLastAction => match &vi_state.previous {
                 Some(event) => vec![ReedlineOption::Event(event.clone())],
                 None => vec![],

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -89,8 +89,8 @@ impl EditMode for Vi {
                             self.cache.clear();
                             ReedlineEvent::None
                         } else if res.is_complete(self.mode) {
-                            if res.enters_insert_mode() {
-                                self.mode = ViMode::Insert;
+                            if let Some(mode) = res.changes_mode() {
+                                self.mode = mode;
                             }
 
                             let event = res.to_reedline_event(self);

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -19,6 +19,7 @@ use crate::{
 enum ViMode {
     Normal,
     Insert,
+    Visual,
 }
 
 /// This parses incoming input `Event`s like a Vi-Style editor
@@ -62,7 +63,12 @@ impl EditMode for Vi {
             Event::Key(KeyEvent {
                 code, modifiers, ..
             }) => match (self.mode, modifiers, code) {
-                (ViMode::Normal, modifier, KeyCode::Char(c)) => {
+                (ViMode::Normal, KeyModifiers::NONE, KeyCode::Char('v')) => {
+                    self.cache.clear();
+                    self.mode = ViMode::Visual;
+                    ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint])
+                }
+                (ViMode::Normal|ViMode::Visual, modifier, KeyCode::Char(c)) => {
                     let c = c.to_ascii_lowercase();
 
                     if let Some(event) = self
@@ -143,7 +149,7 @@ impl EditMode for Vi {
                     self.mode = ViMode::Insert;
                     ReedlineEvent::Enter
                 }
-                (ViMode::Normal, _, _) => self
+                (ViMode::Normal|ViMode::Visual, _, _) => self
                     .normal_keybindings
                     .find_binding(modifiers, code)
                     .unwrap_or(ReedlineEvent::None),
@@ -165,7 +171,7 @@ impl EditMode for Vi {
 
     fn edit_mode(&self) -> PromptEditMode {
         match self.mode {
-            ViMode::Normal => PromptEditMode::Vi(PromptViMode::Normal),
+            ViMode::Normal|ViMode::Visual => PromptEditMode::Vi(PromptViMode::Normal),
             ViMode::Insert => PromptEditMode::Vi(PromptViMode::Insert),
         }
     }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -68,7 +68,7 @@ impl EditMode for Vi {
                     self.mode = ViMode::Visual;
                     ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint])
                 }
-                (ViMode::Normal|ViMode::Visual, modifier, KeyCode::Char(c)) => {
+                (ViMode::Normal | ViMode::Visual, modifier, KeyCode::Char(c)) => {
                     let c = c.to_ascii_lowercase();
 
                     if let Some(event) = self
@@ -149,7 +149,7 @@ impl EditMode for Vi {
                     self.mode = ViMode::Insert;
                     ReedlineEvent::Enter
                 }
-                (ViMode::Normal|ViMode::Visual, _, _) => self
+                (ViMode::Normal | ViMode::Visual, _, _) => self
                     .normal_keybindings
                     .find_binding(modifiers, code)
                     .unwrap_or(ReedlineEvent::None),
@@ -171,7 +171,7 @@ impl EditMode for Vi {
 
     fn edit_mode(&self) -> PromptEditMode {
         match self.mode {
-            ViMode::Normal|ViMode::Visual => PromptEditMode::Vi(PromptViMode::Normal),
+            ViMode::Normal | ViMode::Visual => PromptEditMode::Vi(PromptViMode::Normal),
             ViMode::Insert => PromptEditMode::Vi(PromptViMode::Insert),
         }
     }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -88,7 +88,7 @@ impl EditMode for Vi {
                         if !res.is_valid() {
                             self.cache.clear();
                             ReedlineEvent::None
-                        } else if res.is_complete() {
+                        } else if res.is_complete(self.mode) {
                             if res.enters_insert_mode() {
                                 self.mode = ViMode::Insert;
                             }

--- a/src/edit_mode/vi/motion.rs
+++ b/src/edit_mode/vi/motion.rs
@@ -1,6 +1,6 @@
 use std::iter::Peekable;
 
-use crate::{EditCommand, ReedlineEvent, Vi};
+use crate::{EditCommand, ReedlineEvent, Vi, edit_mode::vi::ViMode};
 
 use super::parser::{ParseResult, ReedlineOption};
 
@@ -142,6 +142,7 @@ pub enum Motion {
 
 impl Motion {
     pub fn to_reedline(&self, vi_state: &mut Vi) -> Vec<ReedlineOption> {
+        let select_mode = vi_state.mode == ViMode::Visual;
         match self {
             Motion::Left => vec![ReedlineOption::Event(ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::MenuLeft,
@@ -161,70 +162,70 @@ impl Motion {
                 ReedlineEvent::Down,
             ]))],
             Motion::NextWord => vec![ReedlineOption::Edit(EditCommand::MoveWordRightStart {
-                select: false,
+                select: select_mode,
             })],
             Motion::NextBigWord => vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightStart {
-                select: false,
+                select: select_mode,
             })],
             Motion::NextWordEnd => vec![ReedlineOption::Edit(EditCommand::MoveWordRightEnd {
-                select: false,
+                select: select_mode,
             })],
             Motion::NextBigWordEnd => {
                 vec![ReedlineOption::Edit(EditCommand::MoveBigWordRightEnd {
-                    select: false,
+                    select: select_mode,
                 })]
             }
             Motion::PreviousWord => vec![ReedlineOption::Edit(EditCommand::MoveWordLeft {
-                select: false,
+                select: select_mode,
             })],
             Motion::PreviousBigWord => vec![ReedlineOption::Edit(EditCommand::MoveBigWordLeft {
-                select: false,
+                select: select_mode,
             })],
             Motion::Line => vec![], // Placeholder as unusable standalone motion
             Motion::Start => vec![ReedlineOption::Edit(EditCommand::MoveToLineStart {
-                select: false,
+                select: select_mode,
             })],
             Motion::End => vec![ReedlineOption::Edit(EditCommand::MoveToLineEnd {
-                select: false,
+                select: select_mode,
             })],
             Motion::RightUntil(ch) => {
                 vi_state.last_char_search = Some(ViCharSearch::ToRight(*ch));
                 vec![ReedlineOption::Edit(EditCommand::MoveRightUntil {
                     c: *ch,
-                    select: false,
+                    select: select_mode,
                 })]
             }
             Motion::RightBefore(ch) => {
                 vi_state.last_char_search = Some(ViCharSearch::TillRight(*ch));
                 vec![ReedlineOption::Edit(EditCommand::MoveRightBefore {
                     c: *ch,
-                    select: false,
+                    select: select_mode,
                 })]
             }
             Motion::LeftUntil(ch) => {
                 vi_state.last_char_search = Some(ViCharSearch::ToLeft(*ch));
                 vec![ReedlineOption::Edit(EditCommand::MoveLeftUntil {
                     c: *ch,
-                    select: false,
+                    select: select_mode,
                 })]
             }
             Motion::LeftBefore(ch) => {
                 vi_state.last_char_search = Some(ViCharSearch::TillLeft(*ch));
                 vec![ReedlineOption::Edit(EditCommand::MoveLeftBefore {
                     c: *ch,
-                    select: false,
+                    select: select_mode,
                 })]
             }
             Motion::ReplayCharSearch => {
                 if let Some(char_search) = vi_state.last_char_search.as_ref() {
-                    vec![ReedlineOption::Edit(char_search.to_move())]
+                    vec![ReedlineOption::Edit(char_search.to_move(select_mode))]
                 } else {
                     vec![]
                 }
             }
             Motion::ReverseCharSearch => {
                 if let Some(char_search) = vi_state.last_char_search.as_ref() {
-                    vec![ReedlineOption::Edit(char_search.reverse().to_move())]
+                    vec![ReedlineOption::Edit(char_search.reverse().to_move(select_mode))]
                 } else {
                     vec![]
                 }
@@ -257,23 +258,23 @@ impl ViCharSearch {
         }
     }
 
-    pub fn to_move(&self) -> EditCommand {
+    pub fn to_move(&self, select_mode: bool) -> EditCommand {
         match self {
             ViCharSearch::ToRight(c) => EditCommand::MoveRightUntil {
                 c: *c,
-                select: false,
+                select: select_mode,
             },
             ViCharSearch::ToLeft(c) => EditCommand::MoveLeftUntil {
                 c: *c,
-                select: false,
+                select: select_mode,
             },
             ViCharSearch::TillRight(c) => EditCommand::MoveRightBefore {
                 c: *c,
-                select: false,
+                select: select_mode,
             },
             ViCharSearch::TillLeft(c) => EditCommand::MoveLeftBefore {
                 c: *c,
-                select: false,
+                select: select_mode,
             },
         }
     }

--- a/src/edit_mode/vi/motion.rs
+++ b/src/edit_mode/vi/motion.rs
@@ -1,6 +1,6 @@
 use std::iter::Peekable;
 
-use crate::{EditCommand, ReedlineEvent, Vi, edit_mode::vi::ViMode};
+use crate::{edit_mode::vi::ViMode, EditCommand, ReedlineEvent, Vi};
 
 use super::parser::{ParseResult, ReedlineOption};
 
@@ -146,12 +146,16 @@ impl Motion {
         match self {
             Motion::Left => vec![ReedlineOption::Event(ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::MenuLeft,
-                ReedlineEvent::Edit(vec![EditCommand::MoveLeft { select: select_mode, }])
+                ReedlineEvent::Edit(vec![EditCommand::MoveLeft {
+                    select: select_mode,
+                }]),
             ]))],
             Motion::Right => vec![ReedlineOption::Event(ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::HistoryHintComplete,
                 ReedlineEvent::MenuRight,
-                ReedlineEvent::Edit(vec![EditCommand::MoveRight { select: select_mode, }]),
+                ReedlineEvent::Edit(vec![EditCommand::MoveRight {
+                    select: select_mode,
+                }]),
             ]))],
             Motion::Up => vec![ReedlineOption::Event(ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::MenuUp,
@@ -227,7 +231,9 @@ impl Motion {
             }
             Motion::ReverseCharSearch => {
                 if let Some(char_search) = vi_state.last_char_search.as_ref() {
-                    vec![ReedlineOption::Edit(char_search.reverse().to_move(select_mode))]
+                    vec![ReedlineOption::Edit(
+                        char_search.reverse().to_move(select_mode),
+                    )]
                 } else {
                     vec![]
                 }

--- a/src/edit_mode/vi/motion.rs
+++ b/src/edit_mode/vi/motion.rs
@@ -146,20 +146,22 @@ impl Motion {
         match self {
             Motion::Left => vec![ReedlineOption::Event(ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::MenuLeft,
-                ReedlineEvent::Left,
+                ReedlineEvent::Edit(vec![EditCommand::MoveLeft { select: select_mode, }])
             ]))],
             Motion::Right => vec![ReedlineOption::Event(ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::HistoryHintComplete,
                 ReedlineEvent::MenuRight,
-                ReedlineEvent::Right,
+                ReedlineEvent::Edit(vec![EditCommand::MoveRight { select: select_mode, }]),
             ]))],
             Motion::Up => vec![ReedlineOption::Event(ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::MenuUp,
                 ReedlineEvent::Up,
+                // todo: add EditCommand::MoveLineUp
             ]))],
             Motion::Down => vec![ReedlineOption::Event(ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::MenuDown,
                 ReedlineEvent::Down,
+                // todo: add EditCommand::MoveLineDown
             ]))],
             Motion::NextWord => vec![ReedlineOption::Edit(EditCommand::MoveWordRightStart {
                 select: select_mode,

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -106,6 +106,7 @@ impl ParsedViSequence {
                 )
                 | (Some(Command::HistorySearch), ParseResult::Incomplete)
                 | (Some(Command::Change), ParseResult::Valid(_)) => Some(ViMode::Insert),
+            (Some(Command::Delete), ParseResult::Incomplete) => Some(ViMode::Normal),
             _ => None
         }
     }

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -425,16 +425,16 @@ mod tests {
         ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::HistoryHintComplete,
                 ReedlineEvent::MenuRight,
-                ReedlineEvent::Right,
+                ReedlineEvent::Edit(vec![EditCommand::MoveRight{select:false}]),
             ]),ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::HistoryHintComplete,
                 ReedlineEvent::MenuRight,
-                ReedlineEvent::Right,
+                ReedlineEvent::Edit(vec![EditCommand::MoveRight{select:false}]),
             ]) ]))]
     #[case(&['l'], ReedlineEvent::Multiple(vec![ReedlineEvent::UntilFound(vec![
                 ReedlineEvent::HistoryHintComplete,
                 ReedlineEvent::MenuRight,
-                ReedlineEvent::Right,
+                ReedlineEvent::Edit(vec![EditCommand::MoveRight{select:false}]),
             ])]))]
     #[case(&['0'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineStart{select:false}])]))]
     #[case(&['$'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineEnd{select:false}])]))]
@@ -458,6 +458,66 @@ mod tests {
     #[case(&['d', 'B'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutBigWordLeft])]))]
     fn test_reedline_move(#[case] input: &[char], #[case] expected: ReedlineEvent) {
         let mut vi = Vi::default();
+        let res = vi_parse(input);
+        let output = res.to_reedline_event(&mut vi);
+
+        assert_eq!(output, expected);
+    }
+
+    #[rstest]
+    #[case(&['2', 'k'], ReedlineEvent::Multiple(vec![ReedlineEvent::UntilFound(vec![
+                ReedlineEvent::MenuUp,
+                ReedlineEvent::Up,
+            ]), ReedlineEvent::UntilFound(vec![
+                ReedlineEvent::MenuUp,
+                ReedlineEvent::Up,
+            ])]))]
+    #[case(&['k'], ReedlineEvent::Multiple(vec![ReedlineEvent::UntilFound(vec![
+                ReedlineEvent::MenuUp,
+                ReedlineEvent::Up,
+            ])]))]
+    #[case(&['w'],
+        ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveWordRightStart{select:true}])]))]
+    #[case(&['W'],
+        ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveBigWordRightStart{select:true}])]))]
+    #[case(&['2', 'l'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::UntilFound(vec![
+                ReedlineEvent::HistoryHintComplete,
+                ReedlineEvent::MenuRight,
+                ReedlineEvent::Edit(vec![EditCommand::MoveRight{select:true}]),
+            ]),ReedlineEvent::UntilFound(vec![
+                ReedlineEvent::HistoryHintComplete,
+                ReedlineEvent::MenuRight,
+                ReedlineEvent::Edit(vec![EditCommand::MoveRight{select:true}]),
+            ]) ]))]
+    #[case(&['l'], ReedlineEvent::Multiple(vec![ReedlineEvent::UntilFound(vec![
+                ReedlineEvent::HistoryHintComplete,
+                ReedlineEvent::MenuRight,
+                ReedlineEvent::Edit(vec![EditCommand::MoveRight{select:true}]),
+            ])]))]
+    #[case(&['0'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineStart{select:true}])]))]
+    #[case(&['$'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::MoveToLineEnd{select:true}])]))]
+    #[case(&['i'], ReedlineEvent::Multiple(vec![ReedlineEvent::Repaint]))]
+    #[case(&['p'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter])]))]
+    #[case(&['2', 'p'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter]),
+        ReedlineEvent::Edit(vec![EditCommand::PasteCutBufferAfter])
+        ]))]
+    #[case(&['u'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::Undo])]))]
+    #[case(&['2', 'u'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Edit(vec![EditCommand::Undo]),
+        ReedlineEvent::Edit(vec![EditCommand::Undo])
+        ]))]
+    #[case(&['d', 'd'], ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Edit(vec![EditCommand::CutCurrentLine])]))]
+    #[case(&['d', 'w'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRightToNext])]))]
+    #[case(&['d', 'W'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutBigWordRightToNext])]))]
+    #[case(&['d', 'e'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordRight])]))]
+    #[case(&['d', 'b'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutWordLeft])]))]
+    #[case(&['d', 'B'], ReedlineEvent::Multiple(vec![ReedlineEvent::Edit(vec![EditCommand::CutBigWordLeft])]))]
+    fn test_reedline_move_in_visual_mode(#[case] input: &[char], #[case] expected: ReedlineEvent) {
+        let mut vi = Vi::default();
+        vi.mode = ViMode::Visual;
         let res = vi_parse(input);
         let output = res.to_reedline_event(&mut vi);
 

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -1,6 +1,6 @@
 use super::command::{parse_command, Command};
 use super::motion::{parse_motion, Motion};
-use crate::{EditCommand, ReedlineEvent, Vi};
+use crate::{EditCommand, ReedlineEvent, Vi, edit_mode::vi::ViMode};
 use std::iter::Peekable;
 
 #[derive(Debug, Clone)]
@@ -50,11 +50,12 @@ impl ParsedViSequence {
         !self.motion.is_invalid()
     }
 
-    pub fn is_complete(&self) -> bool {
+    pub fn is_complete(&self, mode: ViMode) -> bool {
+        assert!(mode == ViMode::Normal || mode == ViMode::Visual);
         match (&self.command, &self.motion) {
             (None, ParseResult::Valid(_)) => true,
             (Some(Command::Incomplete), _) => false,
-            (Some(cmd), ParseResult::Incomplete) if !cmd.requires_motion() => true,
+            (Some(cmd), ParseResult::Incomplete) if !cmd.requires_motion() || mode == ViMode::Visual => true,
             (Some(_), ParseResult::Valid(_)) => true,
             (Some(cmd), ParseResult::Incomplete) if cmd.requires_motion() => false,
             _ => false,
@@ -203,7 +204,8 @@ mod tests {
             }
         );
         assert_eq!(output.is_valid(), true);
-        assert_eq!(output.is_complete(), true);
+        assert_eq!(output.is_complete(ViMode::Normal), true);
+        assert_eq!(output.is_complete(ViMode::Visual), true);
     }
 
     #[test]
@@ -221,7 +223,8 @@ mod tests {
             }
         );
         assert_eq!(output.is_valid(), true);
-        assert_eq!(output.is_complete(), true);
+        assert_eq!(output.is_complete(ViMode::Normal), true);
+        assert_eq!(output.is_complete(ViMode::Visual), true);
     }
 
     #[test]
@@ -239,7 +242,8 @@ mod tests {
             }
         );
         assert_eq!(output.is_valid(), true);
-        assert_eq!(output.is_complete(), true);
+        assert_eq!(output.is_complete(ViMode::Normal), true);
+        assert_eq!(output.is_complete(ViMode::Visual), true);
     }
 
     #[test]
@@ -257,7 +261,8 @@ mod tests {
             }
         );
         assert_eq!(output.is_valid(), true);
-        assert_eq!(output.is_complete(), true);
+        assert_eq!(output.is_complete(ViMode::Normal), true);
+        assert_eq!(output.is_complete(ViMode::Visual), true);
     }
 
     #[test]
@@ -275,7 +280,8 @@ mod tests {
             }
         );
         assert_eq!(output.is_valid(), true);
-        assert_eq!(output.is_complete(), true);
+        assert_eq!(output.is_complete(ViMode::Normal), true);
+        assert_eq!(output.is_complete(ViMode::Visual), true);
     }
 
     #[test]
@@ -293,7 +299,8 @@ mod tests {
             }
         );
         assert_eq!(output.is_valid(), true);
-        assert_eq!(output.is_complete(), true);
+        assert_eq!(output.is_complete(ViMode::Normal), true);
+        assert_eq!(output.is_complete(ViMode::Visual), true);
     }
 
     #[test]
@@ -329,7 +336,8 @@ mod tests {
         );
 
         assert_eq!(output.is_valid(), true);
-        assert_eq!(output.is_complete(), false);
+        assert_eq!(output.is_complete(ViMode::Normal), false);
+        assert_eq!(output.is_complete(ViMode::Visual), false);
     }
 
     #[test]
@@ -347,7 +355,8 @@ mod tests {
             }
         );
         assert_eq!(output.is_valid(), true);
-        assert_eq!(output.is_complete(), false);
+        assert_eq!(output.is_complete(ViMode::Normal), false);
+        assert_eq!(output.is_complete(ViMode::Visual), false);
     }
 
     #[test]
@@ -366,7 +375,8 @@ mod tests {
         );
 
         assert_eq!(output.is_valid(), true);
-        assert_eq!(output.is_complete(), true);
+        assert_eq!(output.is_complete(ViMode::Normal), true);
+        assert_eq!(output.is_complete(ViMode::Visual), true);
     }
 
     #[test]
@@ -384,7 +394,8 @@ mod tests {
             }
         );
         assert_eq!(output.is_valid(), true);
-        assert_eq!(output.is_complete(), true);
+        assert_eq!(output.is_complete(ViMode::Normal), true);
+        assert_eq!(output.is_complete(ViMode::Visual), true);
     }
 
     #[test]
@@ -402,7 +413,8 @@ mod tests {
             }
         );
         assert_eq!(output.is_valid(), true);
-        assert_eq!(output.is_complete(), true);
+        assert_eq!(output.is_complete(ViMode::Normal), true);
+        assert_eq!(output.is_complete(ViMode::Visual), true);
     }
 
     #[rstest]

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -92,9 +92,8 @@ impl ParsedViSequence {
         }
     }
 
-    pub fn enters_insert_mode(&self) -> bool {
-        matches!(
-            (&self.command, &self.motion),
+    pub fn changes_mode(&self) -> Option<ViMode>{
+        match (&self.command, &self.motion) {
             (Some(Command::EnterViInsert), ParseResult::Incomplete)
                 | (Some(Command::EnterViAppend), ParseResult::Incomplete)
                 | (Some(Command::ChangeToLineEnd), ParseResult::Incomplete)
@@ -106,8 +105,9 @@ impl ParsedViSequence {
                     ParseResult::Incomplete
                 )
                 | (Some(Command::HistorySearch), ParseResult::Incomplete)
-                | (Some(Command::Change), ParseResult::Valid(_))
-        )
+                | (Some(Command::Change), ParseResult::Valid(_)) => Some(ViMode::Insert),
+            _ => None
+        }
     }
 
     pub fn to_reedline_event(&self, vi_state: &mut Vi) -> ReedlineEvent {

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -1,6 +1,6 @@
 use super::command::{parse_command, Command};
 use super::motion::{parse_motion, Motion};
-use crate::{EditCommand, ReedlineEvent, Vi, edit_mode::vi::ViMode};
+use crate::{edit_mode::vi::ViMode, EditCommand, ReedlineEvent, Vi};
 use std::iter::Peekable;
 
 #[derive(Debug, Clone)]
@@ -55,7 +55,11 @@ impl ParsedViSequence {
         match (&self.command, &self.motion) {
             (None, ParseResult::Valid(_)) => true,
             (Some(Command::Incomplete), _) => false,
-            (Some(cmd), ParseResult::Incomplete) if !cmd.requires_motion() || mode == ViMode::Visual => true,
+            (Some(cmd), ParseResult::Incomplete)
+                if !cmd.requires_motion() || mode == ViMode::Visual =>
+            {
+                true
+            }
             (Some(_), ParseResult::Valid(_)) => true,
             (Some(cmd), ParseResult::Incomplete) if cmd.requires_motion() => false,
             _ => false,
@@ -92,22 +96,19 @@ impl ParsedViSequence {
         }
     }
 
-    pub fn changes_mode(&self) -> Option<ViMode>{
+    pub fn changes_mode(&self) -> Option<ViMode> {
         match (&self.command, &self.motion) {
             (Some(Command::EnterViInsert), ParseResult::Incomplete)
-                | (Some(Command::EnterViAppend), ParseResult::Incomplete)
-                | (Some(Command::ChangeToLineEnd), ParseResult::Incomplete)
-                | (Some(Command::AppendToEnd), ParseResult::Incomplete)
-                | (Some(Command::PrependToStart), ParseResult::Incomplete)
-                | (Some(Command::RewriteCurrentLine), ParseResult::Incomplete)
-                | (
-                    Some(Command::SubstituteCharWithInsert),
-                    ParseResult::Incomplete
-                )
-                | (Some(Command::HistorySearch), ParseResult::Incomplete)
-                | (Some(Command::Change), ParseResult::Valid(_)) => Some(ViMode::Insert),
+            | (Some(Command::EnterViAppend), ParseResult::Incomplete)
+            | (Some(Command::ChangeToLineEnd), ParseResult::Incomplete)
+            | (Some(Command::AppendToEnd), ParseResult::Incomplete)
+            | (Some(Command::PrependToStart), ParseResult::Incomplete)
+            | (Some(Command::RewriteCurrentLine), ParseResult::Incomplete)
+            | (Some(Command::SubstituteCharWithInsert), ParseResult::Incomplete)
+            | (Some(Command::HistorySearch), ParseResult::Incomplete)
+            | (Some(Command::Change), ParseResult::Valid(_)) => Some(ViMode::Insert),
             (Some(Command::Delete), ParseResult::Incomplete) => Some(ViMode::Normal),
-            _ => None
+            _ => None,
         }
     }
 


### PR DESCRIPTION
This extends the vi mode with a visual mode. Can be tested in the basic example: v to enter in normal mode. Regular movements (e.g. b,w) work and d or C to delete and reenter normal or invert mode.