### PR TITLE
fix(editor)!: undo requires two presses after copy

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -213,7 +213,7 @@ impl Editor {
                 let deleted_char = self.edit_stack.current().grapheme_left().chars().next();
                 UndoBehavior::Backspace(deleted_char)
             }
-            (_, EditType::UndoRedo) => UndoBehavior::UndoRedo,
+            (_, EditType::UndoRedo | EditType::NoOp) => UndoBehavior::NoOp,
             (_, _) => UndoBehavior::CreateUndoPoint,
         };
 
@@ -343,8 +343,8 @@ impl Editor {
     }
 
     pub(crate) fn update_undo_state(&mut self, undo_behavior: UndoBehavior) {
-        if matches!(undo_behavior, UndoBehavior::UndoRedo) {
-            self.last_undo_behavior = UndoBehavior::UndoRedo;
+        if matches!(undo_behavior, UndoBehavior::NoOp) {
+            self.last_undo_behavior = UndoBehavior::NoOp;
             return;
         }
         if !undo_behavior.create_undo_point_after(&self.last_undo_behavior) {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -746,8 +746,8 @@ pub enum UndoBehavior {
     /// Catch-all for actions that should always form a unique undo point and never be
     /// grouped with later edits
     CreateUndoPoint,
-    /// Undo/Redo actions shouldn't be reflected on the edit stack
-    UndoRedo,
+    /// For actions that shouldn't be reflected on the edit stack e.g. Undo/Redo
+    NoOp,
 }
 
 impl UndoBehavior {


### PR DESCRIPTION
Previously all copy commands created redundant undo point, this commit resolves this by not creating an undo point when EditType is NoOp

fixes #955
