### PR TITLE
fix: dislocation of cursor after previous_history navigation to a multiline entry

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1311,6 +1311,7 @@ impl Reedline {
         self.editor.move_to_line_end(false);
         self.editor
             .update_undo_state(UndoBehavior::HistoryNavigation);
+        self.editor.move_to_end(false);
     }
 
     fn next_history(&mut self) {


### PR DESCRIPTION
Fixes this bug:

When I press ctrl-p/up to bring up this kind of command:

<img width="207" alt="image" src="https://github.com/user-attachments/assets/56d65ead-c68a-4d86-88b8-82c3dc8a3d81" />

The cursor is at the end of the first line. However when I press left/right key to move the cursor, it unexpectedly jumps to the last line and executes the movement there.

After pressing left:

<img width="207" alt="image" src="https://github.com/user-attachments/assets/5a33c245-dfe2-4fc3-a4f7-67b63f6fa5c7" />


After this PR, however.

It shows the cursor directly at the end of the last line, just like selecting that entry in a history menu will do.

The same thing happens for vi normal mode.