### PR TITLE
Fix #912

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -521,6 +521,10 @@ impl Menu for ColumnarMenu {
 
     /// Updates menu values
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
+        if self.settings.only_buffer_difference && self.input.is_none() {
+            self.input = Some(editor.get_buffer().to_string());
+        }
+
         let (input, pos) = completer_input(
             editor.get_buffer(),
             editor.insertion_point(),
@@ -551,20 +555,13 @@ impl Menu for ColumnarMenu {
         if let Some(event) = self.event.take() {
             match event {
                 MenuEvent::Activate(updated) => {
-                    self.active = true;
                     self.reset_position();
-
-                    self.input = if self.settings.only_buffer_difference {
-                        Some(editor.get_buffer().to_string())
-                    } else {
-                        None
-                    };
 
                     if !updated {
                         self.update_values(editor, completer);
                     }
                 }
-                MenuEvent::Deactivate => self.active = false,
+                MenuEvent::Deactivate => {}
                 MenuEvent::Edit(updated) => {
                     self.reset_position();
 

--- a/src/menu/description_menu.rs
+++ b/src/menu/description_menu.rs
@@ -442,6 +442,10 @@ impl Menu for DescriptionMenu {
 
     /// Updates menu values
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
+        if self.settings.only_buffer_difference && self.input.is_none() {
+            self.input = Some(editor.get_buffer().to_string());
+        }
+
         let (input, pos) = completer_input(
             editor.get_buffer(),
             editor.insertion_point(),
@@ -465,7 +469,6 @@ impl Menu for DescriptionMenu {
             match event {
                 MenuEvent::Activate(_) => {
                     self.reset_position();
-                    self.input = Some(editor.get_buffer().to_string());
                     self.update_values(editor, completer);
                 }
                 MenuEvent::Deactivate => self.active = false,

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -652,6 +652,10 @@ impl Menu for IdeMenu {
 
     /// Update menu values
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
+        if self.settings.only_buffer_difference && self.input.is_none() {
+            self.input = Some(editor.get_buffer().to_string());
+        }
+
         let (input, pos) = completer_input(
             editor.get_buffer(),
             editor.insertion_point(),
@@ -681,20 +685,13 @@ impl Menu for IdeMenu {
         if let Some(event) = self.event.take() {
             match event {
                 MenuEvent::Activate(updated) => {
-                    self.active = true;
                     self.reset_position();
-
-                    self.input = if self.settings.only_buffer_difference {
-                        Some(editor.get_buffer().to_string())
-                    } else {
-                        None
-                    };
 
                     if !updated {
                         self.update_values(editor, completer);
                     }
                 }
-                MenuEvent::Deactivate => self.active = false,
+                MenuEvent::Deactivate => {}
                 MenuEvent::Edit(updated) => {
                     self.reset_position();
 

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -346,6 +346,10 @@ impl Menu for ListMenu {
 
     /// Collecting the value from the completer to be shown in the menu
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
+        if self.settings.only_buffer_difference && self.input.is_none() {
+            self.input = Some(editor.get_buffer().to_string());
+        }
+
         let (input, pos) = completer_input(
             editor.get_buffer(),
             editor.insertion_point(),
@@ -422,12 +426,6 @@ impl Menu for ListMenu {
                 MenuEvent::Activate(_) => {
                     self.reset_position();
 
-                    self.input = if self.settings.only_buffer_difference {
-                        Some(editor.get_buffer().to_string())
-                    } else {
-                        None
-                    };
-
                     self.update_values(editor, completer);
 
                     self.pages.push(Page {
@@ -435,10 +433,7 @@ impl Menu for ListMenu {
                         full: false,
                     });
                 }
-                MenuEvent::Deactivate => {
-                    self.active = false;
-                    self.input = None;
-                }
+                MenuEvent::Deactivate => {}
                 MenuEvent::Edit(_) => {
                     self.update_values(editor, completer);
                     self.pages.push(Page {


### PR DESCRIPTION
Fixes #912 by making sure that the `input` field in each menu is set before partial completion is triggered. This is done by setting `self.input` in the `update_values` method (after checking that it hasn't been set already), rather than in `update_working_details` (which is only run when it's time to paint the menu).