### PR TITLE
Alternate removal of `unsafe impl Send`

### DIFF
--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -9,11 +9,7 @@ const SELECTION_CHAR: char = '!';
 
 // The HistoryCompleter is created just before updating the menu
 // It pulls data from the object that contains access to the History
-pub(crate) struct HistoryCompleter<'menu>(&'menu dyn History);
-
-// Safe to implement Send since the HistoryCompleter should only be used when
-// updating the menu and that must happen in the same thread
-unsafe impl Send for HistoryCompleter<'_> {}
+pub(crate) struct HistoryCompleter<'menu>(&'menu (dyn History + Send + Sync));
 
 fn search_unique(
     completer: &HistoryCompleter,
@@ -48,7 +44,7 @@ impl Completer for HistoryCompleter<'_> {
 }
 
 impl<'menu> HistoryCompleter<'menu> {
-    pub fn new(history: &'menu dyn History) -> Self {
+    pub fn new(history: &'menu (dyn History + Send + Sync)) -> Self {
         Self(history)
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -103,7 +103,7 @@ pub struct Reedline {
     editor: Editor,
 
     // History
-    history: Box<dyn History>,
+    history: Box<dyn History + Send + Sync>,
     history_cursor: HistoryCursor,
     history_session_id: Option<HistorySessionId>,
     // none if history doesn't support this
@@ -420,7 +420,7 @@ impl Reedline {
     ///     .with_history(history);
     /// ```
     #[must_use]
-    pub fn with_history(mut self, history: Box<dyn History>) -> Self {
+    pub fn with_history(mut self, history: Box<dyn History + Send + Sync>) -> Self {
         self.history = history;
         self
     }

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -307,7 +307,7 @@ impl ReedlineMenu {
         values_updated: bool,
         editor: &mut Editor,
         completer: &mut dyn Completer,
-        history: &dyn History,
+        history: &(dyn History + Send + Sync),
     ) -> bool {
         match self {
             Self::EngineCompleter(menu) => {
@@ -328,7 +328,7 @@ impl ReedlineMenu {
         &mut self,
         editor: &mut Editor,
         completer: &mut dyn Completer,
-        history: &dyn History,
+        history: &(dyn History + Send + Sync),
     ) {
         match self {
             Self::EngineCompleter(menu) => menu.update_values(editor, completer),
@@ -349,7 +349,7 @@ impl ReedlineMenu {
         &mut self,
         editor: &mut Editor,
         completer: &mut dyn Completer,
-        history: &dyn History,
+        history: &(dyn History + Send + Sync),
         painter: &Painter,
     ) {
         match self {


### PR DESCRIPTION
Trying a different approach from requiring `Sync` which breaks the `SqliteBackedHistory` as is in #869

API breakage as we now explicitly state `History + Send + Sync`
