### PR TITLE
Refractor: group colors

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -180,7 +180,6 @@ impl Drop for Reedline {
     }
 }
 
-
 pub struct Theme {
     pub visual_selection: Style,
     pub use_ansi_coloring: bool,
@@ -189,13 +188,14 @@ pub struct Theme {
     pub prompt_multiline: nu_ansi_term::Color,
     pub indicator: Color,
     pub prompt_right: Color,
-
 }
 
 impl Default for Theme {
     fn default() -> Self {
         Self {
-            visual_selection: Style::new().fg(nu_ansi_term::Color::Black).on(nu_ansi_term::Color::LightGray),
+            visual_selection: Style::new()
+                .fg(nu_ansi_term::Color::Black)
+                .on(nu_ansi_term::Color::LightGray),
             use_ansi_coloring: true,
             prompt: Color::Green,
             prompt_multiline: nu_ansi_term::Color::LightBlue,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -138,7 +138,7 @@ pub struct Reedline {
     hide_hints: bool,
 
     // Use ansi coloring or not
-    theme: Theme,
+    theme: ReedlineTheme,
 
     // Engine Menus
     menus: Vec<ReedlineMenu>,
@@ -180,7 +180,7 @@ impl Drop for Reedline {
     }
 }
 
-pub struct Theme {
+pub struct ReedlineTheme {
     pub visual_selection: Style,
     pub use_ansi_coloring: bool,
     /// The color for the prompt, indicator, and right prompt
@@ -190,7 +190,7 @@ pub struct Theme {
     pub prompt_right: Color,
 }
 
-impl Default for Theme {
+impl Default for ReedlineTheme {
     fn default() -> Self {
         Self {
             visual_selection: Style::new()
@@ -244,7 +244,7 @@ impl Reedline {
             hinter,
             hide_hints: false,
             validator,
-            theme: Theme::default(),
+            theme: ReedlineTheme::default(),
             menus: Vec::new(),
             buffer_editor: None,
             cursor_shapes: None,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -407,7 +407,6 @@ impl Reedline {
         self
     }
 
-
     /// A builder which sets the color to use for the right side of the prompt.
     #[must_use]
     pub fn with_prompt_right_color(mut self, color: Color) -> Self {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -195,7 +195,7 @@ pub struct Theme {
 impl Default for Theme {
     fn default() -> Self {
         Self {
-            visual_selection: Style::new().on(nu_ansi_term::Color::LightGray),
+            visual_selection: Style::new().fg(nu_ansi_term::Color::Black).on(nu_ansi_term::Color::LightGray),
             use_ansi_coloring: true,
             prompt: Color::Green,
             prompt_multiline: nu_ansi_term::Color::LightBlue,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1721,7 +1721,6 @@ impl Reedline {
             );
 
             self.painter.repaint_buffer(
-                prompt,
                 &lines,
                 self.prompt_edit_mode(),
                 None,
@@ -1798,7 +1797,6 @@ impl Reedline {
         let menu = self.menus.iter().find(|menu| menu.is_active());
 
         self.painter.repaint_buffer(
-            prompt,
             &lines,
             self.prompt_edit_mode(),
             menu,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -386,6 +386,34 @@ impl Reedline {
         self
     }
 
+    /// A builder which sets the color to use for the prompt.
+    #[must_use]
+    pub fn with_prompt_color(mut self, color: Color) -> Self {
+        self.theme.prompt = color;
+        self
+    }
+
+    /// A builder which sets the color to use for the multiline prompt.
+    #[must_use]
+    pub fn with_prompt_multiline_color(mut self, color: nu_ansi_term::Color) -> Self {
+        self.theme.prompt_multiline = color;
+        self
+    }
+
+    /// A builder which sets the indicator color to use for the prompt.
+    #[must_use]
+    pub fn with_indicator_color(mut self, color: Color) -> Self {
+        self.theme.indicator = color;
+        self
+    }
+
+
+    /// A builder which sets the color to use for the right side of the prompt.
+    #[must_use]
+    pub fn with_prompt_right_color(mut self, color: Color) -> Self {
+        self.theme.prompt_right = color;
+        self
+    }
     /// Update current working directory.
     #[must_use]
     pub fn with_cwd(mut self, cwd: Option<String>) -> Self {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use itertools::Itertools;
-use nu_ansi_term::{Color, Style};
+use nu_ansi_term::Style;
 
 use crate::{enums::ReedlineRawEvent, CursorConfig};
 #[cfg(feature = "bashisms")]
@@ -39,6 +39,7 @@ use {
         cursor::{SetCursorStyle, Show},
         event,
         event::{Event, KeyCode, KeyEvent, KeyModifiers},
+        style::Color,
         terminal, QueueableCommand,
     },
     std::{
@@ -179,16 +180,27 @@ impl Drop for Reedline {
     }
 }
 
-struct Theme {
-    visual_selection: Style,
-    use_ansi_coloring: bool,
+
+pub struct Theme {
+    pub visual_selection: Style,
+    pub use_ansi_coloring: bool,
+    /// The color for the prompt, indicator, and right prompt
+    pub prompt: Color,
+    pub prompt_multiline: nu_ansi_term::Color,
+    pub indicator: Color,
+    pub prompt_right: Color,
+
 }
 
 impl Default for Theme {
     fn default() -> Self {
         Self {
-            visual_selection: Style::new().on(Color::LightGray),
+            visual_selection: Style::new().on(nu_ansi_term::Color::LightGray),
             use_ansi_coloring: true,
+            prompt: Color::Green,
+            prompt_multiline: nu_ansi_term::Color::LightBlue,
+            indicator: Color::Cyan,
+            prompt_right: Color::AnsiValue(5),
         }
     }
 }
@@ -1713,7 +1725,7 @@ impl Reedline {
                 &lines,
                 self.prompt_edit_mode(),
                 None,
-                self.theme.use_ansi_coloring,
+                &self.theme,
                 &self.cursor_shapes,
             )?;
         }
@@ -1738,7 +1750,7 @@ impl Reedline {
         let (before_cursor, after_cursor) = styled_text.render_around_insertion_point(
             cursor_position_in_buffer,
             prompt,
-            self.theme.use_ansi_coloring,
+            &self.theme,
         );
 
         let hint: String = if self.hints_active() {
@@ -1790,7 +1802,7 @@ impl Reedline {
             &lines,
             self.prompt_edit_mode(),
             menu,
-            self.theme.use_ansi_coloring,
+            &self.theme,
             &self.cursor_shapes,
         )
     }

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1,4 +1,4 @@
-use crate::{engine::Theme, CursorConfig, PromptEditMode, PromptViMode};
+use crate::{engine::ReedlineTheme, CursorConfig, PromptEditMode, PromptViMode};
 
 use {
     super::utils::{coerce_crlf, line_width},
@@ -187,7 +187,7 @@ impl Painter {
         lines: &PromptLines,
         prompt_mode: PromptEditMode,
         menu: Option<&ReedlineMenu>,
-        theme: &Theme,
+        theme: &ReedlineTheme,
         cursor_config: &Option<CursorConfig>,
     ) -> Result<()> {
         self.stdout.queue(cursor::Hide)?;
@@ -315,7 +315,7 @@ impl Painter {
         &mut self,
         lines: &PromptLines,
         menu: Option<&ReedlineMenu>,
-        theme: &Theme,
+        theme: &ReedlineTheme,
     ) -> Result<()> {
         // print our prompt with color
         if theme.use_ansi_coloring {
@@ -362,7 +362,7 @@ impl Painter {
         &mut self,
         lines: &PromptLines,
         menu: Option<&ReedlineMenu>,
-        theme: &Theme,
+        theme: &ReedlineTheme,
     ) -> Result<()> {
         let screen_width = self.screen_width();
         let screen_height = self.screen_height();

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -5,7 +5,6 @@ use {
     crate::{
         menu::{Menu, ReedlineMenu},
         painting::PromptLines,
-        Prompt,
     },
     crossterm::{
         cursor::{self, MoveTo, RestorePosition, SavePosition},
@@ -185,7 +184,6 @@ impl Painter {
     /// the screen.
     pub(crate) fn repaint_buffer(
         &mut self,
-        prompt: &dyn Prompt,
         lines: &PromptLines,
         prompt_mode: PromptEditMode,
         menu: Option<&ReedlineMenu>,
@@ -229,9 +227,9 @@ impl Painter {
             .queue(Clear(ClearType::FromCursorDown))?;
 
         if self.large_buffer {
-            self.print_large_buffer(prompt, lines, menu, theme)?;
+            self.print_large_buffer(lines, menu, theme)?;
         } else {
-            self.print_small_buffer(prompt, lines, menu, theme)?;
+            self.print_small_buffer(lines, menu, theme)?;
         }
 
         // The last_required_lines is used to calculate safe range of the current prompt.
@@ -315,7 +313,6 @@ impl Painter {
 
     fn print_small_buffer(
         &mut self,
-        prompt: &dyn Prompt,
         lines: &PromptLines,
         menu: Option<&ReedlineMenu>,
         theme: &Theme,
@@ -366,7 +363,6 @@ impl Painter {
 
     fn print_large_buffer(
         &mut self,
-        prompt: &dyn Prompt,
         lines: &PromptLines,
         menu: Option<&ReedlineMenu>,
         theme: &Theme,

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1,4 +1,4 @@
-use crate::{CursorConfig, PromptEditMode, PromptViMode, engine::Theme};
+use crate::{engine::Theme, CursorConfig, PromptEditMode, PromptViMode};
 
 use {
     super::utils::{coerce_crlf, line_width},
@@ -319,24 +319,21 @@ impl Painter {
     ) -> Result<()> {
         // print our prompt with color
         if theme.use_ansi_coloring {
-            self.stdout
-                .queue(SetForegroundColor(theme.prompt))?;
+            self.stdout.queue(SetForegroundColor(theme.prompt))?;
         }
 
         self.stdout
             .queue(Print(&coerce_crlf(&lines.prompt_str_left)))?;
 
         if theme.use_ansi_coloring {
-            self.stdout
-                .queue(SetForegroundColor(theme.indicator))?;
+            self.stdout.queue(SetForegroundColor(theme.indicator))?;
         }
 
         self.stdout
             .queue(Print(&coerce_crlf(&lines.prompt_indicator)))?;
 
         if theme.use_ansi_coloring {
-            self.stdout
-                .queue(SetForegroundColor(theme.prompt_right))?;
+            self.stdout.queue(SetForegroundColor(theme.prompt_right))?;
         }
 
         self.print_right_prompt(lines)?;
@@ -386,8 +383,7 @@ impl Painter {
 
         // print our prompt with color
         if theme.use_ansi_coloring {
-            self.stdout
-                .queue(SetForegroundColor(theme.prompt))?;
+            self.stdout.queue(SetForegroundColor(theme.prompt))?;
         }
 
         // In case the prompt is made out of multiple lines, the prompt is split by
@@ -397,8 +393,7 @@ impl Painter {
 
         if extra_rows == 0 {
             if theme.use_ansi_coloring {
-                self.stdout
-                    .queue(SetForegroundColor(theme.prompt_right))?;
+                self.stdout.queue(SetForegroundColor(theme.prompt_right))?;
             }
 
             self.print_right_prompt(lines)?;
@@ -408,8 +403,7 @@ impl Painter {
         let extra_rows = extra_rows.saturating_sub(prompt_lines);
 
         if theme.use_ansi_coloring {
-            self.stdout
-                .queue(SetForegroundColor(theme.indicator))?;
+            self.stdout.queue(SetForegroundColor(theme.indicator))?;
         }
         let indicator_skipped = skip_buffer_lines(&lines.prompt_indicator, extra_rows, None);
         self.stdout.queue(Print(&coerce_crlf(indicator_skipped)))?;

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -16,7 +16,7 @@ use {
     std::ops::RangeInclusive,
 };
 #[cfg(feature = "external_printer")]
-use {crate::LineBuffer, crossterm::cursor::MoveUp};
+use {crate::LineBuffer, crate::Prompt, crossterm::cursor::MoveUp};
 
 // Returns a string that skips N number of lines with the next offset of lines
 // An offset of 0 would return only one line after skipping the required lines

--- a/src/painting/styled_text.rs
+++ b/src/painting/styled_text.rs
@@ -1,6 +1,6 @@
 use nu_ansi_term::Style;
 
-use crate::Prompt;
+use crate::{Prompt, engine::Theme};
 
 use super::utils::strip_ansi;
 
@@ -101,14 +101,14 @@ impl StyledText {
         insertion_point: usize,
         prompt: &dyn Prompt,
         // multiline_prompt: &str,
-        use_ansi_coloring: bool,
+        theme: &Theme,
     ) -> (String, String) {
         let mut current_idx = 0;
         let mut left_string = String::new();
         let mut right_string = String::new();
 
         let multiline_prompt = prompt.render_prompt_multiline_indicator();
-        let prompt_style = Style::new().fg(prompt.get_prompt_multiline_color());
+        let prompt_style = Style::new().fg(theme.prompt_multiline);
 
         for pair in &self.buffer {
             if current_idx >= insertion_point {
@@ -135,7 +135,7 @@ impl StyledText {
             current_idx += pair.1.len();
         }
 
-        if use_ansi_coloring {
+        if theme.use_ansi_coloring {
             (left_string, right_string)
         } else {
             (strip_ansi(&left_string), strip_ansi(&right_string))

--- a/src/painting/styled_text.rs
+++ b/src/painting/styled_text.rs
@@ -1,6 +1,6 @@
 use nu_ansi_term::Style;
 
-use crate::{Prompt, engine::Theme};
+use crate::{engine::Theme, Prompt};
 
 use super::utils::strip_ansi;
 

--- a/src/painting/styled_text.rs
+++ b/src/painting/styled_text.rs
@@ -1,6 +1,6 @@
 use nu_ansi_term::Style;
 
-use crate::{engine::Theme, Prompt};
+use crate::{engine::ReedlineTheme, Prompt};
 
 use super::utils::strip_ansi;
 
@@ -101,7 +101,7 @@ impl StyledText {
         insertion_point: usize,
         prompt: &dyn Prompt,
         // multiline_prompt: &str,
-        theme: &Theme,
+        theme: &ReedlineTheme,
     ) -> (String, String) {
         let mut current_idx = 0;
         let mut left_string = String::new();

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -1,5 +1,4 @@
 use {
-    crossterm::style::Color,
     serde::{Deserialize, Serialize},
     std::{
         borrow::Cow,

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -8,12 +8,6 @@ use {
     strum_macros::EnumIter,
 };
 
-/// The default color for the prompt, indicator, and right prompt
-pub static DEFAULT_PROMPT_COLOR: Color = Color::Green;
-pub static DEFAULT_PROMPT_MULTILINE_COLOR: nu_ansi_term::Color = nu_ansi_term::Color::LightBlue;
-pub static DEFAULT_INDICATOR_COLOR: Color = Color::Cyan;
-pub static DEFAULT_PROMPT_RIGHT_COLOR: Color = Color::AnsiValue(5);
-
 /// The current success/failure of the history search
 pub enum PromptHistorySearchStatus {
     /// Success for the search
@@ -97,22 +91,6 @@ pub trait Prompt: Send {
         &self,
         history_search: PromptHistorySearch,
     ) -> Cow<str>;
-    /// Get the default prompt color
-    fn get_prompt_color(&self) -> Color {
-        DEFAULT_PROMPT_COLOR
-    }
-    /// Get the default multiline prompt color
-    fn get_prompt_multiline_color(&self) -> nu_ansi_term::Color {
-        DEFAULT_PROMPT_MULTILINE_COLOR
-    }
-    /// Get the default indicator color
-    fn get_indicator_color(&self) -> Color {
-        DEFAULT_INDICATOR_COLOR
-    }
-    /// Get the default right prompt color
-    fn get_prompt_right_color(&self) -> Color {
-        DEFAULT_PROMPT_RIGHT_COLOR
-    }
 
     /// Whether to render right prompt on the last line
     fn right_prompt_on_last_line(&self) -> bool {


### PR DESCRIPTION
In https://github.com/nushell/reedline/pull/800#issuecomment-2182943637 @fdncred said:

> we really need to make the colors configurable but that's not for this pr. It just looks a bit janky (not your fault).
> 
> ![image](https://private-user-images.githubusercontent.com/343840/341808525-707fc76b-3e7d-45a6-8ef0-7ba628b4b0a8.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTkxMzc5MjcsIm5iZiI6MTcxOTEzNzYyNywicGF0aCI6Ii8zNDM4NDAvMzQxODA4NTI1LTcwN2ZjNzZiLTNlN2QtNDVhNi04ZWYwLTdiYTYyOGI0YjBhOC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNjIzJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDYyM1QxMDEzNDdaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT05ZjE0YzVlYzBkYzFmODM3YzNlYjdlMDg5YjcwOGVkMTAyNzhiOTE5YjI2NTUwYzI2NTM1NDUwZTkzOGZjNWVmJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.haKuldfc10lkc0aHLvrFclelYymF4cmKbtBLsHFqGUI)

This pull request groups the statically defined colors into a single record. This is the first step if we would want to support configurable colors at a later time. In addition it changes the fg color of selected text to black so there is a contrast to the bg color. This improves the readability and it looks nicer.

![image](https://github.com/nushell/reedline/assets/178606/47b0e742-d88b-42ae-9884-35343f819c32)

The colors of the menu and the highlighter have not been moved to the theme record. It is at least theoretically possible to have different menus and highlighters with different colors and I conservatively didn't want to ruin that.
