### PR TITLE
Make default completer work on blank lines

### DIFF
--- a/src/completion/default.rs
+++ b/src/completion/default.rs
@@ -67,6 +67,7 @@ impl Completer for DefaultCompleter {
     ///         Suggestion {value: "batman".into(), span: Span { start: 8, end: 11 }, ..Default::default()},
     ///         Suggestion {value: "batmobile".into(), span: Span { start: 8, end: 11 }, ..Default::default()},
     ///     ]);
+    ///
     /// assert_eq!(
     ///     completions.complete("", 0),
     ///     vec![


### PR DESCRIPTION
The default completer currently doesn't show any suggestions if you hit tab without entering anything. This PR makes it show all suggestions when given either an empty line or a line that's all spaces. Not super important, but should help confuse new users less (https://github.com/nushell/reedline/issues/921 was opened by a user who thought completions weren't working because of this behavior).

Screenshot:

![image](https://github.com/user-attachments/assets/02682a34-5a2b-4a0f-a16c-f6e570f0a621)

I also touched the surrounding code a teeny bit, but nothing major.