### PR TITLE
fix: bashism parsing

### DIFF
--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -70,7 +70,6 @@ pub fn parse_selection_char(buffer: &str, marker: char) -> ParseResult<'_> {
     let mut input = buffer.chars().peekable();
 
     let mut index = 0;
-    let mut action = ParseAction::ForwardSearch;
     while let Some(char) = input.next() {
         if char == marker {
             match input.peek() {
@@ -97,12 +96,15 @@ pub fn parse_selection_char(buffer: &str, marker: char) -> ParseResult<'_> {
                 Some(&x) if x.is_ascii_digit() || x == '-' => {
                     let mut count: usize = 0;
                     let mut size: usize = marker.len_utf8();
+                    let action = if x == '-' {
+                        size += 1;
+                        let _ = input.next();
+                        ParseAction::BackwardSearch
+                    } else {
+                        ParseAction::ForwardSearch
+                    };
                     while let Some(&c) = input.peek() {
-                        if c == '-' {
-                            let _ = input.next();
-                            size += 1;
-                            action = ParseAction::BackwardSearch;
-                        } else if c.is_ascii_digit() {
+                        if c.is_ascii_digit() {
                             let c = c.to_digit(10).expect("already checked if is a digit");
                             let _ = input.next();
                             count *= 10;
@@ -141,7 +143,7 @@ pub fn parse_selection_char(buffer: &str, marker: char) -> ParseResult<'_> {
                         remainder: &buffer[0..index],
                         index: Some(0),
                         marker: Some(&buffer[index..buffer.len()]),
-                        action,
+                        action: ParseAction::ForwardSearch,
                         prefix: Some(&buffer[index..buffer.len()]),
                     }
                 }
@@ -155,7 +157,7 @@ pub fn parse_selection_char(buffer: &str, marker: char) -> ParseResult<'_> {
         remainder: buffer,
         index: None,
         marker: None,
-        action,
+        action: ParseAction::ForwardSearch,
         prefix: None,
     }
 }


### PR DESCRIPTION
The current parsing behavior of bashism such as `!-<n>` or `!<n>` is faulty. `!<n>---` is parsed as a whole, and rewritten the same as `!<n>`, and `!-----<n>` is the same as `!-<n>`. You can see what other buggy behavior is possible if you take a closer look at the changed code.
Now they all correctly parse.