### PR TITLE
Fix forgotten `Cargo.lock`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,17 @@ jobs:
       - name: Tests
         run: cargo llvm-cov nextest --all ${{ matrix.flags }} --lcov --output-path lcov.info
 
+      - name: Check for clean repo
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "there are changes";
+            git status --porcelain
+            exit 1
+          else
+            echo "no changes in working directory";
+          fi
+
       - name: Check lockfile
         run: cargo check --locked ${{ matrix.flags }} --all-targets --all
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.4
       - name: Setup nextest
         uses: taiki-e/install-action@nextest
-      - name: Setup cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Rustfmt
         run: cargo fmt --all -- --check
@@ -47,7 +45,7 @@ jobs:
         run: cargo clippy ${{ matrix.flags }} --all-targets --all -- -D warnings
 
       - name: Tests
-        run: cargo llvm-cov nextest --all ${{ matrix.flags }} --lcov --output-path lcov.info
+        run: cargo nextest run --all ${{ matrix.flags }}
 
       - name: Check for clean repo
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.4

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check spelling
         uses: crate-ci/typos@master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "arboard",
  "chrono",


### PR DESCRIPTION
Wasn't commited with the last release or similar.

Added the CI step we have on the main repo to catch leaky tests or uncommited lockfiles
