### PR TITLE
Clear selection when exiting visual mode

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -202,12 +202,6 @@ impl Editor {
             None
         };
     }
-
-    /// Sets the selection anchor to None, clearing the selection
-    pub fn clear_selection_anchor(&mut self) {
-        self.selection_anchor = None;
-    }
-
     fn move_to_position(&mut self, position: usize, select: bool) {
         self.update_selection_anchor(select);
         self.line_buffer.set_insertion_point(position)

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -202,6 +202,12 @@ impl Editor {
             None
         };
     }
+
+    /// Sets the selection anchor to None, clearing the selection
+    pub fn clear_selection_anchor(&mut self) {
+        self.selection_anchor = None;
+    }
+
     fn move_to_position(&mut self, position: usize, select: bool) {
         self.update_selection_anchor(select);
         self.line_buffer.set_insertion_point(position)

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -142,11 +142,7 @@ impl EditMode for Vi {
                 (_, KeyModifiers::NONE, KeyCode::Esc) => {
                     self.cache.clear();
                     self.mode = ViMode::Normal;
-                    ReedlineEvent::Multiple(vec![
-                        ReedlineEvent::ResetSelection,
-                        ReedlineEvent::Esc,
-                        ReedlineEvent::Repaint,
-                    ])
+                    ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint])
                 }
                 (_, KeyModifiers::NONE, KeyCode::Enter) => {
                     self.mode = ViMode::Insert;
@@ -195,11 +191,7 @@ mod test {
 
         assert_eq!(
             result,
-            ReedlineEvent::Multiple(vec![
-                ReedlineEvent::ResetSelection,
-                ReedlineEvent::Esc,
-                ReedlineEvent::Repaint
-            ])
+            ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint])
         );
         assert!(matches!(vi.mode, ViMode::Normal));
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1070,6 +1070,7 @@ impl Reedline {
             }
             ReedlineEvent::Esc => {
                 self.deactivate_menus();
+                self.editor.clear_selection_anchor();
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::CtrlD => {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -909,10 +909,6 @@ impl Reedline {
                 self.input_mode = InputMode::Regular;
                 Ok(EventStatus::Handled)
             }
-            ReedlineEvent::ResetSelection => {
-                self.editor.reset_selection();
-                Ok(EventStatus::Handled)
-            }
             // TODO: Check if events should be handled
             ReedlineEvent::Right
             | ReedlineEvent::Left
@@ -1070,7 +1066,7 @@ impl Reedline {
             }
             ReedlineEvent::Esc => {
                 self.deactivate_menus();
-                self.editor.clear_selection_anchor();
+                self.editor.reset_selection();
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::CtrlD => {
@@ -1202,10 +1198,6 @@ impl Reedline {
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::OpenEditor => self.open_editor().map(|_| EventStatus::Handled),
-            ReedlineEvent::ResetSelection => {
-                self.editor.reset_selection();
-                Ok(EventStatus::Handled)
-            }
             ReedlineEvent::Resize(width, height) => {
                 self.painter.handle_resize(width, height);
                 Ok(EventStatus::Handled)

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -748,9 +748,6 @@ pub enum ReedlineEvent {
 
     /// Open text editor
     OpenEditor,
-
-    /// Reset the current text selection
-    ResetSelection,
 }
 
 impl Display for ReedlineEvent {
@@ -794,7 +791,6 @@ impl Display for ReedlineEvent {
             ReedlineEvent::MenuPagePrevious => write!(f, "MenuPagePrevious"),
             ReedlineEvent::ExecuteHostCommand(_) => write!(f, "ExecuteHostCommand"),
             ReedlineEvent::OpenEditor => write!(f, "OpenEditor"),
-            ReedlineEvent::ResetSelection => write!(f, "ResetSelection"),
         }
     }
 }


### PR DESCRIPTION
After exiting visual mode with Escape, the selection is currently not cleared until another action is performed such as moving the cursor left or right. This PR fixes that, clearing the selection as soon as Escape is pressed to match the behaviour of Vim.