### PR TITLE
Only repaint at the end when processing a batch of events

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -789,6 +789,7 @@ impl Reedline {
             }
 
             // Handle reedline events.
+            let mut need_repaint = false;
             for event in reedline_events {
                 match self.handle_event(prompt, event)? {
                     EventStatus::Exits(signal) => {
@@ -802,12 +803,15 @@ impl Reedline {
                         return Ok(signal);
                     }
                     EventStatus::Handled => {
-                        self.repaint(prompt)?;
+                        need_repaint = true;
                     }
                     EventStatus::Inapplicable => {
                         // Nothing changed, no need to repaint
                     }
                 }
+            }
+            if need_repaint {
+                self.repaint(prompt)?;
             }
         }
     }


### PR DESCRIPTION
Reedline will batch KeyEvents when they arrive in quick successions. It then further accumulates edit events into a single edit event. This allows it to only perform a single repaint for the whole batch, instead of always needing one repaint per event. However, as of now, events which aren't edit event, such as arrow key presses, still trigger one repaint per event. This commit will change that, and always repaint once at the end of the batch (if a repaint is needed).

- fixes #914 