### PR TITLE
Add Newline keybindings

### DIFF
--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -234,6 +234,7 @@ pub fn add_common_edit_bindings(kb: &mut Keybindings) {
     );
     kb.add_binding(KM::ALT, KC::Enter, edit_bind(EC::InsertNewline));
     kb.add_binding(KM::SHIFT, KC::Enter, edit_bind(EC::InsertNewline));
+    kb.add_binding(KM::CONTROL, KC::Char('j'), edit_bind(EC::InsertNewline));
 }
 
 pub fn add_common_selection_bindings(kb: &mut Keybindings) {

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -232,6 +232,8 @@ pub fn add_common_edit_bindings(kb: &mut Keybindings) {
         KC::Char('v'),
         edit_bind(EC::PasteSystem),
     );
+    kb.add_binding(KM::ALT, KC::Enter, edit_bind(EC::InsertNewline));
+    kb.add_binding(KM::SHIFT, KC::Enter, edit_bind(EC::InsertNewline));
 }
 
 pub fn add_common_selection_bindings(kb: &mut Keybindings) {


### PR DESCRIPTION
Implements #792 and also should be the proper implementation of https://github.com/nushell/nushell/pull/13606

---

Adds <kbd>Alt</kbd>+<kbd>Enter</kbd> and <kbd>Shift</kbd>+<kbd>Enter</kbd> as keybindings to insert a newline in Emacs and Vi-insert modes.

In the Nushell PR, @sholderbach said:

> so it might be that for some `Alt-Enter` won't work while for others `Shift-Enter` or `Ctrl-Enter` is unreliable.

I figure there's no reason we can't just bind *both* so that multiple platforms and terminals can handle this gracefully.  I know <kbd>Alt</kbd>+<kbd>Enter</kbd> is commonly captured by Windows Terminal, and <kbd>Shift</kbd>+<kbd>Enter</kbd> doesn't seem to be recognized on Linux (also via `input listen`).

If the Terminal captures one of the keybindings, then hopefully the other is available.  And if not, the user can always add their own in their Nushell config.