### PR TITLE
Fix `mismatched_lifetime_syntaxes`

### DIFF
--- a/examples/custom_prompt.rs
+++ b/examples/custom_prompt.rs
@@ -16,13 +16,13 @@ use std::{borrow::Cow, cell::Cell, io};
 pub struct CustomPrompt(Cell<u32>, &'static str);
 pub static DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
 impl Prompt for CustomPrompt {
-    fn render_prompt_left(&self) -> Cow<str> {
+    fn render_prompt_left(&self) -> Cow<'_, str> {
         {
             Cow::Owned(self.1.to_string())
         }
     }
 
-    fn render_prompt_right(&self) -> Cow<str> {
+    fn render_prompt_right(&self) -> Cow<'_, str> {
         {
             let old = self.0.get();
             self.0.set(old + 1);
@@ -30,18 +30,18 @@ impl Prompt for CustomPrompt {
         }
     }
 
-    fn render_prompt_indicator(&self, _edit_mode: PromptEditMode) -> Cow<str> {
+    fn render_prompt_indicator(&self, _edit_mode: PromptEditMode) -> Cow<'_, str> {
         Cow::Owned(">".to_string())
     }
 
-    fn render_prompt_multiline_indicator(&self) -> Cow<str> {
+    fn render_prompt_multiline_indicator(&self) -> Cow<'_, str> {
         Cow::Borrowed(DEFAULT_MULTILINE_INDICATOR)
     }
 
     fn render_prompt_history_search_indicator(
         &self,
         history_search: PromptHistorySearch,
-    ) -> Cow<str> {
+    ) -> Cow<'_, str> {
         let prefix = match history_search.status {
             PromptHistorySearchStatus::Passing => "",
             PromptHistorySearchStatus::Failing => "failing ",

--- a/examples/transient_prompt.rs
+++ b/examples/transient_prompt.rs
@@ -24,26 +24,26 @@ pub static TRANSIENT_PROMPT: &str = "! ";
 pub static TRANSIENT_MULTILINE_INDICATOR: &str = ": ";
 
 impl Prompt for TransientPrompt {
-    fn render_prompt_left(&self) -> Cow<str> {
+    fn render_prompt_left(&self) -> Cow<'_, str> {
         Cow::Owned(String::new())
     }
 
-    fn render_prompt_right(&self) -> Cow<str> {
+    fn render_prompt_right(&self) -> Cow<'_, str> {
         Cow::Owned(String::new())
     }
 
-    fn render_prompt_indicator(&self, _prompt_mode: PromptEditMode) -> Cow<str> {
+    fn render_prompt_indicator(&self, _prompt_mode: PromptEditMode) -> Cow<'_, str> {
         Cow::Borrowed(TRANSIENT_PROMPT)
     }
 
-    fn render_prompt_multiline_indicator(&self) -> Cow<str> {
+    fn render_prompt_multiline_indicator(&self) -> Cow<'_, str> {
         Cow::Borrowed(TRANSIENT_MULTILINE_INDICATOR)
     }
 
     fn render_prompt_history_search_indicator(
         &self,
         history_search: PromptHistorySearch,
-    ) -> Cow<str> {
+    ) -> Cow<'_, str> {
         let prefix = match history_search.status {
             PromptHistorySearchStatus::Passing => "",
             PromptHistorySearchStatus::Failing => "failing ",

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -56,7 +56,7 @@ pub enum ParseAction {
 /// )
 ///
 /// ```
-pub fn parse_selection_char(buffer: &str, marker: char) -> ParseResult {
+pub fn parse_selection_char(buffer: &str, marker: char) -> ParseResult<'_> {
     if buffer.is_empty() {
         return ParseResult {
             remainder: buffer,

--- a/src/painting/utils.rs
+++ b/src/painting/utils.rs
@@ -5,7 +5,7 @@ use unicode_width::UnicodeWidthStr;
 ///
 /// Needed for correct output in raw mode.
 /// Only replaces solitary LF with CRLF.
-pub(crate) fn coerce_crlf(input: &str) -> Cow<str> {
+pub(crate) fn coerce_crlf(input: &str) -> Cow<'_, str> {
     let mut result = Cow::Borrowed(input);
     let mut cursor: usize = 0;
     for (idx, _) in input.match_indices('\n') {

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -85,18 +85,18 @@ impl Display for PromptEditMode {
 /// displayed before the `LineBuffer` is drawn.
 pub trait Prompt: Send {
     /// Provide content of the left full prompt
-    fn render_prompt_left(&self) -> Cow<str>;
+    fn render_prompt_left(&self) -> Cow<'_, str>;
     /// Provide content of the right full prompt
-    fn render_prompt_right(&self) -> Cow<str>;
+    fn render_prompt_right(&self) -> Cow<'_, str>;
     /// Render the prompt indicator (Last part of the prompt that changes based on the editor mode)
-    fn render_prompt_indicator(&self, prompt_mode: PromptEditMode) -> Cow<str>;
+    fn render_prompt_indicator(&self, prompt_mode: PromptEditMode) -> Cow<'_, str>;
     /// Indicator to show before explicit new lines
-    fn render_prompt_multiline_indicator(&self) -> Cow<str>;
+    fn render_prompt_multiline_indicator(&self) -> Cow<'_, str>;
     /// Render the prompt indicator for `Ctrl-R` history search
     fn render_prompt_history_search_indicator(
         &self,
         history_search: PromptHistorySearch,
-    ) -> Cow<str>;
+    ) -> Cow<'_, str>;
     /// Get the default prompt color
     fn get_prompt_color(&self) -> Color {
         DEFAULT_PROMPT_COLOR

--- a/src/prompt/default.rs
+++ b/src/prompt/default.rs
@@ -38,7 +38,7 @@ pub enum DefaultPromptSegment {
 /// Given a prompt segment, render it to a Cow<str> that we can use to
 /// easily implement [`Prompt`]'s `render_prompt_left` and `render_prompt_right`
 /// functions.
-fn render_prompt_segment(prompt: &DefaultPromptSegment) -> Cow<str> {
+fn render_prompt_segment(prompt: &DefaultPromptSegment) -> Cow<'_, str> {
     match &prompt {
         DefaultPromptSegment::Basic(s) => Cow::Borrowed(s),
         DefaultPromptSegment::WorkingDirectory => {
@@ -51,15 +51,15 @@ fn render_prompt_segment(prompt: &DefaultPromptSegment) -> Cow<str> {
 }
 
 impl Prompt for DefaultPrompt {
-    fn render_prompt_left(&self) -> Cow<str> {
+    fn render_prompt_left(&self) -> Cow<'_, str> {
         render_prompt_segment(&self.left_prompt)
     }
 
-    fn render_prompt_right(&self) -> Cow<str> {
+    fn render_prompt_right(&self) -> Cow<'_, str> {
         render_prompt_segment(&self.right_prompt)
     }
 
-    fn render_prompt_indicator(&self, edit_mode: PromptEditMode) -> Cow<str> {
+    fn render_prompt_indicator(&self, edit_mode: PromptEditMode) -> Cow<'_, str> {
         match edit_mode {
             PromptEditMode::Default | PromptEditMode::Emacs => DEFAULT_PROMPT_INDICATOR.into(),
             PromptEditMode::Vi(vi_mode) => match vi_mode {
@@ -70,14 +70,14 @@ impl Prompt for DefaultPrompt {
         }
     }
 
-    fn render_prompt_multiline_indicator(&self) -> Cow<str> {
+    fn render_prompt_multiline_indicator(&self) -> Cow<'_, str> {
         Cow::Borrowed(DEFAULT_MULTILINE_INDICATOR)
     }
 
     fn render_prompt_history_search_indicator(
         &self,
         history_search: PromptHistorySearch,
-    ) -> Cow<str> {
+    ) -> Cow<'_, str> {
         let prefix = match history_search.status {
             PromptHistorySearchStatus::Passing => "",
             PromptHistorySearchStatus::Failing => "failing ",


### PR DESCRIPTION
From Rust 1.89.0 on this lints.
https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint
