### PR TITLE
Modal Modes

### DIFF
--- a/examples/ide_completions_with_modal.rs
+++ b/examples/ide_completions_with_modal.rs
@@ -28,7 +28,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
     keybindings.add_binding(
         KeyModifiers::ALT,
         KeyCode::Char('f'),
-        ReedlineEvent::ForceDeactivate,
+        ReedlineEvent::Multiple(vec![ReedlineEvent::ForceDeactivate, ReedlineEvent::Enter]),
     );
 }
 

--- a/examples/ide_completions_with_modal.rs
+++ b/examples/ide_completions_with_modal.rs
@@ -1,0 +1,137 @@
+// Create a reedline object with tab completions support and modal modes
+// cargo run --example completions
+//
+// "t" [Tab] will allow you to select the completions "test" and "this is the reedline crate"
+// [Enter] to select the chosen alternative
+
+use reedline::{
+    default_emacs_keybindings, DefaultCompleter, DefaultPrompt, DescriptionMode, EditCommand,
+    Emacs, IdeMenu, KeyCode, KeyModifiers, Keybindings, MenuBuilder, Reedline, ReedlineEvent,
+    ReedlineMenu, Signal,
+};
+use std::io;
+
+fn add_menu_keybindings(keybindings: &mut Keybindings) {
+    keybindings.add_binding(
+        KeyModifiers::NONE,
+        KeyCode::Tab,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::Menu("completion_menu".to_string()),
+            ReedlineEvent::MenuNext,
+        ]),
+    );
+    keybindings.add_binding(
+        KeyModifiers::ALT,
+        KeyCode::Enter,
+        ReedlineEvent::Edit(vec![EditCommand::InsertNewline]),
+    );
+    keybindings.add_binding(
+        KeyModifiers::ALT,
+        KeyCode::Char('f'),
+        ReedlineEvent::ForceDeactivate,
+    );
+}
+
+fn main() -> io::Result<()> {
+    // Min width of the completion box, including the border
+    let min_completion_width: u16 = 0;
+    // Max width of the completion box, including the border
+    let max_completion_width: u16 = 50;
+    // Max height of the completion box, including the border
+    let max_completion_height: u16 = u16::MAX;
+    // Padding inside of the completion box (on the left and right side)
+    let padding: u16 = 0;
+    // Whether to draw the default border around the completion box
+    let border: bool = false;
+    // Offset of the cursor from the top left corner of the completion box
+    // By default the top left corner is below the cursor
+    let cursor_offset: i16 = 0;
+    // How the description should be aligned
+    let description_mode: DescriptionMode = DescriptionMode::PreferRight;
+    // Min width of the description box, including the border
+    let min_description_width: u16 = 0;
+    // Max width of the description box, including the border
+    let max_description_width: u16 = 50;
+    // Distance between the completion and the description box
+    let description_offset: u16 = 1;
+    // If true, the cursor pos will be corrected, so the suggestions match up with the typed text
+    // ```text
+    // C:\> str
+    //      str join
+    //      str trim
+    //      str split
+    // ```
+    // If a border is being used
+    let correct_cursor_pos: bool = false;
+
+    let commands = vec![
+        "test".into(),
+        "clear".into(),
+        "exit".into(),
+        "history 1".into(),
+        "history 2".into(),
+        "logout".into(),
+        "login".into(),
+        "hello world".into(),
+        "hello world reedline".into(),
+        "hello world something".into(),
+        "hello world another".into(),
+        "hello world 1".into(),
+        "hello world 2".into(),
+        "hello another very large option for hello word that will force one column".into(),
+        "this is the reedline crate".into(),
+        "abaaabas".into(),
+        "abaaacas".into(),
+        "ababac".into(),
+        "abacaxyc".into(),
+        "abadarabc".into(),
+    ];
+
+    let completer = Box::new(DefaultCompleter::new_with_wordlen(commands, 2));
+
+    // Use the interactive menu to select options from the completer
+    let mut ide_menu = IdeMenu::default()
+        .with_name("completion_menu")
+        .with_min_completion_width(min_completion_width)
+        .with_max_completion_width(max_completion_width)
+        .with_max_completion_height(max_completion_height)
+        .with_padding(padding)
+        .with_cursor_offset(cursor_offset)
+        .with_description_mode(description_mode)
+        .with_min_description_width(min_description_width)
+        .with_max_description_width(max_description_width)
+        .with_description_offset(description_offset)
+        .with_correct_cursor_pos(correct_cursor_pos);
+
+    if border {
+        ide_menu = ide_menu.with_default_border();
+    }
+
+    let completion_menu = Box::new(ide_menu);
+
+    let mut keybindings = default_emacs_keybindings();
+    add_menu_keybindings(&mut keybindings);
+
+    let edit_mode = Box::new(Emacs::new(keybindings));
+
+    let mut line_editor = Reedline::create()
+        .with_completer(completer)
+        .with_menu(ReedlineMenu::EngineCompleter(completion_menu))
+        .with_edit_mode(edit_mode)
+        .with_modal_mode(true);
+
+    let prompt = DefaultPrompt::default();
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {buffer}");
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+        }
+    }
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -221,7 +221,7 @@ impl Reedline {
             history_excluded_item: None,
             history_cursor_on_excluded: false,
             input_mode: InputMode::Regular,
-            modal_mode: false,
+            modal_mode: true,
             suspended_state: None,
             painter,
             transient_prompt: None,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1182,7 +1182,7 @@ impl Reedline {
                             Some(&EditCommand::Backspace)
                             | Some(&EditCommand::BackspaceWord)
                             | Some(&EditCommand::MoveToLineStart { select: false }) => {
-                                menu.menu_event(MenuEvent::Deactivate(false))
+                                menu.menu_event(MenuEvent::Deactivate(self.modal_mode))
                             }
                             _ => {
                                 menu.menu_event(MenuEvent::Edit(self.quick_completions));

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1182,7 +1182,7 @@ impl Reedline {
                             Some(&EditCommand::Backspace)
                             | Some(&EditCommand::BackspaceWord)
                             | Some(&EditCommand::MoveToLineStart { select: false }) => {
-                                menu.menu_event(MenuEvent::Deactivate(self.modal_mode))
+                                menu.menu_event(MenuEvent::Deactivate(false))
                             }
                             _ => {
                                 menu.menu_event(MenuEvent::Edit(self.quick_completions));

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -221,7 +221,7 @@ impl Reedline {
             history_excluded_item: None,
             history_cursor_on_excluded: false,
             input_mode: InputMode::Regular,
-            modal_mode: true,
+            modal_mode: false,
             suspended_state: None,
             painter,
             transient_prompt: None,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -569,6 +569,9 @@ pub enum ReedlineEvent {
     /// Submit at the end of the *complete* text, otherwise newline
     SubmitOrNewline,
 
+    /// Force deactivate - used for modal menus
+    ForceDeactivate,
+
     /// Esc event
     Esc,
 
@@ -659,6 +662,7 @@ impl Display for ReedlineEvent {
             ReedlineEvent::Enter => write!(f, "Enter"),
             ReedlineEvent::Submit => write!(f, "Submit"),
             ReedlineEvent::SubmitOrNewline => write!(f, "SubmitOrNewline"),
+            ReedlineEvent::ForceDeactivate => write!(f, "ForceDeactivate"),
             ReedlineEvent::Esc => write!(f, "Esc"),
             ReedlineEvent::Mouse => write!(f, "Mouse"),
             ReedlineEvent::Resize(_, _) => write!(f, "Resize <int> <int>"),

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -475,9 +475,11 @@ impl Menu for ColumnarMenu {
     fn menu_event(&mut self, event: MenuEvent) {
         match &event {
             MenuEvent::Activate(_) => self.active = true,
-            MenuEvent::Deactivate => {
-                self.active = false;
-                self.input = None;
+            MenuEvent::Deactivate(modal_mode) => {
+                if !modal_mode {
+                    self.active = false;
+                    self.input = None;
+                }
             }
             _ => {}
         }
@@ -530,7 +532,11 @@ impl Menu for ColumnarMenu {
                         self.update_values(editor, completer);
                     }
                 }
-                MenuEvent::Deactivate => self.active = false,
+                MenuEvent::Deactivate(modal_mode) => {
+                    if !modal_mode {
+                        self.active = false;
+                    }
+                }
                 MenuEvent::Edit(updated) => {
                     self.reset_position();
 

--- a/src/menu/description_menu.rs
+++ b/src/menu/description_menu.rs
@@ -429,10 +429,12 @@ impl Menu for DescriptionMenu {
     fn menu_event(&mut self, event: MenuEvent) {
         match &event {
             MenuEvent::Activate(_) => self.active = true,
-            MenuEvent::Deactivate => {
-                self.active = false;
-                self.input = None;
-                self.values = Vec::new();
+            MenuEvent::Deactivate(modal_mode) => {
+                if !modal_mode {
+                    self.active = false;
+                    self.input = None;
+                    self.values = Vec::new();
+                }
             }
             _ => {}
         };
@@ -468,7 +470,11 @@ impl Menu for DescriptionMenu {
                     self.input = Some(editor.get_buffer().to_string());
                     self.update_values(editor, completer);
                 }
-                MenuEvent::Deactivate => self.active = false,
+                MenuEvent::Deactivate(modal_mode) => {
+                    if !modal_mode {
+                        self.active = false;
+                    }
+                }
                 MenuEvent::Edit(_) => {
                     self.reset_position();
                     self.update_values(editor, completer);

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -617,9 +617,11 @@ impl Menu for IdeMenu {
     fn menu_event(&mut self, event: MenuEvent) {
         match &event {
             MenuEvent::Activate(_) => self.active = true,
-            MenuEvent::Deactivate => {
-                self.active = false;
-                self.input = None;
+            MenuEvent::Deactivate(modal_mode) => {
+                if !modal_mode {
+                    self.active = false;
+                    self.input = None;
+                }
             }
             _ => {}
         }
@@ -671,7 +673,11 @@ impl Menu for IdeMenu {
                         self.update_values(editor, completer);
                     }
                 }
-                MenuEvent::Deactivate => self.active = false,
+                MenuEvent::Deactivate(modal_mode) => {
+                    if !modal_mode {
+                        self.active = false;
+                    }
+                }
                 MenuEvent::Edit(updated) => {
                     self.reset_position();
 

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -334,9 +334,11 @@ impl Menu for ListMenu {
     fn menu_event(&mut self, event: MenuEvent) {
         match &event {
             MenuEvent::Activate(_) => self.active = true,
-            MenuEvent::Deactivate => {
-                self.active = false;
-                self.input = None;
+            MenuEvent::Deactivate(modal_mode) => {
+                if !modal_mode {
+                    self.active = false;
+                    self.input = None;
+                }
             }
             _ => {}
         }
@@ -435,9 +437,11 @@ impl Menu for ListMenu {
                         full: false,
                     });
                 }
-                MenuEvent::Deactivate => {
-                    self.active = false;
-                    self.input = None;
+                MenuEvent::Deactivate(modal_mode) => {
+                    if !modal_mode {
+                        self.active = false;
+                        self.input = None;
+                    }
                 }
                 MenuEvent::Edit(_) => {
                     self.update_values(editor, completer);

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -49,7 +49,7 @@ pub enum MenuEvent {
     /// have already being updated. This is true when the option `quick_completions` is true
     Activate(bool),
     /// Deactivation event
-    Deactivate,
+    Deactivate(bool),
     /// Line buffer edit event. When the bool is true it means that the values
     /// have already being updated. This is true when the option `quick_completions` is true
     Edit(bool),


### PR DESCRIPTION
This is directly related to: #789
It also could be a potential solution to: #820 

The main thing I did was disable the deactivation of menus if you have the modal_menu option set to true, and instead you need
to use a ReedlineEvent to force the deactivation of the menus in order to submit your message on the reedline.
This works almost in the ide_completions_with_modal.rs example (based on ide_completions, with just additional keybinds and option for modal_menus set) - it still has some visual issues, that I would iron out.

The reason why I'm making this draft PR is because there is an issue I'm not sure how to handle. While I can get this working in the examples, building nushell produces a different behaviour. With just the main branch of reedline, the examples allow you to stay in the completion menus which pressing backspace - however in nushell backspace throws you out of menu completion. Because of this nushell and the reedline examples have different behaviour when it comes to the reedline completion.

Is there a way to get the reedline working the same way in nushell?