### PR TITLE
Fixed demo completions

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -246,6 +246,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
         KeyCode::Tab,
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::Menu("completion_menu".to_string()),
+            ReedlineEvent::MenuNext,
             ReedlineEvent::Edit(vec![EditCommand::Complete]),
         ]),
     );


### PR DESCRIPTION
Rel: #834 Added MenuNext as a menu event upon pressing tab to the demo example. Fixes the currently broken completions on the example.