### PR TITLE
fix: prompt duplication when resizing with non-empty right_prompt

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -210,7 +210,8 @@ impl Painter {
         {
             self.prompt_start_row = self.prompt_start_row.saturating_sub(
                 (lines.prompt_str_left.matches('\n').count()
-                    + lines.prompt_indicator.matches('\n').count()) as u16,
+                    + lines.prompt_indicator.matches('\n').count()
+                    + lines.before_cursor.matches('\n').count()) as u16,
             );
             // If the right prompt gets wrapped with smaller terminal width,
             // move the prompt one row up to avoid left prompt glitches.


### PR DESCRIPTION
Supposed to fix #864 , this method works well on my mac with ghostty/wezterm/terminal, but I need help to test on other terminal/os.

After:

https://github.com/user-attachments/assets/e1198bed-49db-4003-a388-22e9e2f8290f

The prompt start position goes up with the line-wrapped text, which is the same behavior as zsh.