### PR TITLE
Protect against invalid suggestion spans

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -1,7 +1,9 @@
 use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
-    menu_functions::{can_partially_complete, completer_input, replace_in_buffer},
+    menu_functions::{
+        can_partially_complete, completer_input, floor_char_boundary, replace_in_buffer,
+    },
     painting::Painter,
     Completer, Suggestion,
 };
@@ -533,7 +535,11 @@ impl Menu for ColumnarMenu {
         self.values = values;
         self.working_details.shortest_base_string = base_ranges
             .iter()
-            .map(|range| editor.get_buffer()[range.clone()].to_string())
+            .map(|range| {
+                let end = floor_char_boundary(editor.get_buffer(), range.end);
+                let start = floor_char_boundary(editor.get_buffer(), range.start).min(end);
+                editor.get_buffer()[start..end].to_string()
+            })
             .min_by_key(|s| s.width())
             .unwrap_or_default();
 

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -1,7 +1,9 @@
 use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
-    menu_functions::{can_partially_complete, completer_input, replace_in_buffer},
+    menu_functions::{
+        can_partially_complete, completer_input, floor_char_boundary, replace_in_buffer,
+    },
     painting::Painter,
     Completer, Suggestion,
 };
@@ -663,7 +665,11 @@ impl Menu for IdeMenu {
         self.values = values;
         self.working_details.shortest_base_string = base_ranges
             .iter()
-            .map(|range| editor.get_buffer()[range.clone()].to_string())
+            .map(|range| {
+                let end = floor_char_boundary(editor.get_buffer(), range.end);
+                let start = floor_char_boundary(editor.get_buffer(), range.start).min(end);
+                editor.get_buffer()[start..end].to_string()
+            })
             .min_by_key(|s| s.len())
             .unwrap_or_default();
 

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -295,6 +295,22 @@ pub fn completer_input(
     }
 }
 
+/// Find the closest index less than or equal to the current index that's a
+/// character boundary
+///
+/// This is already a method on `str`, but it's nightly-only. Once that becomes
+/// stable, this function will be removed.
+pub fn floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        s.len()
+    } else {
+        (1..=index)
+            .rev()
+            .find(|i| s.is_char_boundary(*i))
+            .unwrap_or(0)
+    }
+}
+
 /// Helper to accept a completion suggestion and edit the buffer
 pub fn replace_in_buffer(value: Option<Suggestion>, editor: &mut Editor) {
     if let Some(Suggestion {
@@ -304,8 +320,8 @@ pub fn replace_in_buffer(value: Option<Suggestion>, editor: &mut Editor) {
         ..
     }) = value
     {
-        let start = span.start.min(editor.line_buffer().len());
-        let end = span.end.min(editor.line_buffer().len());
+        let start = floor_char_boundary(editor.get_buffer(), span.start);
+        let end = floor_char_boundary(editor.get_buffer(), span.end);
         if append_whitespace {
             value.push(' ');
         }
@@ -325,21 +341,23 @@ pub fn can_partially_complete(values: &[Suggestion], editor: &mut Editor) -> boo
     if let (Some(Suggestion { value, span, .. }), Some(index)) = find_common_string(values) {
         let index = index.min(value.len());
         let matching = &value[0..index];
+        let start = floor_char_boundary(editor.get_buffer(), span.start);
+        let end = floor_char_boundary(editor.get_buffer(), span.end);
 
         // make sure that the partial completion does not overwrite user entered input
-        let extends_input = matching.starts_with(&editor.get_buffer()[span.start..span.end])
-            && matching != &editor.get_buffer()[span.start..span.end];
+        let extends_input = matching.starts_with(&editor.get_buffer()[start..end])
+            && matching != &editor.get_buffer()[start..end];
 
         if !matching.is_empty() && extends_input {
             let mut line_buffer = editor.line_buffer().clone();
-            line_buffer.replace_range(span.start..span.end, matching);
+            line_buffer.replace_range(start..end, matching);
 
-            let offset = if matching.len() < (span.end - span.start) {
+            let offset = if matching.len() < (end - start) {
                 line_buffer
                     .insertion_point()
-                    .saturating_sub((span.end - span.start) - matching.len())
+                    .saturating_sub((end - start) - matching.len())
             } else {
-                line_buffer.insertion_point() + matching.len() - (span.end - span.start)
+                line_buffer.insertion_point() + matching.len() - (end - start)
             };
 
             line_buffer.set_insertion_point(offset);


### PR DESCRIPTION
This PR protects against some panics by suggestion spans whose start or end isn't on a character boundary. It does this by using the highest index greater than or equal to the span start/end that's on a character boundary. There's already a [`floor_char_boundary`](https://doc.rust-lang.org/std/primitive.str.html#method.floor_char_boundary) method on `str` for doing this, but it's nightly-only right now, so I had to add a new public helper to `menu_functions`. This helper will be removed when `str.floor_char_boundary` becomes stable, though.

Indices that go beyond the end of the buffer are replaced with the length of the buffer.