### PR TITLE
fix: accurately locate the match within the suggestion value

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -307,8 +307,12 @@ impl ColumnarMenu {
                 .unwrap_or(shortest_base);
             let match_len = shortest_base.len();
 
-            // Find match position - look for the base string in the suggestion
-            let match_position = suggestion.value.find(shortest_base).unwrap_or(0);
+            // Find match position - look for the base string in the suggestion (case-insensitive)
+            let match_position = suggestion
+                .value
+                .to_lowercase()
+                .find(&shortest_base.to_lowercase())
+                .unwrap_or(0);
 
             // The match is just the part that matches the shortest_base
             let match_str = &suggestion.value[match_position

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -308,17 +308,18 @@ impl ColumnarMenu {
             let match_len = shortest_base.len();
 
             let suggestion_value = &suggestion.value;
-            
+
             // Find match position - look for the base string in the suggestion
             // Use rfind to match from the end (for file paths, this will match the filename)
             let match_position = suggestion_value.rfind(shortest_base).unwrap_or(0);
-            
+
             // The match is just the part that matches the shortest_base
-            let match_str = &suggestion_value[match_position..match_position + match_len.min(suggestion_value.len() - match_position)];
-            
+            let match_str = &suggestion_value[match_position
+                ..match_position + match_len.min(suggestion_value.len() - match_position)];
+
             // Prefix is everything before the match
             let prefix = &suggestion_value[..match_position];
-            
+
             // Remaining is everything after the match
             let remaining_str = &suggestion_value[match_position + match_str.len()..];
 

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -307,21 +307,18 @@ impl ColumnarMenu {
                 .unwrap_or(shortest_base);
             let match_len = shortest_base.len();
 
-            let suggestion_value = &suggestion.value;
-
             // Find match position - look for the base string in the suggestion
-            // Use rfind to match from the end (for file paths, this will match the filename)
-            let match_position = suggestion_value.rfind(shortest_base).unwrap_or(0);
+            let match_position = suggestion.value.find(shortest_base).unwrap_or(0);
 
             // The match is just the part that matches the shortest_base
-            let match_str = &suggestion_value[match_position
-                ..match_position + match_len.min(suggestion_value.len() - match_position)];
+            let match_str = &suggestion.value[match_position
+                ..match_position + match_len.min(suggestion.value.len() - match_position)];
 
             // Prefix is everything before the match
-            let prefix = &suggestion_value[..match_position];
+            let prefix = &suggestion.value[..match_position];
 
             // Remaining is everything after the match
-            let remaining_str = &suggestion_value[match_position + match_str.len()..];
+            let remaining_str = &suggestion.value[match_position + match_str.len()..];
 
             let suggestion_style_prefix = suggestion
                 .style

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -332,7 +332,7 @@ impl ColumnarMenu {
             let left_text_size = self.longest_suggestion + self.default_details.col_padding;
             let right_text_size = self.get_width().saturating_sub(left_text_size);
 
-            let max_remaining = left_text_size.saturating_sub(match_str.width());
+            let max_remaining = left_text_size.saturating_sub(match_str.width() + prefix.width());
             let max_match = max_remaining.saturating_sub(remaining_str.width());
 
             if index == self.index() {

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -816,6 +816,6 @@ mod tests {
 
         editor.set_buffer("おは".to_string(), UndoBehavior::CreateUndoPoint);
         menu.update_values(&mut editor, &mut completer);
-        assert!(menu.menu_string(2, true).contains("`おは"));
+        assert!(menu.menu_string(2, true).contains("おは"));
     }
 }

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -1484,6 +1484,6 @@ mod tests {
 
         editor.set_buffer("おは".to_string(), UndoBehavior::CreateUndoPoint);
         menu.update_values(&mut editor, &mut completer);
-        assert!(menu.menu_string(2, true).contains("`おは"));
+        assert!(menu.menu_string(2, true).contains("おは"));
     }
 }

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -521,8 +521,7 @@ impl IdeMenu {
             let match_len = shortest_base.len().min(string.len());
 
             // Find match position - look for the base string in the suggestion
-            // Use rfind to match from the end (for file paths, this will match the filename)
-            let match_position = string.rfind(shortest_base).unwrap_or(0);
+            let match_position = string.find(shortest_base).unwrap_or(0);
 
             // The match is just the part that matches the shortest_base
             let match_str = &string
@@ -541,12 +540,11 @@ impl IdeMenu {
 
             if index == self.index() {
                 format!(
-                    "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+                    "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
                     vertical_border,
                     suggestion_style_prefix,
                     self.settings.color.selected_text_style.prefix(),
                     prefix,
-                    " ".repeat(padding_right),
                     RESET,
                     suggestion_style_prefix,
                     " ".repeat(padding),
@@ -562,11 +560,10 @@ impl IdeMenu {
                 )
             } else {
                 format!(
-                    "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+                    "{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
                     vertical_border,
                     suggestion_style_prefix,
                     prefix,
-                    " ".repeat(padding_right),
                     RESET,
                     suggestion_style_prefix,
                     " ".repeat(padding),

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -520,8 +520,12 @@ impl IdeMenu {
                 .unwrap_or(shortest_base);
             let match_len = shortest_base.len().min(string.len());
 
-            // Find match position - look for the base string in the suggestion
-            let match_position = string.find(shortest_base).unwrap_or(0);
+            // Find match position - look for the base string in the suggestion (case-insensitive)
+            let match_position = suggestion
+                .value
+                .to_lowercase()
+                .find(&shortest_base.to_lowercase())
+                .unwrap_or(0);
 
             // The match is just the part that matches the shortest_base
             let match_str = &string

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -523,13 +523,14 @@ impl IdeMenu {
             // Find match position - look for the base string in the suggestion
             // Use rfind to match from the end (for file paths, this will match the filename)
             let match_position = string.rfind(shortest_base).unwrap_or(0);
-            
+
             // The match is just the part that matches the shortest_base
-            let match_str = &string[match_position..match_position + match_len.min(string.len() - match_position)];
-            
+            let match_str = &string
+                [match_position..match_position + match_len.min(string.len() - match_position)];
+
             // Prefix is everything before the match
             let prefix = &string[..match_position];
-            
+
             // Remaining is everything after the match
             let remaining_str = &string[match_position + match_str.len()..];
 


### PR DESCRIPTION
# before
![image](https://github.com/user-attachments/assets/86c17cb5-664f-441d-b82f-b5b557662bcf)


# after
![image](https://github.com/user-attachments/assets/ab057445-67fc-42c8-b2b7-0c61eb74f295)


