### PR TITLE
Set `Ctrl-J`/`\n` to `ReedlineCommand::Enter`

### DIFF
--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -234,7 +234,7 @@ pub fn add_common_edit_bindings(kb: &mut Keybindings) {
     );
     kb.add_binding(KM::ALT, KC::Enter, edit_bind(EC::InsertNewline));
     kb.add_binding(KM::SHIFT, KC::Enter, edit_bind(EC::InsertNewline));
-    kb.add_binding(KM::CONTROL, KC::Char('j'), edit_bind(EC::InsertNewline));
+    kb.add_binding(KM::CONTROL, KC::Char('j'), ReedlineEvent::Enter);
 }
 
 pub fn add_common_selection_bindings(kb: &mut Keybindings) {


### PR DESCRIPTION
Permits terminal automation sending a `\n` to behave the same as if a
`\r` is sent which is the canonical Enter according to ANSI/crossterm

Closes https://github.com/nushell/nushell/issues/6427
See also #832 
