### PR TITLE
feat: add `ViChangeMode` event

### DIFF
--- a/src/edit_mode/base.rs
+++ b/src/edit_mode/base.rs
@@ -1,5 +1,5 @@
 use crate::{
-    enums::{ReedlineEvent, ReedlineRawEvent},
+    enums::{EventStatus, ReedlineEvent, ReedlineRawEvent},
     PromptEditMode,
 };
 
@@ -13,4 +13,9 @@ pub trait EditMode: Send {
 
     /// What to display in the prompt indicator
     fn edit_mode(&self) -> PromptEditMode;
+
+    /// Handles events that apply only to specific edit modes (e.g changing vi mode)
+    fn handle_mode_specific_event(&mut self, _event: ReedlineEvent) -> EventStatus {
+        EventStatus::Inapplicable
+    }
 }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -3,6 +3,8 @@ mod motion;
 mod parser;
 mod vi_keybindings;
 
+use std::str::FromStr;
+
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 pub use vi_keybindings::{default_vi_insert_keybindings, default_vi_normal_keybindings};
 
@@ -22,13 +24,15 @@ enum ViMode {
     Visual,
 }
 
-impl ViMode {
-    pub fn from_str<S: AsRef<str>>(s: S) -> Option<ViMode> {
+impl FromStr for ViMode {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.as_ref() {
-            "normal" => Some(ViMode::Normal),
-            "insert" => Some(ViMode::Insert),
-            "visual" => Some(ViMode::Visual),
-            _ => None,
+            "normal" => Ok(ViMode::Normal),
+            "insert" => Ok(ViMode::Insert),
+            "visual" => Ok(ViMode::Visual),
+            _ => Err(()),
         }
     }
 }
@@ -188,12 +192,12 @@ impl EditMode for Vi {
 
     fn handle_mode_specific_event(&mut self, event: ReedlineEvent) -> EventStatus {
         match event {
-            ReedlineEvent::ViChangeMode(mode_str) => match ViMode::from_str(mode_str) {
-                Some(mode) => {
+            ReedlineEvent::ViChangeMode(mode_str) => match ViMode::from_str(&mode_str) {
+                Ok(mode) => {
                     self.mode = mode;
                     EventStatus::Handled
                 }
-                None => EventStatus::Inapplicable,
+                Err(_) => EventStatus::Inapplicable,
             },
             _ => EventStatus::Inapplicable,
         }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -28,7 +28,7 @@ impl FromStr for ViMode {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.as_ref() {
+        match s {
             "normal" => Ok(ViMode::Normal),
             "insert" => Ok(ViMode::Insert),
             "visual" => Ok(ViMode::Visual),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -928,7 +928,8 @@ impl Reedline {
             | ReedlineEvent::MenuLeft
             | ReedlineEvent::MenuRight
             | ReedlineEvent::MenuPageNext
-            | ReedlineEvent::MenuPagePrevious => Ok(EventStatus::Inapplicable),
+            | ReedlineEvent::MenuPagePrevious
+            | ReedlineEvent::ViChangeMode(_) => Ok(EventStatus::Inapplicable),
         }
     }
 
@@ -1273,6 +1274,7 @@ impl Reedline {
                 // Exhausting the event handlers is still considered handled
                 Ok(EventStatus::Inapplicable)
             }
+            ReedlineEvent::ViChangeMode(_) => Ok(self.edit_mode.handle_mode_specific_event(event)),
             ReedlineEvent::None | ReedlineEvent::Mouse => Ok(EventStatus::Inapplicable),
         }
     }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -809,7 +809,7 @@ impl Display for ReedlineEvent {
     }
 }
 
-pub(crate) enum EventStatus {
+pub enum EventStatus {
     Handled,
     Inapplicable,
     Exits(Signal),

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -758,6 +758,9 @@ pub enum ReedlineEvent {
 
     /// Open text editor
     OpenEditor,
+
+    /// Change mode (vi mode only)
+    ViChangeMode(String),
 }
 
 impl Display for ReedlineEvent {
@@ -801,11 +804,12 @@ impl Display for ReedlineEvent {
             ReedlineEvent::MenuPagePrevious => write!(f, "MenuPagePrevious"),
             ReedlineEvent::ExecuteHostCommand(_) => write!(f, "ExecuteHostCommand"),
             ReedlineEvent::OpenEditor => write!(f, "OpenEditor"),
+            ReedlineEvent::ViChangeMode(_) => write!(f, "ViChangeMode mode: <string>"),
         }
     }
 }
 
-pub(crate) enum EventStatus {
+pub enum EventStatus {
     Handled,
     Inapplicable,
     Exits(Signal),

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -809,7 +809,7 @@ impl Display for ReedlineEvent {
     }
 }
 
-pub enum EventStatus {
+pub(crate) enum EventStatus {
     Handled,
     Inapplicable,
     Exits(Signal),


### PR DESCRIPTION
Closes #499.

This PR adds the `ViChangeMode` event. Making it possible to change the mode using the normal event system. To achieve this, a new optional function `handle_mode_specific_event` was added to the `EditMode` trait. Vi mode implements this function and handles the event to change the mode accordingly. 

This will make it very easy to add the possibility of configuring mode-change keybindings in nushell.
Here's an example of how it could look:
```
{
  name: exit_insert_mode_with_ctrl_c
  modifier: control
  keycode: char_c
  mode: vi_insert
  event: {
    send: vichangemode
    mode: normal
  }
}
```

I plan on submitting a PR to nushell if this gets merged to add the functionality there too.

The main difference with #670 is that PR makes it user-configurable instead of it being a hard-coded value.
As for #853, this might prove good enough for the time being, as I'm sure many nushell users (like myself!) would really appreciate a way of remapping the vi mode change keybindings.