### PR TITLE
Add Vi `o` command to swap anchor and cursor

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -1127,6 +1127,31 @@ mod test {
         editor.run_edit_command(&EditCommand::Undo);
         assert_eq!(editor.get_buffer(), "This \r\n is a test");
     }
+
+    #[test]
+    fn test_swap_cursor_and_anchor() {
+        let mut editor = editor_with("This is some test content");
+        editor.line_buffer.set_insertion_point(0);
+        editor.update_selection_anchor(true);
+
+        for _ in 0..3 {
+            editor.run_edit_command(&EditCommand::MoveRight { select: true });
+        }
+        assert_eq!(editor.selection_anchor, Some(0));
+        assert_eq!(editor.insertion_point(), 3);
+        assert_eq!(editor.get_selection(), Some((0, 4)));
+
+        editor.run_edit_command(&EditCommand::SwapCursorAndAnchor);
+        assert_eq!(editor.selection_anchor, Some(3));
+        assert_eq!(editor.insertion_point(), 0);
+        assert_eq!(editor.get_selection(), Some((0, 4)));
+
+        editor.run_edit_command(&EditCommand::SwapCursorAndAnchor);
+        assert_eq!(editor.selection_anchor, Some(0));
+        assert_eq!(editor.insertion_point(), 3);
+        assert_eq!(editor.get_selection(), Some((0, 4)));
+    }
+
     #[cfg(feature = "system_clipboard")]
     mod without_system_clipboard {
         use super::*;

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -163,6 +163,7 @@ impl Editor {
                     );
                 }
             }
+            EditCommand::SwapCursorAndAnchor => self.swap_cursor_and_anchor(),
             #[cfg(feature = "system_clipboard")]
             EditCommand::CutSelectionSystem => self.cut_selection_to_system(),
             #[cfg(feature = "system_clipboard")]
@@ -194,6 +195,14 @@ impl Editor {
 
         self.update_undo_state(new_undo_behavior);
     }
+
+    fn swap_cursor_and_anchor(&mut self) {
+        if let Some(anchor) = self.selection_anchor {
+            self.selection_anchor = Some(self.insertion_point());
+            self.line_buffer.set_insertion_point(anchor);
+        }
+    }
+
     fn update_selection_anchor(&mut self, select: bool) {
         self.selection_anchor = if select {
             self.selection_anchor

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -113,6 +113,10 @@ where
             let _ = input.next();
             Some(Command::RepeatLastAction)
         }
+        Some('o') => {
+            let _ = input.next();
+            Some(Command::SwapCursorAndAnchor)
+        }
         _ => None,
     }
 }
@@ -143,6 +147,7 @@ pub enum Command {
     ChangeInsidePair { left: char, right: char },
     DeleteInsidePair { left: char, right: char },
     YankInsidePair { left: char, right: char },
+    SwapCursorAndAnchor,
 }
 
 impl Command {
@@ -221,6 +226,9 @@ impl Command {
                     left: *left,
                     right: *right,
                 })]
+            }
+            Self::SwapCursorAndAnchor => {
+                vec![ReedlineOption::Edit(EditCommand::SwapCursorAndAnchor)]
             }
         }
     }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -317,6 +317,8 @@ pub enum EditCommand {
 
     /// Copy left before char
     CopyLeftBefore(char),
+    /// Swap the positions of the cursor and anchor
+    SwapCursorAndAnchor,
 
     /// Cut selection to system clipboard
     #[cfg(feature = "system_clipboard")]
@@ -448,6 +450,7 @@ impl Display for EditCommand {
             EditCommand::CopyRightBefore(_) => write!(f, "CopyRightBefore Value: <char>"),
             EditCommand::CopyLeftUntil(_) => write!(f, "CopyLeftUntil Value: <char>"),
             EditCommand::CopyLeftBefore(_) => write!(f, "CopyLeftBefore Value: <char>"),
+            EditCommand::SwapCursorAndAnchor => write!(f, "SwapCursorAndAnchor"),
             #[cfg(feature = "system_clipboard")]
             EditCommand::CutSelectionSystem => write!(f, "CutSelectionSystem"),
             #[cfg(feature = "system_clipboard")]
@@ -486,6 +489,7 @@ impl EditCommand {
             | EditCommand::MoveLeftBefore { select, .. } => {
                 EditType::MoveCursor { select: *select }
             }
+            EditCommand::SwapCursorAndAnchor => EditType::MoveCursor { select: true },
 
             EditCommand::SelectAll => EditType::MoveCursor { select: true },
             // Text edits


### PR DESCRIPTION
This PR adds a keybinding to `o` in Vi visual mode, which swaps the cursor and the anchor - see [here](https://vimdoc.sourceforge.net/htmldoc/visual.html#visual-change) for Vim docs explaining this behaviour.