### PR TITLE
made can_partially_complete() only complete when suggesting more than the input

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -967,17 +967,17 @@ impl Reedline {
             }
             ReedlineEvent::MenuNext => {
                 if let Some(menu) = self.menus.iter_mut().find(|menu| menu.is_active()) {
-                    if self.partial_completions {
-                        menu.can_partially_complete(
-                            self.quick_completions,
-                            &mut self.editor,
-                            self.completer.as_mut(),
-                            self.history.as_ref(),
-                        );
-                    };
                     if menu.get_values().len() == 1 && menu.can_quick_complete() {
                         self.handle_editor_event(prompt, ReedlineEvent::Enter)
                     } else {
+                        if self.partial_completions {
+                            menu.can_partially_complete(
+                                self.quick_completions,
+                                &mut self.editor,
+                                self.completer.as_mut(),
+                                self.history.as_ref(),
+                            );
+                        }
                         menu.menu_event(MenuEvent::NextElement);
                         Ok(EventStatus::Handled)
                     }

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -327,7 +327,8 @@ pub fn can_partially_complete(values: &[Suggestion], editor: &mut Editor) -> boo
         let matching = &value[0..index];
 
         // make sure that the partial completion does not overwrite user entered input
-        let extends_input = matching.starts_with(&editor.get_buffer()[span.start..span.end]);
+        let extends_input = matching.starts_with(&editor.get_buffer()[span.start..span.end])
+            && matching != &editor.get_buffer()[span.start..span.end];
 
         if !matching.is_empty() && extends_input {
             let mut line_buffer = editor.line_buffer().clone();


### PR DESCRIPTION
Addresses #833 . `menu.can_partially_complete()` would reset the current selection 0 and return true even if the suggested partial completion was exactly the same. Changed `can_partially_complete` in `menu_functions` to return false and not complete if the suggested partial completion is the exact same as the input. 