### PR TITLE
Remove questionable `unsafe impl Send`

### DIFF
--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -11,10 +11,6 @@ const SELECTION_CHAR: char = '!';
 // It pulls data from the object that contains access to the History
 pub(crate) struct HistoryCompleter<'menu>(&'menu dyn History);
 
-// Safe to implement Send since the HistoryCompleter should only be used when
-// updating the menu and that must happen in the same thread
-unsafe impl Send for HistoryCompleter<'_> {}
-
 fn search_unique(
     completer: &HistoryCompleter,
     line: &str,

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -175,7 +175,7 @@ impl SearchQuery {
 
 /// Represents a history file or database
 /// Data could be stored e.g. in a plain text file, in a `JSONL` file, in a `SQLite` database
-pub trait History: Send {
+pub trait History: Send + Sync {
     /// save a history item to the database
     /// if given id is None, a new id is created and set in the return value
     /// if given id is Some, the existing entry is updated


### PR DESCRIPTION
`HistoryCompleter` is not `Send` due to it containing a reference to a `&dyn History` which was only `trait History: Send`.
Here the property of a type T needing to implement `Sync` for its `&T` to be `Send` comes into play. Thus this `unsafe impl Send` is unsound.

The change of making `trait History: Send + Sync` makes `HistoryCompleter: Send` automatically and should be compatible for all sound implementations.
