### PR TITLE
feat: Builder option to immediately accept input

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -755,8 +755,8 @@ impl Reedline {
                 #[cfg(not(feature = "external_printer"))]
                 events.push(crossterm::event::read()?);
 
-                // a line of input is completed.
                 // Receive all events in the queue without blocking. Will stop when
+                // a line of input is completed.
                 while !completed(&events) && event::poll(Duration::from_millis(0))? {
                     events.push(crossterm::event::read()?);
                 }


### PR DESCRIPTION
# Summary

Adds a builder function to immediately accept the input and return from `read_line`. It introduces non-breaking changes to the API in response to [this comment](https://github.com/nushell/nushell/pull/15092#issuecomment-2968244904):

```rust
line_editor = line_editor.with_immediately_accept(true);
let input = line_editor.read_line(...)
```