### PR TITLE
Bump itertools version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4.19", default-features = false, features = [
 crossbeam = { version = "0.8.2", optional = true }
 crossterm = { version = "0.28.1", features = ["serde"] }
 fd-lock = "4.0.2"
-itertools = "0.12.0"
+itertools = "0.13.0"
 nu-ansi-term = "0.50.0"
 rusqlite = { version = "0.31.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
`0.13.0` now the most common among nushell dependencies
