### PR TITLE
Handle suggestions that are substrings of first suggestion

### DIFF
--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -585,7 +585,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(&["nushell", "NULL"], 2)]
+    #[case(&["nushell", "nush", "NULL"], 2)]
     #[case(&["ｎｕｓｈｅｌｌ", "ｎｕｌｌ"], 6)]
     #[case(&["nushell", "nu"], 2)]
     #[case(&["nu", "nushell"], 2)]


### PR DESCRIPTION
Currently, when finding a common prefix for partial completions, we assume that suggestions after the first one won't be substrings of the first suggestion. This PR handles that case.

We did have code handling the case when the first suggestion is a substring of a later suggestion, but it doesn't do case-insensitive comparison, so this PR takes care of that too.