### PR TITLE
Fix missing use in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Reedline::create().with_highlighter(Box::new(ExampleHighlighter::new(commands)))
 ```rust
 // Create a reedline object with tab completions support
 
-use reedline::{default_emacs_keybindings, ColumnarMenu, DefaultCompleter, Emacs, KeyCode, KeyModifiers, Reedline, ReedlineEvent, ReedlineMenu};
+use reedline::{default_emacs_keybindings, ColumnarMenu, DefaultCompleter, Emacs, KeyCode, KeyModifiers, Reedline, ReedlineEvent, ReedlineMenu, MenuBuilder};
 
 let commands = vec![
   "test".into(),


### PR DESCRIPTION
Hey! I was looking at the instructions and noticed this was missing to have it compile. There was a correct example [here](https://docs.rs/reedline/latest/reedline/index.html#integrate-with-custom-tab-completion) though