### PR TITLE
Implemented change in and delete in functionality

### DIFF
--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -12,8 +12,8 @@ where
             if let Some('i') = input.peek() {
                 let _ = input.next();
                 match input.next() {
-                    Some(c) => Some(Command::DeleteInside(*c)),
-                    None => Some(Command::Incomplete),
+                    Some(c) if is_valid_change_in(c) => Some(Command::DeleteInside(*c)),
+                    _ => None,
                 }
             } else {
                 Some(Command::Delete)
@@ -44,8 +44,8 @@ where
             if let Some('i') = input.peek() {
                 let _ = input.next();
                 match input.next() {
-                    Some(c) => Some(Command::ChangeInside(*c)),
-                    None => Some(Command::Incomplete),
+                    Some(c) if is_valid_change_in(c) => Some(Command::ChangeInside(*c)),
+                    _ => None,
                 }
             } else {
                 Some(Command::Change)
@@ -315,5 +315,12 @@ fn right_bracket_for(c: &char) -> char {
         '[' => ']',
         '{' => '}',
         _ => *c,
+    }
+}
+
+fn is_valid_change_in(c: &char) -> bool {
+    match *c {
+        '(' | '[' | '{' | ')' | ']' | '}' | '"' | '\'' | '`' => true,
+        _ => false,
     }
 }

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -101,6 +101,7 @@ impl ParsedViSequence {
             (Some(Command::EnterViInsert), ParseResult::Incomplete)
             | (Some(Command::EnterViAppend), ParseResult::Incomplete)
             | (Some(Command::ChangeToLineEnd), ParseResult::Incomplete)
+            | (Some(Command::ChangeInside(_)), ParseResult::Incomplete)
             | (Some(Command::AppendToEnd), ParseResult::Incomplete)
             | (Some(Command::PrependToStart), ParseResult::Incomplete)
             | (Some(Command::RewriteCurrentLine), ParseResult::Incomplete)


### PR DESCRIPTION
This implements the change in (ci) and delete in functionality:
- ci" - Change in quotes
- di" - Delete in quotes
- ci[ - change in brackets

supports [ , ( , ", ', `, { 