### PR TITLE
fix: prompt glitch when resizing with cursor in a multiline command

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -203,7 +203,8 @@ impl Painter {
         if self.just_resized {
             self.prompt_start_row = self.prompt_start_row.saturating_sub(
                 (lines.prompt_str_left.matches('\n').count()
-                    + lines.prompt_indicator.matches('\n').count()) as u16,
+                    + lines.prompt_indicator.matches('\n').count()
+                    + lines.before_cursor.matches('\n').count()) as u16,
             );
             self.just_resized = false;
         }


### PR DESCRIPTION
Fixes a bug overlooked in #841 (forgot that the `before_cursor` string could have newlines in it too).

Before:

https://github.com/user-attachments/assets/cf79d8db-24c8-45f0-9a6d-f0092daaa7eb

After: stays in the same row.