### PR TITLE
Update rstest from 0.23 to 0.26, the current version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,19 +752,18 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ unicode-width = "0.2"
 [dev-dependencies]
 gethostname = "0.4.0"
 pretty_assertions = "1.4.0"
-rstest = { version = "0.23.0", default-features = false }
+rstest = { version = "0.26.0", default-features = false }
 tempfile = "3.3.0"
 
 [features]


### PR DESCRIPTION
I confirmed that `cargo test` still passes.

https://github.com/la10736/rstest/blob/v0.26.1/CHANGELOG.md