### PR TITLE
fix: columnar_menu create_string with quoted suggestions

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -299,10 +299,21 @@ impl ColumnarMenu {
         use_ansi_coloring: bool,
     ) -> String {
         if use_ansi_coloring {
-            let match_len = self.working_details.shortest_base_string.len();
+            // strip quotes
+            let is_quote = |c: char| "`'\"".contains(c);
+            let shortest_base = &self.working_details.shortest_base_string;
+            let shortest_base = shortest_base
+                .strip_prefix(is_quote)
+                .unwrap_or(shortest_base);
+            let match_len = shortest_base.len();
 
             // Split string so the match text can be styled
-            let (match_str, remaining_str) = suggestion.value.split_at(match_len);
+            let skip_len = suggestion
+                .value
+                .chars()
+                .take_while(|c| is_quote(*c))
+                .count();
+            let (match_str, remaining_str) = suggestion.value.split_at(match_len + skip_len);
 
             let suggestion_style_prefix = suggestion
                 .style
@@ -772,5 +783,20 @@ mod tests {
             editor.is_cursor_at_buffer_end(),
             "cursor should be at the end after completion"
         );
+    }
+
+    #[test]
+    fn test_menu_create_string() {
+        // https://github.com/nushell/nushell/issues/13951
+        let mut completer = FakeCompleter::new(&["おはよう", "`おはよう(`"]);
+        let mut menu = ColumnarMenu::default().with_name("testmenu");
+        let mut editor = Editor::default();
+
+        editor.set_buffer("おは".to_string(), UndoBehavior::CreateUndoPoint);
+
+        menu.update_values(&mut editor, &mut completer);
+
+        // After replacing the editor, make sure insertion_point is at the right spot
+        assert!(menu.menu_string(2, true).contains("`おは"));
     }
 }

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -793,10 +793,7 @@ mod tests {
         let mut editor = Editor::default();
 
         editor.set_buffer("おは".to_string(), UndoBehavior::CreateUndoPoint);
-
         menu.update_values(&mut editor, &mut completer);
-
-        // After replacing the editor, make sure insertion_point is at the right spot
         assert!(menu.menu_string(2, true).contains("`おは"));
     }
 }

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -313,7 +313,9 @@ impl ColumnarMenu {
                 .chars()
                 .take_while(|c| is_quote(*c))
                 .count();
-            let (match_str, remaining_str) = suggestion.value.split_at(match_len + skip_len);
+            let (match_str, remaining_str) = suggestion
+                .value
+                .split_at((match_len + skip_len).min(suggestion.value.len()));
 
             let suggestion_style_prefix = suggestion
                 .style


### PR DESCRIPTION
This is a stopgap for https://github.com/nushell/nushell/issues/12680, https://github.com/nushell/nushell/issues/13951, https://github.com/nushell/nushell/issues/13630, https://github.com/nushell/nushell/issues/15302.

Fuzzy matching will need more care, and I think @ysthakur knows how to fix that.

https://github.com/nushell/nushell/issues/13951 also exposes another bug in `directory_completion`, i.e. not doing quoting, which is handled properly in `file_completion`.