### PR TITLE
editor: introduce a KillLine command, and bind it to ctrl_k in emacs

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -84,6 +84,7 @@ impl Editor {
             EditCommand::CutFromLineStart => self.cut_from_line_start(),
             EditCommand::CutToEnd => self.cut_from_end(),
             EditCommand::CutToLineEnd => self.cut_to_line_end(),
+            EditCommand::KillLine => self.kill_line(),
             EditCommand::CutWordLeft => self.cut_word_left(),
             EditCommand::CutBigWordLeft => self.cut_big_word_left(),
             EditCommand::CutWordRight => self.cut_word_right(),
@@ -360,6 +361,14 @@ impl Editor {
         if !cut_slice.is_empty() {
             self.cut_buffer.set(cut_slice, ClipboardMode::Normal);
             self.line_buffer.clear_to_line_end();
+        }
+    }
+
+    fn kill_line(&mut self) {
+        if self.line_buffer.insertion_point() == self.line_buffer.find_current_line_end() {
+            self.cut_char()
+        } else {
+            self.cut_to_line_end()
         }
     }
 

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -1308,4 +1308,20 @@ mod test {
         assert_eq!(editor.insertion_point(), 4);
         assert_eq!(editor.cut_buffer.get().0, "bar(bazbaz)qux");
     }
+
+    #[test]
+    fn test_kill_line() {
+        let mut editor = editor_with("foo\nbar");
+        editor.move_to_position(1, false);
+        editor.kill_line();
+        assert_eq!(editor.get_buffer(), "f\nbar"); // Just cut until the end of line
+        assert_eq!(editor.insertion_point(), 1); // Cursor should return to original position
+        assert_eq!(editor.cut_buffer.get().0, "oo");
+
+        // continue kill line at current position.
+        editor.kill_line();
+        assert_eq!(editor.get_buffer(), "fbar"); // Just cut the new line character
+        assert_eq!(editor.insertion_point(), 1);
+        assert_eq!(editor.cut_buffer.get().0, "\n");
+    }
 }

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -1323,5 +1323,25 @@ mod test {
         assert_eq!(editor.get_buffer(), "fbar"); // Just cut the new line character
         assert_eq!(editor.insertion_point(), 1);
         assert_eq!(editor.cut_buffer.get().0, "\n");
+
+        // Test when editor start with newline character point.
+        let mut editor = editor_with("foo\nbar");
+        editor.move_to_position(3, false);
+        editor.kill_line();
+        assert_eq!(editor.get_buffer(), "foobar"); // Just cut the new line character
+        assert_eq!(editor.insertion_point(), 3); // Cursor should return to original position
+        assert_eq!(editor.cut_buffer.get().0, "\n");
+
+        // continue kill line at current position.
+        editor.kill_line();
+        assert_eq!(editor.get_buffer(), "foo"); // Just cut until line end.
+        assert_eq!(editor.insertion_point(), 3);
+        assert_eq!(editor.cut_buffer.get().0, "bar");
+
+        // continue kill line, all remains the same.
+        editor.kill_line();
+        assert_eq!(editor.get_buffer(), "foo");
+        assert_eq!(editor.insertion_point(), 3);
+        assert_eq!(editor.cut_buffer.get().0, "bar");
     }
 }

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -288,4 +288,18 @@ mod test {
             ReedlineEvent::Edit(vec![EditCommand::InsertChar('😀')])
         );
     }
+
+    #[test]
+    fn kill_line() {
+        let mut emacs = Emacs::default();
+
+        let ctrl_k = ReedlineRawEvent::try_from(Event::Key(KeyEvent::new(
+            KeyCode::Char('k'),
+            KeyModifiers::CONTROL,
+        )))
+        .unwrap();
+        let result = emacs.parse_event(ctrl_k);
+
+        assert_eq!(result, ReedlineEvent::Edit(vec![EditCommand::KillLine]));
+    }
 }

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -52,7 +52,7 @@ pub fn default_emacs_keybindings() -> Keybindings {
         edit_bind(EC::PasteCutBufferBefore),
     );
     kb.add_binding(KM::CONTROL, KC::Char('w'), edit_bind(EC::CutWordLeft));
-    kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::CutToLineEnd));
+    kb.add_binding(KM::CONTROL, KC::Char('k'), edit_bind(EC::KillLine));
     kb.add_binding(KM::CONTROL, KC::Char('u'), edit_bind(EC::CutFromStart));
     kb.add_binding(KM::ALT, KC::Char('d'), edit_bind(EC::CutWordRight));
     // Edits

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -163,6 +163,10 @@ pub enum EditCommand {
     /// Cut from the insertion point to the end of the current line
     CutToLineEnd,
 
+    /// Cut from the insertion point to the end of the current line
+    /// If the cursor is already at the end of the line, remove the newline character
+    KillLine,
+
     /// Cut the word left of the insertion point
     CutWordLeft,
 
@@ -407,6 +411,7 @@ impl Display for EditCommand {
             EditCommand::CutFromLineStart => write!(f, "CutFromLineStart"),
             EditCommand::CutToEnd => write!(f, "CutToEnd"),
             EditCommand::CutToLineEnd => write!(f, "CutToLineEnd"),
+            EditCommand::KillLine => write!(f, "KillLine"),
             EditCommand::CutWordLeft => write!(f, "CutWordLeft"),
             EditCommand::CutBigWordLeft => write!(f, "CutBigWordLeft"),
             EditCommand::CutWordRight => write!(f, "CutWordRight"),
@@ -510,6 +515,7 @@ impl EditCommand {
             | EditCommand::CutFromStart
             | EditCommand::CutFromLineStart
             | EditCommand::CutToLineEnd
+            | EditCommand::KillLine
             | EditCommand::CutToEnd
             | EditCommand::CutWordLeft
             | EditCommand::CutBigWordLeft


### PR DESCRIPTION
Currently `ctrl-k` runs `CutToLineEnd`, I think it can be improved.
Because in emacs, `ctrl-k` not only `CutToLineEnd`, but also removes the line if the cursor is at the end of the line.