### PR TITLE
fix: allow custom Enter keybindings in vi mode

### DIFF
--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -159,18 +159,29 @@ impl EditMode for Vi {
                     self.mode = ViMode::Normal;
                     ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint])
                 }
-                (_, KeyModifiers::NONE, KeyCode::Enter) => {
-                    self.mode = ViMode::Insert;
-                    ReedlineEvent::Enter
-                }
                 (ViMode::Normal | ViMode::Visual, _, _) => self
                     .normal_keybindings
                     .find_binding(modifiers, code)
-                    .unwrap_or(ReedlineEvent::None),
+                    .unwrap_or_else(|| {
+                        // Default Enter behavior when no custom binding
+                        if modifiers == KeyModifiers::NONE && code == KeyCode::Enter {
+                            self.mode = ViMode::Insert;
+                            ReedlineEvent::Enter
+                        } else {
+                            ReedlineEvent::None
+                        }
+                    }),
                 (ViMode::Insert, _, _) => self
                     .insert_keybindings
                     .find_binding(modifiers, code)
-                    .unwrap_or(ReedlineEvent::None),
+                    .unwrap_or_else(|| {
+                        // Default Enter behavior when no custom binding
+                        if modifiers == KeyModifiers::NONE && code == KeyCode::Enter {
+                            ReedlineEvent::Enter
+                        } else {
+                            ReedlineEvent::None
+                        }
+                    }),
             },
 
             Event::Mouse(_) => ReedlineEvent::Mouse,


### PR DESCRIPTION
## Summary

- Vi mode now respects custom Enter keybindings instead of hardcoding `ReedlineEvent::Enter`
- Makes vi mode consistent with emacs mode behavior

## Problem

Previously, the Enter key in vi mode was handled before checking custom keybindings:

```rust
(_, KeyModifiers::NONE, KeyCode::Enter) => {
    self.mode = ViMode::Insert;
    ReedlineEvent::Enter
}
```

This meant users could not override Enter behavior in `vi_insert` or `vi_normal` modes. Custom keybindings like abbreviation expansion menus would work with Space but not Enter.

## Solution

Check keybindings first via `find_binding()`, fall back to default Enter behavior only if no custom binding exists. This matches how emacs mode already handles Enter.

```mermaid
flowchart TD
    A[Enter key pressed in vi mode] --> B{Custom keybinding exists?}
    B -->|Yes| C[Execute custom binding]
    B -->|No| D[Default: ReedlineEvent::Enter]
```

## Testing

Tested with nushell's abbreviation expansion menu - Enter now correctly triggers the menu before submitting, matching Space behavior.

## Note

Made with claude code.