### PR TITLE
Moved partial completion menu next into new menu event

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -918,6 +918,7 @@ impl Reedline {
             | ReedlineEvent::OpenEditor
             | ReedlineEvent::Menu(_)
             | ReedlineEvent::MenuNext
+            | ReedlineEvent::MenuNextComplete
             | ReedlineEvent::MenuPrevious
             | ReedlineEvent::MenuUp
             | ReedlineEvent::MenuDown
@@ -968,13 +969,33 @@ impl Reedline {
                 Ok(EventStatus::Inapplicable)
             }
             ReedlineEvent::MenuNext => {
+                if let Some(menu) = self.active_menu() {
+                    if menu.get_values().len() == 1 && menu.can_quick_complete() {
+                        self.handle_editor_event(prompt, ReedlineEvent::Enter)
+                    } else {
+                        menu.menu_event(MenuEvent::NextElement);
+                        Ok(EventStatus::Handled)
+                    }
+                } else {
+                    Ok(EventStatus::Inapplicable)
+                }
+            }
+            ReedlineEvent::MenuNextComplete => {
+                // Ensure values are updated before this event is called!
                 if let Some(menu) = self.menus.iter_mut().find(|menu| menu.is_active()) {
                     if menu.get_values().len() == 1 && menu.can_quick_complete() {
                         self.handle_editor_event(prompt, ReedlineEvent::Enter)
                     } else {
-                        if self.partial_completions {
-                            menu.can_partially_complete(
-                                self.quick_completions,
+                        // Requires can partially complete to actually also complete.
+                        if self.partial_completions
+                            && menu.can_partially_complete(
+                                true,
+                                &mut self.editor,
+                                self.completer.as_mut(),
+                                self.history.as_ref(),
+                            )
+                        {
+                            menu.update_values(
                                 &mut self.editor,
                                 self.completer.as_mut(),
                                 self.history.as_ref(),

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -618,6 +618,9 @@ pub enum ReedlineEvent {
     /// Next element in the menu
     MenuNext,
 
+    /// Next element in menu with partial completions
+    MenuNextComplete,
+
     /// Previous element in the menu
     MenuPrevious,
 
@@ -678,6 +681,7 @@ impl Display for ReedlineEvent {
             ReedlineEvent::UntilFound(_) => write!(f, "UntilFound [ {{ ReedLineEvents, }} ]"),
             ReedlineEvent::Menu(_) => write!(f, "Menu Name: <string>"),
             ReedlineEvent::MenuNext => write!(f, "MenuNext"),
+            ReedlineEvent::MenuNextComplete => write!(f, "MenuNextComplete"),
             ReedlineEvent::MenuPrevious => write!(f, "MenuPrevious"),
             ReedlineEvent::MenuUp => write!(f, "MenuUp"),
             ReedlineEvent::MenuDown => write!(f, "MenuDown"),


### PR DESCRIPTION
Addresses nushell/nushell#14152 (more context can also be found in #828 ). Creates a separate event, MenuNextComplete, that not only selects the next element but also attempts to partially complete the selection. Reverts MenuNext to simply advancing the next element and quick completing if possible. 

The nushell PR to use this new event can be found at nushell/nushell#15063
