### PR TITLE
Upgrade `unicode-width` to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,9 +1009,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ strum = "0.26"
 strum_macros = "0.26"
 thiserror = "1.0.31"
 unicode-segmentation = "1.9.0"
-unicode-width = "0.1.9"
+unicode-width = "0.2"
 
 [dev-dependencies]
 gethostname = "0.4.0"


### PR DESCRIPTION
`unicode-width` has to bundle unicode codepoint tables, so it's quite large (1.5MB).  They've recently released the version 0.2, which caused a split in Nushell dependencies between 0.1 and 0.2, doubling the size.

The main breaking change for `unicode-width` is that `\n` is now counted as having width 1 and not 0.  But that shouldn't matter for reedline, since the menus which use it (columnar/IDE/list) work on lines.