### PR TITLE
Upgrade GitHub Actions and Rust toolchain versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-            components: rustfmt
+            components: clippy, rustfmt
         
       - name: Setup nextest
         uses: taiki-e/install-action@nextest


### PR DESCRIPTION
Try following the example for setup-rust-toolchain to see if that gets over the hump of fmt not working.