### PR TITLE
feat: allow user to Select MatchDirection in Menu

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,8 +277,8 @@ pub use validator::{DefaultValidator, ValidationResult, Validator};
 
 mod menu;
 pub use menu::{
-    menu_functions, ColumnarMenu, DescriptionMenu, DescriptionMode, IdeMenu, ListMenu, Menu,
-    MenuBuilder, MenuEvent, MenuTextStyle, ReedlineMenu,
+    menu_functions, ColumnarMenu, DescriptionMenu, DescriptionMode, IdeMenu, ListMenu,
+    MatchDirection, Menu, MenuBuilder, MenuEvent, MenuTextStyle, ReedlineMenu,
 };
 
 mod terminal_extensions;

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -470,3 +470,12 @@ impl Menu for ReedlineMenu {
         self.as_mut().set_cursor_pos(pos);
     }
 }
+
+/// The direction to search for matches in suggestions
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchDirection {
+    /// Search from the start of the string
+    Forward,
+    /// Search from the end of the string
+    Backward,
+}


### PR DESCRIPTION

* Added a new `MatchDirection` enum to specify the direction for searching matches in suggestions. (`src/menu/mod.rs`)
