### PR TITLE
Add ReedlineEvent::SubmitOrSpace

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1183,7 +1183,7 @@ impl Reedline {
                     }
                 }
                 self.run_edit_commands(&[EditCommand::InsertChar(' ')]);
-                return Ok(EventStatus::Handled);
+                Ok(EventStatus::Handled)
             }
             ReedlineEvent::ExecuteHostCommand(host_command) => {
                 self.suspended_state = Some(self.painter.state_before_suspension());

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -880,7 +880,8 @@ impl Reedline {
             ReedlineEvent::Enter
             | ReedlineEvent::HistoryHintComplete
             | ReedlineEvent::Submit
-            | ReedlineEvent::SubmitOrNewline => {
+            | ReedlineEvent::SubmitOrNewline
+            | ReedlineEvent::SubmitOrSpace => {
                 if let Some(string) = self.history_cursor.string_at_cursor() {
                     self.editor
                         .set_buffer(string, UndoBehavior::CreateUndoPoint);
@@ -1169,6 +1170,20 @@ impl Reedline {
                         Ok(EventStatus::Handled)
                     }
                 }
+            }
+            ReedlineEvent::SubmitOrSpace => {
+                #[cfg(feature = "bashisms")]
+                if let Some(event) = self.parse_bang_command() {
+                    return self.handle_editor_event(prompt, event);
+                }
+                for menu in self.menus.iter_mut() {
+                    if menu.is_active() {
+                        menu.replace_in_buffer(&mut self.editor);
+                        menu.menu_event(MenuEvent::Deactivate);
+                    }
+                }
+                self.run_edit_commands(&[EditCommand::InsertChar(' ')]);
+                return Ok(EventStatus::Handled);
             }
             ReedlineEvent::ExecuteHostCommand(host_command) => {
                 self.suspended_state = Some(self.painter.state_before_suspension());

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -755,6 +755,9 @@ pub enum ReedlineEvent {
     /// Submit at the end of the *complete* text, otherwise newline
     SubmitOrNewline,
 
+    /// Submit at the end of the *complete* text, otherwise space
+    SubmitOrSpace,
+
     /// Esc event
     Esc,
 
@@ -848,6 +851,7 @@ impl Display for ReedlineEvent {
             ReedlineEvent::Enter => write!(f, "Enter"),
             ReedlineEvent::Submit => write!(f, "Submit"),
             ReedlineEvent::SubmitOrNewline => write!(f, "SubmitOrNewline"),
+            ReedlineEvent::SubmitOrSpace => write!(f, "SubmitOrSpace"),
             ReedlineEvent::Esc => write!(f, "Esc"),
             ReedlineEvent::Mouse => write!(f, "Mouse"),
             ReedlineEvent::Resize(_, _) => write!(f, "Resize <int> <int>"),


### PR DESCRIPTION
This PR solves https://github.com/nushell/nushell/issues/9227 without changing the default behavior.

## Context
The issue reports that when tab completion is active, pressing space doesn't accept the currently selected option (unlike pressing Enter). Instead, the completion menu persists, which differs from the expected behavior in most shells.

I've been struggling with this issue myself. While it seems most users haven't encountered it, I'll leave it up to you whether to approve this change.


## What this PR does
With this fix, pressing space during tab completion will accept the current selection and close the completion menu.
Example with nushell:

```nushell
$env.config.keybindings ++= [
  {
    name: submit_or_space
    modifier: none
    keycode: space
    mode: [emacs vi_normal vi_insert]
    event: [
      {send: SubmitOrSpace}
    ]
  }
]
```

```sh
touch a1 a2
cat a<tab><space>
```
will update the buffer to:
```sh
cat a1 [cursor here]
```

similar to the behavior in zsh or fish or pwsh.