### PR TITLE
Added partial completions to the MenuNext event

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -967,8 +967,9 @@ impl Reedline {
             }
             ReedlineEvent::MenuNext => {
                 if let Some(menu) = self.menus.iter_mut().find(|menu| menu.is_active()) {
-                    if self.quick_completions && menu.can_quick_complete() {
-                        menu.update_values(
+                    if self.partial_completions {
+                        menu.can_partially_complete(
+                            self.quick_completions,
                             &mut self.editor,
                             self.completer.as_mut(),
                             self.history.as_ref(),


### PR DESCRIPTION
This PR is meant to address a nushell specific issue (https://github.com/nushell/nushell/issues/11251) about the tab button not partially completing suggestions if the menu is already open. I added partial completions to the MenuNext event after checking if they were enabled. 