### PR TITLE
Fix wrong unit when split string

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -299,7 +299,7 @@ impl ColumnarMenu {
         use_ansi_coloring: bool,
     ) -> String {
         if use_ansi_coloring {
-            let match_len = self.working_details.shortest_base_string.width();
+            let match_len = self.working_details.shortest_base_string.len();
 
             // Split string so the match text can be styled
             let (match_str, remaining_str) = suggestion.value.split_at(match_len);


### PR DESCRIPTION
Fixes #837.

https://github.com/nushell/reedline/blob/4634f71705785a772c894aa45e30db88f3c7a8d5/src/menu/columnar_menu.rs#L305

[split_at](https://doc.rust-lang.org/std/string/struct.String.html#method.split_at ) expect byte offset.

https://github.com/nushell/reedline/blob/4634f71705785a772c894aa45e30db88f3c7a8d5/src/menu/columnar_menu.rs#L302

But we given (got from [width](https://docs.rs/unicode-width/latest/unicode_width/trait.UnicodeWidthStr.html#tymethod.width)) isn't.

Thanks for all amazing works in reedline.