### PR TITLE
Add smooth scrolling to menus

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -624,7 +624,7 @@ impl Menu for ColumnarMenu {
                 }
             }
 
-            let available_lines = painter.remaining_lines().saturating_sub(1);
+            let available_lines = painter.remaining_lines();
 
             let first_visible_row = self.skip_values / self.get_cols();
 

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -624,7 +624,12 @@ impl Menu for ColumnarMenu {
                 }
             }
 
-            let available_lines = painter.remaining_lines();
+            let mut available_lines = painter.remaining_lines_real();
+            // Handle the case where a prompt uses the entire screen.
+            // Drawing the menu has priority over the drawing the prompt.
+            if available_lines == 0 {
+                available_lines = painter.remaining_lines().min(self.min_rows());
+            }
 
             let first_visible_row = self.skip_values / self.get_cols();
 
@@ -668,14 +673,16 @@ impl Menu for ColumnarMenu {
             // rather than looping through the values and printing multiple things
             // This reduces the flickering when printing the menu
             let available_values = (available_lines * self.get_cols()) as usize;
+            let skip_values = self.skip_values as usize;
+
             self.get_values()
                 .iter()
-                .skip(self.skip_values as usize)
+                .skip(skip_values)
                 .take(available_values)
                 .enumerate()
                 .map(|(index, suggestion)| {
                     // Correcting the enumerate index based on the number of skipped values
-                    let index = index + self.skip_values as usize;
+                    let index = index + skip_values;
                     let column = index as u16 % self.get_cols();
                     let empty_space = self.get_width().saturating_sub(suggestion.value.width());
 

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -63,7 +63,8 @@ pub struct ColumnarMenu {
     col_pos: u16,
     /// row position in the menu. Starts from 0
     row_pos: u16,
-    /// Number of values that need to be skipped (based on selected & terminal height)
+    /// Number of values that are skipped when printing,
+    /// depending on selected value and terminal height
     skip_values: u16,
     /// Event sent to the menu
     event: Option<MenuEvent>,
@@ -623,24 +624,18 @@ impl Menu for ColumnarMenu {
                 }
             }
 
-            let available_lines = painter.remaining_lines().saturating_sub(1); // Not sure why this is 1 less than the `available_lines` from [`Menu::menu_string`]
+            let available_lines = painter.remaining_lines().saturating_sub(1);
 
-            // The skip values represent the number of lines that should be skipped
-            // while printing the menu
-
-            // Calculate the current first visible row
             let first_visible_row = self.skip_values / self.get_cols();
 
-            // The skip values represent the number of lines that should be skipped
-            // while printing the menu
             self.skip_values = if self.row_pos <= first_visible_row {
-                // Selection is above the visible area, scroll up to make it visible
+                // Selection is above the visible area, scroll up
                 self.row_pos * self.get_cols()
             } else if self.row_pos >= first_visible_row + available_lines {
-                // Selection is below the visible area, scroll down to make it visible
+                // Selection is below the visible area, scroll down
                 (self.row_pos.saturating_sub(available_lines) + 1) * self.get_cols()
             } else {
-                // Selection is within the visible area, maintain current scroll position
+                // Selection is within the visible area
                 self.skip_values
             };
         }

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -633,7 +633,7 @@ impl Menu for ColumnarMenu {
 
             // The skip values represent the number of lines that should be skipped
             // while printing the menu
-            self.skip_values = if self.row_pos < first_visible_row {
+            self.skip_values = if self.row_pos <= first_visible_row {
                 // Selection is above the visible area, scroll up to make it visible
                 self.row_pos * self.get_cols()
             } else if self.row_pos >= first_visible_row + available_lines {

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -812,9 +812,15 @@ impl Menu for IdeMenu {
             self.working_details.space_left = space_left;
             self.working_details.space_right = space_right;
 
-            let available_lines = painter
-                .remaining_lines()
+            let mut available_lines = painter
+                .remaining_lines_real()
                 .min(self.default_details.max_completion_height);
+
+            // Handle the case where a prompt uses the entire screen.
+            // Drawing the menu has priority over the drawing the prompt.
+            if available_lines == 0 {
+                available_lines = painter.remaining_lines().min(self.min_rows());
+            }
 
             let visible_items = available_lines.saturating_sub(border_width);
 

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -811,8 +811,11 @@ impl Menu for IdeMenu {
             self.working_details.space_left = space_left;
             self.working_details.space_right = space_right;
 
-            let available_lines = painter.remaining_lines().min(self.default_details.max_completion_height)
-                .saturating_sub(1); // Not sure why this is 1 less than the `available_lines` from [`Menu::menu_string`] 
+            let available_lines = painter
+                .remaining_lines()
+                .min(self.default_details.max_completion_height)
+                .saturating_sub(1); // Not sure why this is 1 less than the `available_lines` from [`Menu::menu_string`]
+            
             let visible_items = available_lines.saturating_sub(border_width);
 
             self.skip_values = if self.selected < self.skip_values {
@@ -857,7 +860,6 @@ impl Menu for IdeMenu {
                 0
             };
 
-            
             let available_lines = available_lines.min(self.default_details.max_completion_height);
             let skip_values = self.skip_values as usize;
 

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -818,7 +818,7 @@ impl Menu for IdeMenu {
 
             let visible_items = available_lines.saturating_sub(border_width);
 
-            self.skip_values = if self.selected < self.skip_values {
+            self.skip_values = if self.selected <= self.skip_values {
                 // Selection is above the visible area, scroll up to make it visible
                 self.selected
             } else if self.selected >= self.skip_values + visible_items {

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -814,8 +814,8 @@ impl Menu for IdeMenu {
 
             let available_lines = painter
                 .remaining_lines()
-                .min(self.default_details.max_completion_height)
-                .saturating_sub(1);
+                .saturating_sub(1)
+                .min(self.default_details.max_completion_height);
 
             let visible_items = available_lines.saturating_sub(border_width);
 

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -814,7 +814,6 @@ impl Menu for IdeMenu {
 
             let available_lines = painter
                 .remaining_lines()
-                .saturating_sub(1)
                 .min(self.default_details.max_completion_height);
 
             let visible_items = available_lines.saturating_sub(border_width);

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -144,7 +144,8 @@ pub struct IdeMenu {
     values: Vec<Suggestion>,
     /// Selected value. Starts at 0
     selected: u16,
-    /// Number of values that need to be skipped (based on selected & terminal height)
+    /// Number of values that are skipped when printing,
+    /// depending on selected value and terminal height
     skip_values: u16,
     /// Event sent to the menu
     event: Option<MenuEvent>,
@@ -814,18 +815,18 @@ impl Menu for IdeMenu {
             let available_lines = painter
                 .remaining_lines()
                 .min(self.default_details.max_completion_height)
-                .saturating_sub(1); // Not sure why this is 1 less than the `available_lines` from [`Menu::menu_string`]
+                .saturating_sub(1);
 
             let visible_items = available_lines.saturating_sub(border_width);
 
             self.skip_values = if self.selected <= self.skip_values {
-                // Selection is above the visible area, scroll up to make it visible
+                // Selection is above the visible area
                 self.selected
             } else if self.selected >= self.skip_values + visible_items {
-                // Selection is below the visible area, scroll down to make it visible
+                // Selection is below the visible area
                 self.selected.saturating_sub(visible_items) + 1
             } else {
-                // Selection is within the visible area, maintain current scroll position
+                // Selection is within the visible area
                 self.skip_values
             }
         }

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -815,7 +815,7 @@ impl Menu for IdeMenu {
                 .remaining_lines()
                 .min(self.default_details.max_completion_height)
                 .saturating_sub(1); // Not sure why this is 1 less than the `available_lines` from [`Menu::menu_string`]
-            
+
             let visible_items = available_lines.saturating_sub(border_width);
 
             self.skip_values = if self.selected < self.skip_values {

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -217,7 +217,7 @@ impl Painter {
         }
 
         // Lines and distance parameters
-        let remaining_lines = self.remaining_lines();
+        let remaining_lines = self.remaining_lines() + self.prompt_height;
         let required_lines = lines.required_lines(screen_width, menu);
 
         // Marking the painter state as larger buffer to avoid animations

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -124,11 +124,20 @@ impl Painter {
         self.terminal_size.0
     }
 
-    /// Returns the available lines from the prompt down
-    pub fn remaining_lines(&self) -> u16 {
+    /// Returns the empty lines from the prompt down.
+    pub fn remaining_lines_real(&self) -> u16 {
         self.screen_height()
             .saturating_sub(self.prompt_start_row)
             .saturating_sub(self.prompt_height)
+    }
+
+    /// Returns the number of lines that are available or can be made available by
+    /// stripping the prompt.
+    ///
+    /// If you want the number of empty lines below the prompt,
+    /// use [`Painter::remaining_lines_real`] instead.
+    pub fn remaining_lines(&self) -> u16 {
+        self.screen_height().saturating_sub(self.prompt_start_row)
     }
 
     /// Returns the state necessary before suspending the painter (to run a host command event).
@@ -217,7 +226,7 @@ impl Painter {
         }
 
         // Lines and distance parameters
-        let remaining_lines = self.remaining_lines() + self.prompt_height;
+        let remaining_lines = self.remaining_lines();
         let required_lines = lines.required_lines(screen_width, menu);
 
         // Marking the painter state as larger buffer to avoid animations

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -91,6 +91,8 @@ pub struct Painter {
     // Stdout
     stdout: W,
     prompt_start_row: u16,
+    // The number of lines that the prompt takes up
+    prompt_height: u16,
     terminal_size: (u16, u16),
     last_required_lines: u16,
     large_buffer: bool,
@@ -103,6 +105,7 @@ impl Painter {
         Painter {
             stdout,
             prompt_start_row: 0,
+            prompt_height: 0,
             terminal_size: (0, 0),
             last_required_lines: 0,
             large_buffer: false,
@@ -123,7 +126,7 @@ impl Painter {
 
     /// Returns the available lines from the prompt down
     pub fn remaining_lines(&self) -> u16 {
-        self.screen_height().saturating_sub(self.prompt_start_row)
+        self.screen_height().saturating_sub(self.prompt_height)
     }
 
     /// Returns the state necessary before suspending the painter (to run a host command event).
@@ -198,6 +201,8 @@ impl Painter {
 
         let screen_width = self.screen_width();
         let screen_height = self.screen_height();
+
+        self.prompt_height = lines.prompt_lines_with_wrap(screen_width);
 
         // Handle resize for multi line prompt
         if self.just_resized {

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -126,7 +126,9 @@ impl Painter {
 
     /// Returns the available lines from the prompt down
     pub fn remaining_lines(&self) -> u16 {
-        self.screen_height().saturating_sub(self.prompt_height)
+        self.screen_height()
+            .saturating_sub(self.prompt_start_row)
+            .saturating_sub(self.prompt_height)
     }
 
     /// Returns the state necessary before suspending the painter (to run a host command event).
@@ -202,7 +204,8 @@ impl Painter {
         let screen_width = self.screen_width();
         let screen_height = self.screen_height();
 
-        self.prompt_height = lines.prompt_lines_with_wrap(screen_width);
+        // We add one here as [`PromptLines::prompt_lines_with_wrap`] intentionally subtracts 1 from the real value.
+        self.prompt_height = lines.prompt_lines_with_wrap(screen_width) + 1;
 
         // Handle resize for multi line prompt
         if self.just_resized {

--- a/src/painting/prompt_lines.rs
+++ b/src/painting/prompt_lines.rs
@@ -120,7 +120,9 @@ impl<'prompt> PromptLines<'prompt> {
     pub(crate) fn prompt_lines_with_wrap(&self, screen_width: u16) -> u16 {
         let complete_prompt = self.prompt_str_left.to_string() + &self.prompt_indicator;
         let lines = estimate_required_lines(&complete_prompt, screen_width);
-        lines.saturating_sub(1) as u16
+        // TODO: make sure this doesnt cause any problems in other places
+        // lines.saturating_sub(1) as u16
+        lines as u16
     }
 
     /// Estimated width of the line where right prompt will be rendered

--- a/src/painting/prompt_lines.rs
+++ b/src/painting/prompt_lines.rs
@@ -120,9 +120,7 @@ impl<'prompt> PromptLines<'prompt> {
     pub(crate) fn prompt_lines_with_wrap(&self, screen_width: u16) -> u16 {
         let complete_prompt = self.prompt_str_left.to_string() + &self.prompt_indicator;
         let lines = estimate_required_lines(&complete_prompt, screen_width);
-        // TODO: make sure this doesnt cause any problems in other places
-        // lines.saturating_sub(1) as u16
-        lines as u16
+        lines.saturating_sub(1) as u16
     }
 
     /// Estimated width of the line where right prompt will be rendered


### PR DESCRIPTION
currently when scrolling up, the selected item will always stick to the bottom (see #733)

This PR fixes that.

Currently implemented for
* ide menu
* columnar menu

closes #733 
