### PR TITLE
Fix panic when using fuzzy completion in a folder containing files starting with a multibyte unicode char

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -826,4 +826,16 @@ mod tests {
         menu.update_values(&mut editor, &mut completer);
         assert!(menu.menu_string(2, true).contains("おは"));
     }
+
+    #[test]
+    fn test_menu_create_string_starting_with_multibyte_char() {
+        // https://github.com/nushell/nushell/issues/15938
+        let mut completer = FakeCompleter::new(&["验abcdef/", "abcdef/"]);
+        let mut menu = ColumnarMenu::default().with_name("testmenu");
+        let mut editor = Editor::default();
+
+        editor.set_buffer("ac".to_string(), UndoBehavior::CreateUndoPoint);
+        menu.update_values(&mut editor, &mut completer);
+        assert!(menu.menu_string(10, true).contains("验"));
+    }
 }

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -305,7 +305,7 @@ impl ColumnarMenu {
             let shortest_base = shortest_base
                 .strip_prefix(is_quote)
                 .unwrap_or(shortest_base);
-            let match_len = shortest_base.len();
+            let match_len = shortest_base.chars().count();
 
             // Find match position - look for the base string in the suggestion (case-insensitive)
             let match_position = suggestion
@@ -315,8 +315,15 @@ impl ColumnarMenu {
                 .unwrap_or(0);
 
             // The match is just the part that matches the shortest_base
-            let match_str = &suggestion.value[match_position
-                ..match_position + match_len.min(suggestion.value.len() - match_position)];
+            let match_str = {
+                let match_str = &suggestion.value[match_position..];
+                let match_len_bytes = match_str
+                    .char_indices()
+                    .nth(match_len)
+                    .map(|(i, _)| i)
+                    .unwrap_or_else(|| match_str.len());
+                &suggestion.value[match_position..match_position + match_len_bytes]
+            };
 
             // Prefix is everything before the match
             let prefix = &suggestion.value[..match_position];

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -838,4 +838,16 @@ mod tests {
         menu.update_values(&mut editor, &mut completer);
         assert!(menu.menu_string(10, true).contains("验"));
     }
+
+    #[test]
+    fn test_menu_create_string_long_unicode_string() {
+        // https://github.com/nushell/reedline/pull/918
+        let mut completer = FakeCompleter::new(&["验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验abcdef/", "abcdef/"]);
+        let mut menu = ColumnarMenu::default().with_name("testmenu");
+        let mut editor = Editor::default();
+
+        editor.set_buffer("a".to_string(), UndoBehavior::CreateUndoPoint);
+        menu.update_values(&mut editor, &mut completer);
+        assert!(menu.menu_string(10, true).contains("验"));
+    }
 }

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -830,7 +830,7 @@ mod tests {
     #[test]
     fn test_menu_create_string_starting_with_multibyte_char() {
         // https://github.com/nushell/nushell/issues/15938
-        let mut completer = FakeCompleter::new(&["验abcdef/", "abcdef/"]);
+        let mut completer = FakeCompleter::new(&["验abc/"]);
         let mut menu = ColumnarMenu::default().with_name("testmenu");
         let mut editor = Editor::default();
 
@@ -841,8 +841,8 @@ mod tests {
 
     #[test]
     fn test_menu_create_string_long_unicode_string() {
-        // https://github.com/nushell/reedline/pull/918
-        let mut completer = FakeCompleter::new(&["验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验abcdef/", "abcdef/"]);
+        // Test for possible panic if a long filename gets truncated
+        let mut completer = FakeCompleter::new(&[&("验".repeat(205) + "abc/")]);
         let mut menu = ColumnarMenu::default().with_name("testmenu");
         let mut editor = Editor::default();
 

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -521,19 +521,10 @@ impl IdeMenu {
             let match_len = shortest_base.chars().count().min(string.chars().count());
 
             // Find match position - look for the base string in the suggestion (case-insensitive)
-            let match_position = suggestion
-                .value
+            let match_position = string
                 .to_lowercase()
                 .find(&shortest_base.to_lowercase())
                 .unwrap_or(0);
-
-            // If match_position is beyond the end of string the match is no longer visible
-            // (as string has been truncated due to max_string_width)
-            let match_position = if match_position > string.len() {
-                0
-            } else {
-                match_position
-            };
 
             // The match is just the part that matches the shortest_base
             let match_str = {

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -1487,4 +1487,27 @@ mod tests {
         menu.update_values(&mut editor, &mut completer);
         assert!(menu.menu_string(2, true).contains("おは"));
     }
+
+    #[test]
+    fn test_menu_create_value_string_starting_with_multibyte_char() {
+        // https://github.com/nushell/nushell/issues/15938
+        let mut completer = FakeCompleter::new(&["验abcdef/", "abcdef/"]);
+        let mut menu = IdeMenu::default().with_name("testmenu");
+        menu.working_details = IdeMenuDetails {
+            cursor_col: 50,
+            menu_width: 50,
+            completion_width: 50,
+            description_width: 50,
+            description_is_right: true,
+            space_left: 50,
+            space_right: 50,
+            description_offset: 50,
+            shortest_base_string: String::new(),
+        };
+        let mut editor = Editor::default();
+
+        editor.set_buffer("ac".to_string(), UndoBehavior::CreateUndoPoint);
+        menu.update_values(&mut editor, &mut completer);
+        assert!(menu.menu_string(10, true).contains("验"));
+    }
 }

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -527,6 +527,14 @@ impl IdeMenu {
                 .find(&shortest_base.to_lowercase())
                 .unwrap_or(0);
 
+            // If match_position is beyond the end of string the match is no longer visible
+            // (as string has been truncated due to max_string_width)
+            let match_position = if match_position > string.len() {
+                0
+            } else {
+                match_position
+            };
+
             // The match is just the part that matches the shortest_base
             let match_str = {
                 let match_str = &string[match_position..];

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -518,7 +518,7 @@ impl IdeMenu {
             let shortest_base = shortest_base
                 .strip_prefix(is_quote)
                 .unwrap_or(shortest_base);
-            let match_len = shortest_base.len().min(string.len());
+            let match_len = shortest_base.chars().count().min(string.chars().count());
 
             // Find match position - look for the base string in the suggestion (case-insensitive)
             let match_position = suggestion
@@ -528,8 +528,15 @@ impl IdeMenu {
                 .unwrap_or(0);
 
             // The match is just the part that matches the shortest_base
-            let match_str = &string
-                [match_position..match_position + match_len.min(string.len() - match_position)];
+            let match_str = {
+                let match_str = &string[match_position..];
+                let match_len_bytes = match_str
+                    .char_indices()
+                    .nth(match_len)
+                    .map(|(i, _)| i)
+                    .unwrap_or_else(|| match_str.len());
+                &string[match_position..match_position + match_len_bytes]
+            };
 
             // Prefix is everything before the match
             let prefix = &string[..match_position];

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -1497,19 +1497,9 @@ mod tests {
     #[test]
     fn test_menu_create_value_string_starting_with_multibyte_char() {
         // https://github.com/nushell/nushell/issues/15938
-        let mut completer = FakeCompleter::new(&["验abcdef/", "abcdef/"]);
+        let mut completer = FakeCompleter::new(&["验abc/"]);
         let mut menu = IdeMenu::default().with_name("testmenu");
-        menu.working_details = IdeMenuDetails {
-            cursor_col: 50,
-            menu_width: 50,
-            completion_width: 50,
-            description_width: 50,
-            description_is_right: true,
-            space_left: 50,
-            space_right: 50,
-            description_offset: 50,
-            shortest_base_string: String::new(),
-        };
+        menu.working_details.completion_width = 50;
         let mut editor = Editor::default();
 
         editor.set_buffer("ac".to_string(), UndoBehavior::CreateUndoPoint);
@@ -1519,20 +1509,10 @@ mod tests {
 
     #[test]
     fn test_menu_create_value_string_long_unicode_string() {
-        // https://github.com/nushell/reedline/pull/918
-        let mut completer = FakeCompleter::new(&["验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验abcdef/", "abcdef/"]);
+        // Test for possible panic if a long filename gets truncated
+        let mut completer = FakeCompleter::new(&[&("验".repeat(205) + "abc/")]);
         let mut menu = IdeMenu::default().with_name("testmenu");
-        menu.working_details = IdeMenuDetails {
-            cursor_col: 50,
-            menu_width: 50,
-            completion_width: 50,
-            description_width: 50,
-            description_is_right: true,
-            space_left: 50,
-            space_right: 50,
-            description_offset: 50,
-            shortest_base_string: String::new(),
-        };
+        menu.working_details.completion_width = 50;
         let mut editor = Editor::default();
 
         editor.set_buffer("a".to_string(), UndoBehavior::CreateUndoPoint);

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -1525,4 +1525,27 @@ mod tests {
         menu.update_values(&mut editor, &mut completer);
         assert!(menu.menu_string(10, true).contains("验"));
     }
+
+    #[test]
+    fn test_menu_create_value_string_long_unicode_string() {
+        // https://github.com/nushell/reedline/pull/918
+        let mut completer = FakeCompleter::new(&["验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验验abcdef/", "abcdef/"]);
+        let mut menu = IdeMenu::default().with_name("testmenu");
+        menu.working_details = IdeMenuDetails {
+            cursor_col: 50,
+            menu_width: 50,
+            completion_width: 50,
+            description_width: 50,
+            description_is_right: true,
+            space_left: 50,
+            space_right: 50,
+            description_offset: 50,
+            shortest_base_string: String::new(),
+        };
+        let mut editor = Editor::default();
+
+        editor.set_buffer("a".to_string(), UndoBehavior::CreateUndoPoint);
+        menu.update_values(&mut editor, &mut completer);
+        assert!(menu.menu_string(10, true).contains("验"));
+    }
 }


### PR DESCRIPTION
This fixes https://github.com/nushell/reedline/issues/919 see the issue for a full description

I see a lot of discussion about newer code coming related to fuzzy matching, so this is just to temporarily fix the immediate issue of the panic. I think the most useful thing here is the addition of the test case to catch it.

I wasn't sure if I should handle the match_position = 0 case specially, or modify match_len to mean characters, not bytes. I went with the latter as I thought it looked cleaner, but there's definitely an argument for keeping the old code path for the majority of cases.

This is my first PR, very open to any feedback. Did my best but there's a lot of guidelines to absorb and I don't know most of the code base.