### PR TITLE
Fix panic in long item completion in ide menu

### DIFF
--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -512,7 +512,11 @@ impl IdeMenu {
         };
 
         if use_ansi_coloring {
-            let match_len = self.working_details.shortest_base_string.len();
+            let match_len = self
+                .working_details
+                .shortest_base_string
+                .len()
+                .min(string.len());
 
             // Split string so the match text can be styled
             let (match_str, remaining_str) = string.split_at(match_len);
@@ -1400,5 +1404,41 @@ mod tests {
             editor.is_cursor_at_buffer_end(),
             "cursor should be at the end after completion"
         );
+    }
+
+    #[test]
+    fn test_regression_panic_on_long_item() {
+        let commands = vec![
+            "hello world 2".into(),
+            "hello another very large option for hello word that will force one column".into(),
+            "this is the reedline crate".into(),
+            "abaaabas".into(),
+            "abaaacas".into(),
+        ];
+
+        let mut completer = Box::new(crate::DefaultCompleter::new_with_wordlen(commands, 2));
+
+        let mut menu = IdeMenu::default().with_name("testmenu");
+        menu.working_details = IdeMenuDetails {
+            cursor_col: 50,
+            menu_width: 50,
+            completion_width: 50,
+            description_width: 50,
+            description_is_right: true,
+            space_left: 50,
+            space_right: 50,
+            description_offset: 50,
+            shortest_base_string: String::new(),
+        };
+        let mut editor = Editor::default();
+        // backtick at the end of the line
+        editor.set_buffer(
+            "hello another very large option for hello word that will force one colu".to_string(),
+            UndoBehavior::CreateUndoPoint,
+        );
+
+        menu.update_values(&mut editor, &mut *completer);
+
+        menu.menu_string(500, true);
     }
 }


### PR DESCRIPTION
Ide menu uses `...` for items that are very long, and if the prompt already contains some string inside of `...` it will panic. It can be reproduced by completing the largest item in the `ide_completions`, then deleting one or two characters, and hitting `Tab` again.

The panic was found in #821 