### PR TITLE
Vi mode text objects for word, WORD, brackets and quotes

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -771,7 +771,7 @@ impl Editor {
     }
 
     /// Get the bounds for a text object operation
-    fn get_text_object_bounds(&self, text_object: char, around: bool) -> Option<std::ops::Range<usize>> {
+    fn text_object_range(&self, text_object: char, around: bool) -> Option<std::ops::Range<usize>> {
 
         match text_object {
             'w' => {
@@ -790,7 +790,7 @@ impl Editor {
                 if self.line_buffer.is_in_whitespace_block() {
                     Some(self.line_buffer.current_whitespace_range())
                 } else {
-                    let big_word_range = self.get_current_big_word_range();
+                    let big_word_range = self.current_big_word_range();
                     if around {
                         self.expand_range_with_whitespace(big_word_range)
                     } else {
@@ -803,7 +803,7 @@ impl Editor {
     }
 
     /// Get the range of the current big word (WORD) at cursor position
-    fn get_current_big_word_range(&self) -> std::ops::Range<usize> {
+    fn current_big_word_range(&self) -> std::ops::Range<usize> {
         // Get the end of the current big word
         let right_index = self.line_buffer.big_word_right_end_index();
 
@@ -865,7 +865,7 @@ impl Editor {
     }
 
     fn cut_inside_text_object(&mut self, text_object: char) {
-        if let Some(range) = self.get_text_object_bounds(text_object, false) {
+        if let Some(range) = self.text_object_range(text_object, false) {
             let cut_slice = &self.line_buffer.get_buffer()[range.clone()];
             if !cut_slice.is_empty() {
                 self.cut_buffer.set(cut_slice, ClipboardMode::Normal);
@@ -877,7 +877,7 @@ impl Editor {
 
     fn yank_inside_text_object(&mut self, text_object: char) {
         let old_pos = self.insertion_point();
-        if let Some(range) = self.get_text_object_bounds(text_object, false) {
+        if let Some(range) = self.text_object_range(text_object, false) {
             let yank_slice = &self.line_buffer.get_buffer()[range];
             if !yank_slice.is_empty() {
                 self.cut_buffer.set(yank_slice, ClipboardMode::Normal);
@@ -893,7 +893,7 @@ impl Editor {
     }
 
     fn cut_around_text_object(&mut self, text_object: char) {
-        if let Some(range) = self.get_text_object_bounds(text_object, true) {
+        if let Some(range) = self.text_object_range(text_object, true) {
             let cut_slice = &self.line_buffer.get_buffer()[range.clone()];
             if !cut_slice.is_empty() {
                 self.cut_buffer.set(cut_slice, ClipboardMode::Normal);
@@ -905,7 +905,7 @@ impl Editor {
 
     fn yank_around_text_object(&mut self, text_object: char) {
         let old_pos = self.insertion_point();
-        if let Some(range) = self.get_text_object_bounds(text_object, true) {
+        if let Some(range) = self.text_object_range(text_object, true) {
             let yank_slice = &self.line_buffer.get_buffer()[range];
             if !yank_slice.is_empty() {
                 self.cut_buffer.set(yank_slice, ClipboardMode::Normal);

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -745,7 +745,7 @@ impl Editor {
             })
     }
 
-    /// Returns `Some(Range<usize>)` for range inside brackets (`()`, `[]`, `{}`, `<>`)
+    /// Returns `Some(Range<usize>)` for range inside brackets (`()`, `[]`, `{}`)
     /// at or surrounding the cursor, the next pair of brackets if no brackets
     /// surround the cursor, or `None` if there are no brackets found.
     ///
@@ -756,7 +756,7 @@ impl Editor {
         &self,
         text_object_scope: TextObjectScope,
     ) -> Option<Range<usize>> {
-        const BRACKET_PAIRS: &[(char, char); 4] = &[('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')];
+        const BRACKET_PAIRS: &[(char, char); 3] = &[('(', ')'), ('[', ']'), ('{', '}')];
         self.line_buffer
             .range_inside_current_pair_in_group(*BRACKET_PAIRS)
             .or_else(|| {
@@ -1700,7 +1700,6 @@ mod test {
     #[case("foo(bar)baz", 5, TextObjectScope::Inner, Some(4..7))] // cursor inside brackets
     #[case("foo[bar]baz", 5, TextObjectScope::Inner, Some(4..7))] // square brackets
     #[case("foo{bar}baz", 5, TextObjectScope::Inner, Some(4..7))] // square brackets
-    #[case("foo<bar>baz", 5, TextObjectScope::Inner, Some(4..7))] // square brackets
     #[case("foo()bar", 4, TextObjectScope::Inner, Some(4..4))] // empty brackets
     #[case("(nested[inner]outer)", 8, TextObjectScope::Inner, Some(8..13))] // nested, innermost
     #[case("(nested[mixed{inner}brackets]outer)", 8, TextObjectScope::Inner, Some(8..28))] // nested, innermost

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -929,16 +929,10 @@ impl Editor {
         }
     }
 
-    /// Safely expand the range to include `open_char` and `close_char`
-    /// This isn't safe against the pair being a grapheme.
+    /// Expand the range to include `open_char` and `close_char`
     fn expand_range_to_include_pair(&self, range: Range<usize>) -> Option<Range<usize>> {
         let start = self.line_buffer.grapheme_left_index_from_pos(range.start);
         let end = self.line_buffer.grapheme_right_index_from_pos(range.end);
-
-        // Ensure we don't exceed buffer bounds
-        if end > self.line_buffer.len() {
-            return None;
-        }
 
         Some(start..end)
     }

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -322,7 +322,7 @@ impl LineBuffer {
     ///
     /// This includes being on a whitespace character or at the end of trailing whitespace.
     /// Used for vim-style text object operations where whitespace itself is a text object.
-    pub fn is_in_whitespace_block(&self) -> bool {
+    pub(crate) fn in_whitespace_block(&self) -> bool {
         self.on_whitespace() || self.at_end_of_line_with_preceding_whitespace()
     }
 
@@ -360,7 +360,7 @@ impl LineBuffer {
     /// that trailing block. Returns an empty range (0..0) if not in a whitespace context.
     ///
     /// Used for vim-style text object operations (iw/aw when cursor is on whitespace).
-    pub fn current_whitespace_range(&self) -> Range<usize> {
+    pub(crate) fn current_whitespace_range(&self) -> Range<usize> {
         if self.on_whitespace() {
             let range_end = self.current_whitespace_range_end();
             let range_start = self.current_whitespace_range_start();

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -476,11 +476,11 @@ impl LineBuffer {
     ///
     /// If the cursor is located between `start` and `end` it is adjusted to `start`.
     /// If the cursor is located after `end` it is adjusted to stay at its current char boundary.
-    pub fn clear_range_safe(&mut self, start: usize, end: usize) {
-        let (start, end) = if start > end {
-            (end, start)
+    pub fn clear_range_safe(&mut self, range: Range<usize>) {
+        let (start, end) = if range.start > range.end {
+            (range.end, range.start)
         } else {
-            (start, end)
+            (range.start, range.end)
         };
         if self.insertion_point <= start {
             // No action necessary

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -331,7 +331,7 @@ impl LineBuffer {
     /// Searches forward from cursor position to find where the current whitespace
     /// block ends (first non-whitespace character). Returns buffer length if
     /// whitespace extends to end of buffer.
-    fn current_whitespace_end_index(&self) -> usize {
+    fn current_whitespace_range_end(&self) -> usize {
         self.lines[self.insertion_point..]
             .char_indices()
             .find(|(_, ch)| !ch.is_whitespace())
@@ -344,13 +344,13 @@ impl LineBuffer {
     /// Searches backward from cursor position to find where the current whitespace
     /// block starts (position after last non-whitespace character). Returns 0 if
     /// whitespace extends to start of buffer.
-    fn current_whitespace_start_index(&self) -> usize {
+    fn current_whitespace_range_start(&self) -> usize {
         self.lines[..self.insertion_point]
             .char_indices()
             .rev()
             .find(|(_, ch)| !ch.is_whitespace())
             .map(|(i, _)| i + 1)
-            .unwrap_or(self.lines.len())
+            .unwrap_or(0)
     }
 
     /// Gets the range of the current whitespace block at cursor position.
@@ -362,12 +362,12 @@ impl LineBuffer {
     /// Used for vim-style text object operations (iw/aw when cursor is on whitespace).
     pub fn current_whitespace_range(&self) -> Range<usize> {
         if self.on_whitespace() {
-            let right_index = self.current_whitespace_end_index();
-            let left_index = self.current_whitespace_start_index();
-            left_index..right_index
+            let range_end = self.current_whitespace_range_end();
+            let range_start = self.current_whitespace_range_start();
+            range_start..range_end
         } else if self.at_end_of_line_with_preceding_whitespace() {
-            let left_index = self.current_whitespace_start_index();
-            left_index..self.insertion_point
+            let range_start = self.current_whitespace_range_start();
+            range_start..self.insertion_point
         }
         else {
             0..0

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -979,17 +979,14 @@ impl LineBuffer {
     ///
     /// If multiple pair types are found in the buffer or line, return the innermost
     /// pair that surrounds the cursor. Handles empty quotes as zero-length ranges inside quote.
-    pub(crate) fn range_inside_current_pair_in_group<I>(
+    pub(crate) fn range_inside_current_pair_in_group(
         &self,
-        pair_group: I,
-    ) -> Option<Range<usize>>
-    where
-        I: IntoIterator<Item = (char, char)>,
-    {
-        pair_group
-            .into_iter()
+        matching_pair_group: &[(char, char)],
+    ) -> Option<Range<usize>> {
+        matching_pair_group
+            .iter()
             .filter_map(|(open_char, close_char)| {
-                self.range_inside_current_pair(open_char, close_char)
+                self.range_inside_current_pair(*open_char, *close_char)
             })
             .min_by_key(|range| range.len())
     }
@@ -1003,14 +1000,14 @@ impl LineBuffer {
     /// If multiple pair types are found in the buffer or line, return the innermost
     /// pair that surrounds the cursor. Handles empty pairs as zero-length ranges
     /// inside pair (this enables caller to still get the location of the pair).
-    pub(crate) fn range_inside_next_pair_in_group<I>(&self, pair_group: I) -> Option<Range<usize>>
-    where
-        I: IntoIterator<Item = (char, char)>,
-    {
-        pair_group
-            .into_iter()
+    pub(crate) fn range_inside_next_pair_in_group(
+        &self,
+        matching_pair_group: &[(char, char)],
+    ) -> Option<Range<usize>> {
+        matching_pair_group
+            .iter()
             .filter_map(|(open_char, close_char)| {
-                self.range_inside_next_pair(open_char, close_char)
+                self.range_inside_next_pair(*open_char, *close_char)
             })
             .min_by_key(|range| range.start)
     }
@@ -1949,7 +1946,7 @@ mod test {
     ) {
         let mut buf = LineBuffer::from(input);
         buf.set_insertion_point(cursor_pos);
-        assert_eq!(buf.range_inside_current_pair_in_group(*pairs), expected);
+        assert_eq!(buf.range_inside_current_pair_in_group(pairs), expected);
     }
 
     // Tests for range_inside_next_pair_in_group - cursor before pairs, return range inside next pair if exists
@@ -1983,7 +1980,7 @@ mod test {
     ) {
         let mut buf = LineBuffer::from(input);
         buf.set_insertion_point(cursor_pos);
-        assert_eq!(buf.range_inside_next_pair_in_group(*pairs), expected);
+        assert_eq!(buf.range_inside_next_pair_in_group(pairs), expected);
     }
 
     // Tests for range_inside_current_pair - when cursor is inside a pair

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -1909,76 +1909,46 @@ mod test {
         );
     }
 
-    // Tests for bracket text object functionality
-    #[rstest]
-    // Basic bracket pairs - cursor inside
-    #[case("foo(bar)baz", 5, Some(4..7))] // cursor on 'a' in "bar"
-    #[case("foo[bar]baz", 5, Some(4..7))] // square brackets
-    #[case("foo{bar}baz", 5, Some(4..7))] // curly brackets
-    #[case("foo<bar>baz", 5, Some(4..7))] // angle brackets
-    #[case("foo(bar(baz)qux)end", 9, Some(8..11))] // cursor on 'a' in "baz", finds inner
-    #[case("foo(bar(baz)qux)end", 5, Some(4..15))] // cursor on 'a' in "bar", finds outer
-    #[case("foo([bar])baz", 6, Some(5..8))] // mixed bracket types, cursor on 'a' - should find [bar], not (...)
-    #[case("foo[(bar)]baz", 6, Some(5..8))] // reversed nesting, cursor on 'a' - should find (bar), not [...]
-    #[case("foo(bar)baz", 4, Some(4..7))] // cursor just after opening bracket
-    #[case("foo(bar)baz", 7, Some(4..7))] // cursor just before closing bracket
-    #[case("foo[]bar", 4, Some(4..4))] // empty square brackets
-    #[case("(content)", 0, Some(1..8))] // brackets at buffer start/end
-    #[case("a(b)c", 2, Some(2..3))] // minimal case - cursor inside brackets
-    #[case("foo(🦀bar)baz", 4, Some(4..11))] // emoji inside brackets - cursor after emoji
-    #[case("🦀(bar)🦀", 8, Some(5..8))] // emoji outside brackets - cursor after opening bracket
-    #[case(r#"foo("bar")baz"#, 6, Some(4..9))] // quotes inside brackets
-    #[case(r#"foo"(bar)"baz"#, 6, Some(5..8))] // brackets inside quotes
-    #[case("())", 1, Some(1..1))] // extra closing bracket
-    #[case("", 0, None)] // empty buffer
-    #[case("(", 0, None)] // single opening bracket
-    #[case(")", 0, None)] // single closing bracket
-    #[case("no brackets here", 5, None)] // no brackets in buffer
-    #[case("outside(brackets)", 3, None)] // unmatched brackets
-    #[case("(outside) (brackets)", 9, None)] // between brackets
-    #[case("unclosed (brackets", 10, None)] // unmatched brackets
-    #[case("unclosed (brackets}", 10, None)] // mismatched brackets
-    #[case("", 0, None)] // empty buffer
-    fn test_current_inside_bracket_range(
-        #[case] input: &str,
-        #[case] cursor_pos: usize,
-        #[case] expected: Option<std::ops::Range<usize>>,
-    ) {
-        const BRACKET_PAIRS: &[(char, char); 4] = &[('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')];
-        let mut buf = LineBuffer::from(input);
-
-        buf.set_insertion_point(cursor_pos);
-        assert_eq!(
-            buf.range_inside_current_pair_in_group(*BRACKET_PAIRS),
-            expected
-        );
-    }
-
+    const BRACKET_PAIRS: &[(char, char); 3] = &[('(', ')'), ('[', ']'), ('{', '}')];
     const QUOTE_PAIRS: &[(char, char); 3] = &[('"', '"'), ('\'', '\''), ('`', '`')];
-
     // Tests for range_inside_current_quote - cursor inside or on the boundary
     #[rstest]
-    #[case(r#"foo"bar"baz"#, 5, Some(4..7))] // cursor on 'a' in "bar"
-    #[case("foo'bar'baz", 5, Some(4..7))] // single quotes
-    #[case("foo`bar`baz", 5, Some(4..7))] // backticks
-    #[case(r#"'foo"baz`bar`taz"baz'"#, 9, Some(9..12))] // backticks
-    #[case(r#"'foo"baz`bar`taz"baz'"#, 6, Some(5..16))] // backticks
-    #[case(r#"'foo"baz`bar`taz"baz'"#, 0, Some(1..20))] // backticks
-    #[case(r#""foo"'bar'`baz`"#, 0, Some(1..4))] // cursor at start, should find first (double)
-    #[case("no quotes here", 5, None)] // no quotes in buffer
-    #[case(r#"unclosed "quotes"#, 10, None)] // unmatched quotes
-    #[case("", 0, None)] // empty buffer
-    fn test_range_inside_current_quote(
+    #[case("foo(bar)baz", 5, BRACKET_PAIRS, Some(4..7))] // cursor on 'a' in "bar"
+    #[case("foo[bar]baz", 5, BRACKET_PAIRS, Some(4..7))] // square brackets
+    #[case("foo{bar}baz", 5, BRACKET_PAIRS, Some(4..7))] // curly brackets
+    #[case("foo(bar(baz)qux)end", 9, BRACKET_PAIRS, Some(8..11))] // cursor on 'a' in "baz", finds inner
+    #[case("foo(bar(baz)qux)end", 5, BRACKET_PAIRS, Some(4..15))] // cursor on 'a' in "bar", finds outer
+    #[case("foo([bar])baz", 6, BRACKET_PAIRS, Some(5..8))] // mixed bracket types, cursor on 'a' - should find [bar], not (...)
+    #[case("foo[(bar)]baz", 6, BRACKET_PAIRS, Some(5..8))] // reversed nesting, cursor on 'a' - should find (bar), not [...]
+    #[case("foo(bar)baz", 4, BRACKET_PAIRS, Some(4..7))] // cursor just after opening bracket
+    #[case("foo(bar)baz", 7, BRACKET_PAIRS, Some(4..7))] // cursor just before closing bracket
+    #[case("foo[]bar", 4, BRACKET_PAIRS, Some(4..4))] // empty square brackets
+    #[case("(content)", 0, BRACKET_PAIRS, Some(1..8))] // brackets at buffer start/end
+    #[case("a(b)c", 2, BRACKET_PAIRS, Some(2..3))] // minimal case - cursor inside brackets
+    #[case(r#"foo("bar")baz"#, 6, BRACKET_PAIRS, Some(4..9))] // quotes inside brackets
+    #[case(r#"foo"(bar)"baz"#, 6, BRACKET_PAIRS, Some(5..8))] // brackets inside quotes
+    #[case("())", 1, BRACKET_PAIRS, Some(1..1))] // extra closing bracket
+    #[case("", 0, BRACKET_PAIRS, None)] // empty buffer
+    #[case("(", 0, BRACKET_PAIRS, None)] // single opening bracket
+    #[case(")", 0, BRACKET_PAIRS, None)] // single closing bracket
+    #[case("", 0, BRACKET_PAIRS, None)] // empty buffer
+    #[case(r#"foo"bar"baz"#, 5, QUOTE_PAIRS, Some(4..7))] // cursor on 'a' in "bar"
+    #[case("foo'bar'baz", 5, QUOTE_PAIRS, Some(4..7))] // single quotes
+    #[case("foo`bar`baz", 5, QUOTE_PAIRS, Some(4..7))] // backticks
+    #[case(r#"'foo"baz`bar`taz"baz'"#, 0, QUOTE_PAIRS, Some(1..20))] // backticks
+    #[case(r#""foo"'bar'`baz`"#, 0, QUOTE_PAIRS, Some(1..4))] // cursor at start, should find first (double)
+    #[case("no quotes here", 5, QUOTE_PAIRS, None)] // no quotes in buffer
+    #[case(r#"unclosed "quotes"#, 10, QUOTE_PAIRS, None)] // unmatched quotes
+    #[case("", 0, QUOTE_PAIRS, None)] // empty buffer
+    fn test_range_inside_current_pair_group(
         #[case] input: &str,
         #[case] cursor_pos: usize,
-        #[case] expected: Option<std::ops::Range<usize>>,
+        #[case] pairs: &[(char, char); 3],
+        #[case] expected: Option<Range<usize>>,
     ) {
         let mut buf = LineBuffer::from(input);
         buf.set_insertion_point(cursor_pos);
-        assert_eq!(
-            buf.range_inside_current_pair_in_group(*QUOTE_PAIRS),
-            expected
-        );
+        assert_eq!(buf.range_inside_current_pair_in_group(*pairs), expected);
     }
 
     // Tests for range_inside_next_quote - cursor before quotes, jumping forward
@@ -1997,7 +1967,7 @@ mod test {
     fn test_range_inside_next_quote(
         #[case] input: &str,
         #[case] cursor_pos: usize,
-        #[case] expected: Option<std::ops::Range<usize>>,
+        #[case] expected: Option<Range<usize>>,
     ) {
         let mut buf = LineBuffer::from(input);
         buf.set_insertion_point(cursor_pos);
@@ -2027,7 +1997,7 @@ mod test {
         #[case] cursor_pos: usize,
         #[case] open_char: char,
         #[case] close_char: char,
-        #[case] expected: Option<std::ops::Range<usize>>,
+        #[case] expected: Option<Range<usize>>,
     ) {
         let mut buf = LineBuffer::from(input);
         buf.set_insertion_point(cursor_pos);
@@ -2062,7 +2032,7 @@ mod test {
         #[case] cursor_pos: usize,
         #[case] open_char: char,
         #[case] close_char: char,
-        #[case] expected: Option<std::ops::Range<usize>>,
+        #[case] expected: Option<Range<usize>>,
     ) {
         let mut buf = LineBuffer::from(input);
         buf.set_insertion_point(cursor_pos);
@@ -2075,45 +2045,18 @@ mod test {
     }
 
     #[rstest]
-    // Test quote is restricted to single line
-    #[case("line1\n\"quote\"", 7, '"', '"', Some(7..12))] // cursor at quote start on line 2
-    #[case("\"quote\"\nline2", 2, '"', '"', Some(1..6))] // cursor inside quote on line 1
-    #[case("\"first\"\n\"second\"", 10, '"', '"', Some(9..15))] // cursor in second quote
-    #[case("line1\n\"quote\"", 6, '"', '"', Some(7..12))] // cursor at start of line 2
-    fn test_multiline_quote_behavior(
-        #[case] input: &str,
-        #[case] cursor_pos: usize,
-        #[case] open_char: char,
-        #[case] close_char: char,
-        #[case] expected: Option<std::ops::Range<usize>>,
-    ) {
-        let mut buf = LineBuffer::from(input);
-        buf.set_insertion_point(cursor_pos);
-        let result = buf.range_inside_current_pair(open_char, close_char);
-        assert_eq!(
-            result,
-            expected,
-            "MULTILINE TEST - Input: {:?}, cursor: {}, chars: '{}' '{}', lines: {:?}",
-            input,
-            cursor_pos,
-            open_char,
-            close_char,
-            input.lines().collect::<Vec<_>>()
-        );
-    }
-
-    #[rstest]
     // Test next quote is restricted to single line
-    #[case("line1\n\"quote\"", 0, '"', '"', None)] // cursor line 1, quote line 2
-    #[case("\"quote\"\nline2", 2, '"', '"', None)] // cursor inside quote on line 1
-    #[case("\"first\"\n\"second\"", 3, '"', '"', None)] // quote that spans multiple lines
+    #[case("line1\n\"quote\"", 7, '"', '"', None)] // Inside second line quote, no quotes after
+    #[case("\"quote\"\nline2", 2, '"', '"', None)] // No next quote on current line
+    #[case("line1\n\"quote\"", 6, '"', '"', Some(7..12))] // cursor at start of line 2
+    #[case("line1\n\"quote\"", 0, '"', '"', None)] // cursor line 1 doesn't find quote on line 2
     #[case("line1\n\"quote\"", 5, '"', '"', None)] // cursor at end of line 1
-    fn test_multiline_next_quote_behavior(
+    fn test_multiline_next_quote_multiline(
         #[case] input: &str,
         #[case] cursor_pos: usize,
         #[case] open_char: char,
         #[case] close_char: char,
-        #[case] expected: Option<std::ops::Range<usize>>,
+        #[case] expected: Option<Range<usize>>,
     ) {
         let mut buf = LineBuffer::from(input);
         buf.set_insertion_point(cursor_pos);
@@ -2145,7 +2088,7 @@ mod test {
         #[case] cursor_pos: usize,
         #[case] open_char: char,
         #[case] close_char: char,
-        #[case] expected: Option<std::ops::Range<usize>>,
+        #[case] expected: Option<Range<usize>>,
     ) {
         let mut buf = LineBuffer::from(input);
         buf.set_insertion_point(cursor_pos);
@@ -2173,7 +2116,7 @@ mod test {
         #[case] cursor_pos: usize,
         #[case] open_char: char,
         #[case] close_char: char,
-        #[case] expected: Option<std::ops::Range<usize>>,
+        #[case] expected: Option<Range<usize>>,
     ) {
         let mut buf = LineBuffer::from(input);
         buf.set_insertion_point(cursor_pos);

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -1954,7 +1954,7 @@ mod test {
         );
     }
 
-        const QUOTE_PAIRS: &[(char, char); 3] = &[('"', '"'), ('\'', '\''), ('`', '`')];
+    const QUOTE_PAIRS: &[(char, char); 3] = &[('"', '"'), ('\'', '\''), ('`', '`')];
 
     // Tests for range_inside_current_quote - cursor inside or on the boundary
     #[rstest]

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -152,20 +152,12 @@ impl LineBuffer {
 
     /// Cursor position *behind* the next unicode grapheme to the right
     pub fn grapheme_right_index(&self) -> usize {
-        self.lines[self.insertion_point..]
-            .grapheme_indices(true)
-            .nth(1)
-            .map(|(i, _)| self.insertion_point + i)
-            .unwrap_or_else(|| self.lines.len())
+        self.grapheme_right_index_from_pos(self.insertion_point)
     }
 
     /// Cursor position *in front of* the next unicode grapheme to the left
     pub fn grapheme_left_index(&self) -> usize {
-        self.lines[..self.insertion_point]
-            .grapheme_indices(true)
-            .next_back()
-            .map(|(i, _)| i)
-            .unwrap_or(0)
+        self.grapheme_left_index_from_pos(self.insertion_point)
     }
 
     /// Cursor position *behind* the next unicode grapheme to the right from the given position
@@ -175,6 +167,15 @@ impl LineBuffer {
             .nth(1)
             .map(|(i, _)| pos + i)
             .unwrap_or_else(|| self.lines.len())
+    }
+
+    /// Cursor position *behind* the previous unicode grapheme to the left from the given position
+    pub(crate) fn grapheme_left_index_from_pos(&self, pos: usize) -> usize {
+        self.lines[..pos]
+            .grapheme_indices(true)
+            .next_back()
+            .map(|(i, _)| i)
+            .unwrap_or(0)
     }
 
     /// Cursor position *behind* the next word to the right
@@ -918,7 +919,7 @@ impl LineBuffer {
         Self::find_index_of_matching_pair(start_to_close_char, open_char, close_char, true).map(
             |open_char_index_from_start| {
                 let open_char_index_in_buffer = search_range.start + open_char_index_from_start;
-                (open_char_index_in_buffer + 1)..close_char_index_in_buffer
+                (open_char_index_in_buffer + open_char.len_utf8())..close_char_index_in_buffer
             },
         )
     }

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -36,7 +36,13 @@ where
             } else if let Some('a') = input.peek() {
                 let _ = input.next();
                 input.next().and_then(|c| {
-                    char_to_text_object(*c, TextObjectScope::Around).map(|text_object| Command::DeleteTextObject { text_object })
+                    bracket_pair_for(*c)
+                    .map(|(left, right)|  Command::DeleteAroundPair { left, right })
+                    .or_else(|| {
+                        char_to_text_object(*c, TextObjectScope::Around)
+                        .map(|text_object| Command::DeleteTextObject { text_object })
+                    })
+
                 })
             } else {
                 Some(Command::Delete)
@@ -58,7 +64,12 @@ where
             } else if let Some('a') = input.peek() {
                 let _ = input.next();
                 input.next().and_then(|c| {
-                    char_to_text_object(*c, TextObjectScope::Around).map(|text_object| Command::YankTextObject { text_object })
+                    bracket_pair_for(*c)
+                    .map(|(left, right)|  Command::YankAroundPair { left, right })
+                    .or_else(|| {
+                        char_to_text_object(*c, TextObjectScope::Around)
+                        .map(|text_object| Command::YankTextObject { text_object })
+                    })
                 })
             } else {
                 Some(Command::Yank)
@@ -187,6 +198,8 @@ pub enum Command {
     ChangeInsidePair { left: char, right: char },
     DeleteInsidePair { left: char, right: char },
     YankInsidePair { left: char, right: char },
+    DeleteAroundPair { left: char, right: char },
+    YankAroundPair { left: char, right: char },
     ChangeTextObject { text_object: TextObject },
     YankTextObject { text_object: TextObject },
     DeleteTextObject { text_object: TextObject },
@@ -266,6 +279,18 @@ impl Command {
             }
             Self::YankInsidePair { left, right } => {
                 vec![ReedlineOption::Edit(EditCommand::CopyInsidePair {
+                    left: *left,
+                    right: *right,
+                })]
+            }
+            Self::DeleteAroundPair { left, right } => {
+                vec![ReedlineOption::Edit(EditCommand::CutAroundPair {
+                    left: *left,
+                    right: *right,
+                })]
+            }
+            Self::YankAroundPair { left, right } => {
+                vec![ReedlineOption::Edit(EditCommand::CopyAroundPair {
                     left: *left,
                     right: *right,
                 })]

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -1,17 +1,7 @@
 use super::{motion::Motion, motion::ViCharSearch, parser::ReedlineOption, ViMode};
-use crate::{EditCommand, ReedlineEvent, Vi};
 use crate::enums::{TextObject, TextObjectScope, TextObjectType};
+use crate::{EditCommand, ReedlineEvent, Vi};
 use std::iter::Peekable;
-
-fn char_to_text_object(c: char, scope: TextObjectScope) -> Option<TextObject> {
-    match c {
-        'w' => Some(TextObject { scope, object_type: TextObjectType::Word }),
-        'W' => Some(TextObject { scope, object_type: TextObjectType::BigWord }),
-        'b' => Some(TextObject { scope, object_type: TextObjectType::Brackets }),
-        'q' => Some(TextObject { scope, object_type: TextObjectType::Quote }),
-        _ => None,
-    }
-}
 
 pub fn parse_command<'iter, I>(input: &mut Peekable<I>) -> Option<Command>
 where
@@ -25,24 +15,21 @@ where
                 let _ = input.next();
                 input.next().and_then(|c| {
                     bracket_pair_for(*c)
-                    .map(|(left, right)|
-                        Command::DeleteInsidePair { left, right })
-                    .or_else(|| {
-                        char_to_text_object(*c, TextObjectScope::Inner)
-                        .map(|text_object| Command::DeleteTextObject { text_object })
-                    })
+                        .map(|(left, right)| Command::DeleteInsidePair { left, right })
+                        .or_else(|| {
+                            char_to_text_object(*c, TextObjectScope::Inner)
+                                .map(|text_object| Command::DeleteTextObject { text_object })
+                        })
                 })
-
             } else if let Some('a') = input.peek() {
                 let _ = input.next();
                 input.next().and_then(|c| {
                     bracket_pair_for(*c)
-                    .map(|(left, right)|  Command::DeleteAroundPair { left, right })
-                    .or_else(|| {
-                        char_to_text_object(*c, TextObjectScope::Around)
-                        .map(|text_object| Command::DeleteTextObject { text_object })
-                    })
-
+                        .map(|(left, right)| Command::DeleteAroundPair { left, right })
+                        .or_else(|| {
+                            char_to_text_object(*c, TextObjectScope::Around)
+                                .map(|text_object| Command::DeleteTextObject { text_object })
+                        })
                 })
             } else {
                 Some(Command::Delete)
@@ -55,21 +42,21 @@ where
                 let _ = input.next();
                 input.next().and_then(|c| {
                     bracket_pair_for(*c)
-                    .map(|(left, right)|  Command::YankInsidePair { left, right })
-                    .or_else(|| {
-                        char_to_text_object(*c, TextObjectScope::Inner)
-                        .map(|text_object|  Command::YankTextObject { text_object })
-                    })
+                        .map(|(left, right)| Command::YankInsidePair { left, right })
+                        .or_else(|| {
+                            char_to_text_object(*c, TextObjectScope::Inner)
+                                .map(|text_object| Command::YankTextObject { text_object })
+                        })
                 })
             } else if let Some('a') = input.peek() {
                 let _ = input.next();
                 input.next().and_then(|c| {
                     bracket_pair_for(*c)
-                    .map(|(left, right)|  Command::YankAroundPair { left, right })
-                    .or_else(|| {
-                        char_to_text_object(*c, TextObjectScope::Around)
-                        .map(|text_object| Command::YankTextObject { text_object })
-                    })
+                        .map(|(left, right)| Command::YankAroundPair { left, right })
+                        .or_else(|| {
+                            char_to_text_object(*c, TextObjectScope::Around)
+                                .map(|text_object| Command::YankTextObject { text_object })
+                        })
                 })
             } else {
                 Some(Command::Yank)
@@ -102,16 +89,17 @@ where
                 let _ = input.next();
                 input.next().and_then(|c| {
                     bracket_pair_for(*c)
-                    .map(|(left, right)| Command::ChangeInsidePair { left, right })
-                    .or_else(|| {
-                        char_to_text_object(*c, TextObjectScope::Inner)
-                        .map(|text_object|Command::ChangeTextObject { text_object })
-                    })
+                        .map(|(left, right)| Command::ChangeInsidePair { left, right })
+                        .or_else(|| {
+                            char_to_text_object(*c, TextObjectScope::Inner)
+                                .map(|text_object| Command::ChangeTextObject { text_object })
+                        })
                 })
             } else if let Some('a') = input.peek() {
                 let _ = input.next();
                 input.next().and_then(|c| {
-                    char_to_text_object(*c, TextObjectScope::Around).map(|text_object| Command::ChangeTextObject { text_object })
+                    char_to_text_object(*c, TextObjectScope::Around)
+                        .map(|text_object| Command::ChangeTextObject { text_object })
                 })
             } else {
                 Some(Command::Change)
@@ -297,17 +285,17 @@ impl Command {
             }
             Self::ChangeTextObject { text_object } => {
                 vec![ReedlineOption::Edit(EditCommand::CutTextObject {
-                    text_object: *text_object
+                    text_object: *text_object,
                 })]
             }
             Self::YankTextObject { text_object } => {
                 vec![ReedlineOption::Edit(EditCommand::CopyTextObject {
-                    text_object: *text_object
+                    text_object: *text_object,
                 })]
             }
             Self::DeleteTextObject { text_object } => {
                 vec![ReedlineOption::Edit(EditCommand::CutTextObject {
-                    text_object: *text_object
+                    text_object: *text_object,
                 })]
             }
             Self::SwapCursorAndAnchor => {
@@ -316,7 +304,7 @@ impl Command {
         }
     }
 
-     pub fn to_reedline_with_motion(
+    pub fn to_reedline_with_motion(
         &self,
         motion: &Motion,
         vi_state: &mut Vi,
@@ -480,6 +468,28 @@ impl Command {
             },
             _ => None,
         }
+    }
+}
+
+fn char_to_text_object(c: char, scope: TextObjectScope) -> Option<TextObject> {
+    match c {
+        'w' => Some(TextObject {
+            scope,
+            object_type: TextObjectType::Word,
+        }),
+        'W' => Some(TextObject {
+            scope,
+            object_type: TextObjectType::BigWord,
+        }),
+        'b' => Some(TextObject {
+            scope,
+            object_type: TextObjectType::Brackets,
+        }),
+        'q' => Some(TextObject {
+            scope,
+            object_type: TextObjectType::Quote,
+        }),
+        _ => None,
     }
 }
 

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -9,26 +9,38 @@ where
     match input.peek() {
         Some('d') => {
             let _ = input.next();
-            // Checking for "di(" or "di)" etc.
+            // Checking for "di(" or "diw" etc.
             if let Some('i') = input.peek() {
                 let _ = input.next();
-                input
-                    .next()
-                    .and_then(|c| bracket_pair_for(*c))
-                    .map(|(left, right)| Command::DeleteInsidePair { left, right })
+                input.next().map(|c| {
+                    if let Some((left, right)) = bracket_pair_for(*c) {
+                        Command::DeleteInsidePair { left, right }
+                    } else {
+                        Command::DeleteInsideTextObject { text_object: *c }
+                    }
+                })
+            } else if let Some('a') = input.peek() {
+                let _ = input.next();
+                input.next().map(|c| Command::DeleteAroundTextObject { text_object: *c })
             } else {
                 Some(Command::Delete)
             }
         }
-        // Checking for "yi(" or "yi)" etc.
+        // Checking for "yi(" or "yiw" etc.
         Some('y') => {
             let _ = input.next();
             if let Some('i') = input.peek() {
                 let _ = input.next();
-                input
-                    .next()
-                    .and_then(|c| bracket_pair_for(*c))
-                    .map(|(left, right)| Command::YankInsidePair { left, right })
+                input.next().map(|c| {
+                    if let Some((left, right)) = bracket_pair_for(*c) {
+                        Command::YankInsidePair { left, right }
+                    } else {
+                        Command::YankInsideTextObject { text_object: *c }
+                    }
+                })
+            } else if let Some('a') = input.peek() {
+                let _ = input.next();
+                input.next().map(|c| Command::YankAroundTextObject { text_object: *c })
             } else {
                 Some(Command::Yank)
             }
@@ -53,15 +65,21 @@ where
             let _ = input.next();
             Some(Command::Undo)
         }
-        // Checking for "ci(" or "ci)" etc.
+        // Checking for "ci(" or "ciw" etc.
         Some('c') => {
             let _ = input.next();
             if let Some('i') = input.peek() {
                 let _ = input.next();
-                input
-                    .next()
-                    .and_then(|c| bracket_pair_for(*c))
-                    .map(|(left, right)| Command::ChangeInsidePair { left, right })
+                input.next().map(|c| {
+                    if let Some((left, right)) = bracket_pair_for(*c) {
+                        Command::ChangeInsidePair { left, right }
+                    } else {
+                        Command::ChangeInsideTextObject { text_object: *c }
+                    }
+                })
+            } else if let Some('a') = input.peek() {
+                let _ = input.next();
+                input.next().map(|c| Command::ChangeAroundTextObject { text_object: *c })
             } else {
                 Some(Command::Change)
             }
@@ -147,6 +165,12 @@ pub enum Command {
     ChangeInsidePair { left: char, right: char },
     DeleteInsidePair { left: char, right: char },
     YankInsidePair { left: char, right: char },
+    ChangeInsideTextObject { text_object: char },
+    YankInsideTextObject { text_object: char },
+    DeleteInsideTextObject { text_object: char },
+    ChangeAroundTextObject { text_object: char },
+    YankAroundTextObject { text_object: char },
+    DeleteAroundTextObject { text_object: char },
     SwapCursorAndAnchor,
 }
 
@@ -225,6 +249,36 @@ impl Command {
                 vec![ReedlineOption::Edit(EditCommand::YankInside {
                     left: *left,
                     right: *right,
+                })]
+            }
+            Self::ChangeInsideTextObject { text_object } => {
+                vec![ReedlineOption::Edit(EditCommand::ChangeInsideTextObject {
+                    text_object: *text_object
+                })]
+            }
+            Self::YankInsideTextObject { text_object } => {
+                vec![ReedlineOption::Edit(EditCommand::YankInsideTextObject {
+                    text_object: *text_object
+                })]
+            }
+            Self::DeleteInsideTextObject { text_object } => {
+                vec![ReedlineOption::Edit(EditCommand::DeleteInsideTextObject {
+                    text_object: *text_object
+                })]
+            }
+            Self::ChangeAroundTextObject { text_object } => {
+                vec![ReedlineOption::Edit(EditCommand::ChangeAroundTextObject {
+                    text_object: *text_object
+                })]
+            }
+            Self::YankAroundTextObject { text_object } => {
+                vec![ReedlineOption::Edit(EditCommand::YankAroundTextObject {
+                    text_object: *text_object
+                })]
+            }
+            Self::DeleteAroundTextObject { text_object } => {
+                vec![ReedlineOption::Edit(EditCommand::DeleteAroundTextObject {
+                    text_object: *text_object
                 })]
             }
             Self::SwapCursorAndAnchor => {

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -7,6 +7,8 @@ fn char_to_text_object(c: char, scope: TextObjectScope) -> Option<TextObject> {
     match c {
         'w' => Some(TextObject { scope, object_type: TextObjectType::Word }),
         'W' => Some(TextObject { scope, object_type: TextObjectType::BigWord }),
+        'b' => Some(TextObject { scope, object_type: TextObjectType::Brackets }),
+        'q' => Some(TextObject { scope, object_type: TextObjectType::Quote }),
         _ => None,
     }
 }

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -234,25 +234,25 @@ impl Command {
                 None => vec![],
             },
             Self::ChangeInsidePair { left, right } => {
-                vec![ReedlineOption::Edit(EditCommand::CutInside {
+                vec![ReedlineOption::Edit(EditCommand::CutInsidePair {
                     left: *left,
                     right: *right,
                 })]
             }
             Self::DeleteInsidePair { left, right } => {
-                vec![ReedlineOption::Edit(EditCommand::CutInside {
+                vec![ReedlineOption::Edit(EditCommand::CutInsidePair {
                     left: *left,
                     right: *right,
                 })]
             }
             Self::YankInsidePair { left, right } => {
-                vec![ReedlineOption::Edit(EditCommand::YankInside {
+                vec![ReedlineOption::Edit(EditCommand::YankInsidePair {
                     left: *left,
                     right: *right,
                 })]
             }
             Self::ChangeInsideTextObject { text_object } => {
-                vec![ReedlineOption::Edit(EditCommand::ChangeInsideTextObject {
+                vec![ReedlineOption::Edit(EditCommand::CutInsideTextObject {
                     text_object: *text_object
                 })]
             }
@@ -262,12 +262,12 @@ impl Command {
                 })]
             }
             Self::DeleteInsideTextObject { text_object } => {
-                vec![ReedlineOption::Edit(EditCommand::DeleteInsideTextObject {
+                vec![ReedlineOption::Edit(EditCommand::CutInsideTextObject {
                     text_object: *text_object
                 })]
             }
             Self::ChangeAroundTextObject { text_object } => {
-                vec![ReedlineOption::Edit(EditCommand::ChangeAroundTextObject {
+                vec![ReedlineOption::Edit(EditCommand::CutAroundTextObject {
                     text_object: *text_object
                 })]
             }
@@ -277,7 +277,7 @@ impl Command {
                 })]
             }
             Self::DeleteAroundTextObject { text_object } => {
-                vec![ReedlineOption::Edit(EditCommand::DeleteAroundTextObject {
+                vec![ReedlineOption::Edit(EditCommand::CutAroundTextObject {
                     text_object: *text_object
                 })]
             }

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -114,8 +114,7 @@ impl ParsedViSequence {
                 Some(ViMode::Normal)
             }
             (Some(Command::ChangeInsidePair { .. }), _) => Some(ViMode::Insert),
-            (Some(Command::ChangeInsideTextObject { .. }), _) => Some(ViMode::Insert),
-            (Some(Command::ChangeAroundTextObject { .. }), _) => Some(ViMode::Insert),
+            (Some(Command::ChangeTextObject { .. }), _) => Some(ViMode::Insert),
             (Some(Command::Delete), ParseResult::Incomplete)
             | (Some(Command::DeleteChar), ParseResult::Incomplete)
             | (Some(Command::DeleteToEnd), ParseResult::Incomplete)

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -114,6 +114,8 @@ impl ParsedViSequence {
                 Some(ViMode::Normal)
             }
             (Some(Command::ChangeInsidePair { .. }), _) => Some(ViMode::Insert),
+            (Some(Command::ChangeInsideTextObject { .. }), _) => Some(ViMode::Insert),
+            (Some(Command::ChangeAroundTextObject { .. }), _) => Some(ViMode::Insert),
             (Some(Command::Delete), ParseResult::Incomplete)
             | (Some(Command::DeleteChar), ParseResult::Incomplete)
             | (Some(Command::DeleteToEnd), ParseResult::Incomplete)

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -30,6 +30,10 @@ pub enum TextObjectType {
     Word,
     /// WORD (delimited only by whitespace)
     BigWord,
+    /// (, ), [, ], {, }
+    Brackets,
+    /// ", ', `
+    Quote,
 }
 
 /// Text objects that can be operated on with vim-style commands

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -527,9 +527,9 @@ impl Display for EditCommand {
             #[cfg(feature = "system_clipboard")]
             EditCommand::PasteSystem => write!(f, "PasteSystem"),
             EditCommand::CutInsidePair { .. } => write!(f, "CutInside Value: <char> <char>"),
-            EditCommand::CopyInsidePair { .. } => write!(f, "YankInside Value: <char> <char>"),
-            EditCommand::CutAroundPair { .. } => write!(f, "CutAround Value: <char> <char>"),
-            EditCommand::CopyAroundPair { .. } => write!(f, "YankAround Value: <char> <char>"),
+            EditCommand::CopyInsidePair { .. } => write!(f, "CopyInsidePair Value: <char> <char>"),
+            EditCommand::CutAroundPair { .. } => write!(f, "CutAroundPair Value: <char> <char>"),
+            EditCommand::CopyAroundPair { .. } => write!(f, "CopyAroundPair Value: <char> <char>"),
             EditCommand::CutTextObject { .. } => write!(f, "CutTextObject Value: <TextObject>"),
             EditCommand::CopyTextObject { .. } => write!(f, "CopyTextObject Value: <TextObject>"),
         }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -526,7 +526,7 @@ impl Display for EditCommand {
             EditCommand::CopySelectionSystem => write!(f, "CopySelectionSystem"),
             #[cfg(feature = "system_clipboard")]
             EditCommand::PasteSystem => write!(f, "PasteSystem"),
-            EditCommand::CutInsidePair { .. } => write!(f, "CutInside Value: <char> <char>"),
+            EditCommand::CutInsidePair { .. } => write!(f, "CutInsidePair Value: <char> <char>"),
             EditCommand::CopyInsidePair { .. } => write!(f, "CopyInsidePair Value: <char> <char>"),
             EditCommand::CutAroundPair { .. } => write!(f, "CutAroundPair Value: <char> <char>"),
             EditCommand::CopyAroundPair { .. } => write!(f, "CopyAroundPair Value: <char> <char>"),

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -337,21 +337,21 @@ pub enum EditCommand {
     PasteSystem,
 
     /// Delete text between matching characters atomically
-    CutInside {
+    CutInsidePair {
         /// Left character of the pair
         left: char,
         /// Right character of the pair (usually matching bracket)
         right: char,
     },
     /// Yank text between matching characters atomically
-    YankInside {
+    YankInsidePair {
         /// Left character of the pair
         left: char,
         /// Right character of the pair (usually matching bracket)
         right: char,
     },
     /// Cut text inside a text object (e.g. word)
-    ChangeInsideTextObject {
+    CutInsideTextObject {
         /// The text object character ('w' for word, 'W' for WORD, etc.)
         text_object: char
     },
@@ -360,23 +360,13 @@ pub enum EditCommand {
         /// The text object character ('w' for word, 'W' for WORD, etc.)
         text_object: char
     },
-    /// Delete text inside a text object (e.g. word)
-    DeleteInsideTextObject {
-        /// The text object character ('w' for word, 'W' for WORD, etc.)
-        text_object: char
-    },
     /// Cut text around a text object including surrounding whitespace
-    ChangeAroundTextObject {
+    CutAroundTextObject {
         /// The text object character ('w' for word, 'W' for WORD, etc.)
         text_object: char
     },
     /// Yank text around a text object including surrounding whitespace
     YankAroundTextObject {
-        /// The text object character ('w' for word, 'W' for WORD, etc.)
-        text_object: char
-    },
-    /// Delete text around a text object including surrounding whitespace
-    DeleteAroundTextObject {
         /// The text object character ('w' for word, 'W' for WORD, etc.)
         text_object: char
     },
@@ -492,14 +482,12 @@ impl Display for EditCommand {
             EditCommand::CopySelectionSystem => write!(f, "CopySelectionSystem"),
             #[cfg(feature = "system_clipboard")]
             EditCommand::PasteSystem => write!(f, "PasteSystem"),
-            EditCommand::CutInside { .. } => write!(f, "CutInside Value: <char> <char>"),
-            EditCommand::YankInside { .. } => write!(f, "YankInside Value: <char> <char>"),
-            EditCommand::ChangeInsideTextObject { .. } => write!(f, "CutInsideTextObject"),
+            EditCommand::CutInsidePair { .. } => write!(f, "CutInside Value: <char> <char>"),
+            EditCommand::YankInsidePair { .. } => write!(f, "YankInside Value: <char> <char>"),
+            EditCommand::CutInsideTextObject { .. } => write!(f, "CutInsideTextObject"),
             EditCommand::YankInsideTextObject { .. } => write!(f, "YankInsideTextObject"),
-            EditCommand::DeleteInsideTextObject { .. } => write!(f, "DeleteInsideTextObject"),
-            EditCommand::ChangeAroundTextObject { .. } => write!(f, "CutAroundTextObject"),
+            EditCommand::CutAroundTextObject { .. } => write!(f, "CutAroundTextObject"),
             EditCommand::YankAroundTextObject { .. } => write!(f, "YankAroundTextObject"),
-            EditCommand::DeleteAroundTextObject { .. } => write!(f, "DeleteAroundTextObject"),
         }
     }
 }
@@ -582,14 +570,12 @@ impl EditCommand {
             EditCommand::CopySelection => EditType::NoOp,
             #[cfg(feature = "system_clipboard")]
             EditCommand::CopySelectionSystem => EditType::NoOp,
-            EditCommand::CutInside { .. } => EditType::EditText,
-            EditCommand::YankInside { .. } => EditType::EditText,
-            EditCommand::ChangeInsideTextObject { .. } => EditType::EditText,
-            EditCommand::ChangeAroundTextObject { .. } => EditType::EditText,
+            EditCommand::CutInsidePair { .. } => EditType::EditText,
+            EditCommand::YankInsidePair { .. } => EditType::EditText,
+            EditCommand::CutInsideTextObject { .. } => EditType::EditText,
+            EditCommand::CutAroundTextObject { .. } => EditType::EditText,
             EditCommand::YankInsideTextObject { .. } => EditType::NoOp,
-            EditCommand::DeleteInsideTextObject { .. } => EditType::NoOp,
             EditCommand::YankAroundTextObject { .. } => EditType::NoOp,
-            EditCommand::DeleteAroundTextObject { .. } => EditType::NoOp,
             EditCommand::CopyFromStart
             | EditCommand::CopyFromLineStart
             | EditCommand::CopyToEnd

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -390,6 +390,20 @@ pub enum EditCommand {
         /// Right character of the pair (usually matching bracket)
         right: char,
     },
+    /// Delete text around matching characters atomically (including the pair characters)
+    CutAroundPair {
+        /// Left character of the pair
+        left: char,
+        /// Right character of the pair (usually matching bracket)
+        right: char,
+    },
+    /// Yank text around matching characters atomically (including the pair characters)
+    CopyAroundPair {
+        /// Left character of the pair
+        left: char,
+        /// Right character of the pair (usually matching bracket)
+        right: char,
+    },
     /// Cut the specified text object
     CutTextObject {
         /// The text object to operate on
@@ -514,6 +528,8 @@ impl Display for EditCommand {
             EditCommand::PasteSystem => write!(f, "PasteSystem"),
             EditCommand::CutInsidePair { .. } => write!(f, "CutInside Value: <char> <char>"),
             EditCommand::CopyInsidePair { .. } => write!(f, "YankInside Value: <char> <char>"),
+            EditCommand::CutAroundPair { .. } => write!(f, "CutAround Value: <char> <char>"),
+            EditCommand::CopyAroundPair { .. } => write!(f, "YankAround Value: <char> <char>"),
             EditCommand::CutTextObject { .. } => write!(f, "CutTextObject"),
             EditCommand::CopyTextObject { .. } => write!(f, "CopyTextObject"),
         }
@@ -600,6 +616,8 @@ impl EditCommand {
             EditCommand::CopySelectionSystem => EditType::NoOp,
             EditCommand::CutInsidePair { .. } => EditType::EditText,
             EditCommand::CopyInsidePair { .. } => EditType::EditText,
+            EditCommand::CutAroundPair { .. } => EditType::EditText,
+            EditCommand::CopyAroundPair { .. } => EditType::EditText,
             EditCommand::CutTextObject { .. } => EditType::EditText,
             EditCommand::CopyTextObject { .. } => EditType::NoOp,
             EditCommand::CopyFromStart

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -407,12 +407,12 @@ pub enum EditCommand {
     /// Cut the specified text object
     CutTextObject {
         /// The text object to operate on
-        text_object: TextObject
+        text_object: TextObject,
     },
     /// Copy the specified text object
     CopyTextObject {
         /// The text object to operate on
-        text_object: TextObject
+        text_object: TextObject,
     },
 }
 
@@ -530,8 +530,8 @@ impl Display for EditCommand {
             EditCommand::CopyInsidePair { .. } => write!(f, "YankInside Value: <char> <char>"),
             EditCommand::CutAroundPair { .. } => write!(f, "CutAround Value: <char> <char>"),
             EditCommand::CopyAroundPair { .. } => write!(f, "YankAround Value: <char> <char>"),
-            EditCommand::CutTextObject { .. } => write!(f, "CutTextObject"),
-            EditCommand::CopyTextObject { .. } => write!(f, "CopyTextObject"),
+            EditCommand::CutTextObject { .. } => write!(f, "CutTextObject Value: <TextObject>"),
+            EditCommand::CopyTextObject { .. } => write!(f, "CopyTextObject Value: <TextObject>"),
         }
     }
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -350,6 +350,36 @@ pub enum EditCommand {
         /// Right character of the pair (usually matching bracket)
         right: char,
     },
+    /// Cut text inside a text object (e.g. word)
+    ChangeInsideTextObject {
+        /// The text object character ('w' for word, 'W' for WORD, etc.)
+        text_object: char
+    },
+    /// Yank text inside a text object (e.g. word)
+    YankInsideTextObject {
+        /// The text object character ('w' for word, 'W' for WORD, etc.)
+        text_object: char
+    },
+    /// Delete text inside a text object (e.g. word)
+    DeleteInsideTextObject {
+        /// The text object character ('w' for word, 'W' for WORD, etc.)
+        text_object: char
+    },
+    /// Cut text around a text object including surrounding whitespace
+    ChangeAroundTextObject {
+        /// The text object character ('w' for word, 'W' for WORD, etc.)
+        text_object: char
+    },
+    /// Yank text around a text object including surrounding whitespace
+    YankAroundTextObject {
+        /// The text object character ('w' for word, 'W' for WORD, etc.)
+        text_object: char
+    },
+    /// Delete text around a text object including surrounding whitespace
+    DeleteAroundTextObject {
+        /// The text object character ('w' for word, 'W' for WORD, etc.)
+        text_object: char
+    },
 }
 
 impl Display for EditCommand {
@@ -464,6 +494,12 @@ impl Display for EditCommand {
             EditCommand::PasteSystem => write!(f, "PasteSystem"),
             EditCommand::CutInside { .. } => write!(f, "CutInside Value: <char> <char>"),
             EditCommand::YankInside { .. } => write!(f, "YankInside Value: <char> <char>"),
+            EditCommand::ChangeInsideTextObject { .. } => write!(f, "CutInsideTextObject"),
+            EditCommand::YankInsideTextObject { .. } => write!(f, "YankInsideTextObject"),
+            EditCommand::DeleteInsideTextObject { .. } => write!(f, "DeleteInsideTextObject"),
+            EditCommand::ChangeAroundTextObject { .. } => write!(f, "CutAroundTextObject"),
+            EditCommand::YankAroundTextObject { .. } => write!(f, "YankAroundTextObject"),
+            EditCommand::DeleteAroundTextObject { .. } => write!(f, "DeleteAroundTextObject"),
         }
     }
 }
@@ -548,6 +584,12 @@ impl EditCommand {
             EditCommand::CopySelectionSystem => EditType::NoOp,
             EditCommand::CutInside { .. } => EditType::EditText,
             EditCommand::YankInside { .. } => EditType::EditText,
+            EditCommand::ChangeInsideTextObject { .. } => EditType::EditText,
+            EditCommand::ChangeAroundTextObject { .. } => EditType::EditText,
+            EditCommand::YankInsideTextObject { .. } => EditType::NoOp,
+            EditCommand::DeleteInsideTextObject { .. } => EditType::NoOp,
+            EditCommand::YankAroundTextObject { .. } => EditType::NoOp,
+            EditCommand::DeleteAroundTextObject { .. } => EditType::NoOp,
             EditCommand::CopyFromStart
             | EditCommand::CopyFromLineStart
             | EditCommand::CopyToEnd


### PR DESCRIPTION
### Overview
Implements the vim style inner and around (`i` and `a`) text objects for:
- word bound to `w` (a sequence of letters, digits and underscores, separated with white space)
- WORD `W` (a sequence of non-blank characters, separated with white space)
- brackets bound to `b` (any of `( )`, `[ ]`, `{ }`)
- quote bound to `q` (any of `" "`, `' '`, ` `` `)
-  prior "pair" motion for specific matching pairs (e.g. `di(` or `ci"`) extended for around versions that cover the pair characters

This addresses most of #848 although it doesn't add paragraph text object, that would be fairly straightforward to add later.

Additionally, the pair motions will now jump to the next pair if non are found within search range. For symmetric pairs like quotes searching is restricted to the current line. For asymmetric pairs like brackets search is multi-line across the whole buffer. Symmetric pairs searching does not do any parsing or matching of pairs based on language/groupings. It simply searches for the previous and next matching characters (this is consistently with vim but could be improved, perhaps using tree sitter).
### Repeats
While it might not be the intend to achieve identical behaviour as vim I thought it useful to compare to the default vim behaviour of repeats.
Around brackets:
In the current implementation repeat motions for `around` text objects will cause a jump to the next bracket. 
e.g. 2daw on "(first)between(second)" while in the first bracket will delete both the first and second bracket, included the parentheses themselves, and move the cursor to the end "between".
Vim works around this by not letting you do repeats for "around" motions unless inside a nested bracket.
Inner words:
Repeat motions for words also differ from default vim behaviour for repeated word text objects. In vim a `2diw` performs a single around diw command and then the repeat command is `dw`. The difference in behaviour is that in the reedline implementation `2daw` on `delete th|is word` will result in `delete|word` whereas in vim it would be `delete |word`.

This could perhaps be worked around by adding a method of passing an alternate command for repeats to the command module which could be made in a future change. I think the current behaviour is satisfactory for most use cases.

### Word identification
Currently due to using the unicode-segmentation crate for splitting at word word boundaries word does not have the same meaning as Vi/Vim.  This means `diw` on `not.a..wo|rd` will delete the whole WORD rather than just the word under the cursor.