### PR TITLE
Fix issue with some terminal that might not properly support kitty

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -237,7 +237,7 @@ impl Reedline {
             buffer_editor: None,
             cursor_shapes: None,
             bracketed_paste: BracketedPasteGuard::default(),
-            kitty_protocol: KittyProtocolGuard::default(),
+            kitty_protocol: KittyProtocolGuard::new(),
             #[cfg(feature = "external_printer")]
             external_printer: None,
         }

--- a/src/terminal_extensions/kitty.rs
+++ b/src/terminal_extensions/kitty.rs
@@ -12,15 +12,23 @@ use crossterm::{event, execute};
 /// * [dte text editor](https://gitlab.com/craigbarnes/dte/-/issues/138)
 ///
 /// Refer to <https://sw.kovidgoyal.net/kitty/keyboard-protocol/> if you're curious.
-#[derive(Default)]
 pub(crate) struct KittyProtocolGuard {
     enabled: bool,
     active: bool,
+    support_kitty_protocol: bool,
 }
 
 impl KittyProtocolGuard {
+    pub fn new() -> Self {
+        Self {
+            support_kitty_protocol: super::kitty_protocol_available(),
+            enabled: false,
+            active: false,
+        }
+    }
+
     pub fn set(&mut self, enable: bool) {
-        self.enabled = enable && super::kitty_protocol_available();
+        self.enabled = enable && self.support_kitty_protocol;
     }
     pub fn enter(&mut self) {
         if self.enabled && !self.active {


### PR DESCRIPTION
# Reason

On terminal like Alacritty, Rioterm and Ghostty that "kind of support" kitty protocol (but maybe not perfectly ?), the side-effect of `supports_keyboard_enhancement` seems to cause some issues when some characters are printing on linux (cf. https://github.com/nushell/nushell/issues/13570#issuecomment-2956045122)

Using `kitty_protocol_available` only once when the struct is initialized would solve the issue and I think is a bit better to do.

# Alternative

use a a static `std::sync::Once` instead ?