### PR TITLE
fix: treat `CTRL + J` as `Enter`

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -121,6 +121,7 @@ impl EditMode for Emacs {
             Event::Key(KeyEvent {
                 code, modifiers, ..
             }) => match (modifiers, code) {
+                (KeyModifiers::CONTROL, KeyCode::Char('j')) => ReedlineEvent::Enter,
                 (modifier, KeyCode::Char(c)) => {
                     // Note. The modifier can also be a combination of modifiers, for
                     // example:

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -68,6 +68,10 @@ impl EditMode for Vi {
                     self.mode = ViMode::Visual;
                     ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint])
                 }
+                (_, KeyModifiers::CONTROL, KeyCode::Char('j')) => {
+                    self.mode = ViMode::Insert;
+                    ReedlineEvent::Enter
+                }
                 (ViMode::Normal | ViMode::Visual, modifier, KeyCode::Char(c)) => {
                     let c = c.to_ascii_lowercase();
 


### PR DESCRIPTION
This resolves the issue I noted having in <https://github.com/nushell/nushell/issues/6427#issuecomment-1821895162>, where hitting `Enter` in MacOS and Linux outside the main `Reedline::read_line` call in raw mode results in a <kbd>CTRL + J</kbd> event that yields no actual input once `read_line` is called again.

I'm not positive that this doesn't introduce regressions with, e.g., pasted input. I'm not sure what the best way to test this would be.

I'm also not sure if it resolves that issue in its entirety, since the question of whether its scope should include `\n` is unresolved.