### PR TITLE
fix: set default prompt colors to reset

### DIFF
--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -9,10 +9,10 @@ use {
 };
 
 /// The default color for the prompt, indicator, and right prompt
-pub static DEFAULT_PROMPT_COLOR: Color = Color::Green;
+pub static DEFAULT_PROMPT_COLOR: Color = Color::Reset;
 pub static DEFAULT_PROMPT_MULTILINE_COLOR: nu_ansi_term::Color = nu_ansi_term::Color::LightBlue;
 pub static DEFAULT_INDICATOR_COLOR: Color = Color::Cyan;
-pub static DEFAULT_PROMPT_RIGHT_COLOR: Color = Color::AnsiValue(5);
+pub static DEFAULT_PROMPT_RIGHT_COLOR: Color = Color::Reset;
 
 /// The current success/failure of the history search
 pub enum PromptHistorySearchStatus {


### PR DESCRIPTION
The default left and right prompt colors were set as `Green` and `AnsiValue(5)` respectively, which caused the prompt to be colored even when it was reset. This fix makes the prompts respect the terminal default colors when style="none"

Fixes nushell/nushell#16384