### PR TITLE
Use `rfind` rather `filter.next_back`.

### DIFF
--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -272,8 +272,7 @@ impl LineBuffer {
     pub fn word_left_index(&self) -> usize {
         self.lines[..self.insertion_point]
             .split_word_bound_indices()
-            .filter(|(_, word)| !is_whitespace_str(word))
-            .next_back()
+            .rfind(|(_, word)| !is_whitespace_str(word))
             .map(|(i, _)| i)
             .unwrap_or(0)
     }
@@ -512,8 +511,7 @@ impl LineBuffer {
         let right_index = self.word_right_index();
         let left_index = self.lines[..right_index]
             .split_word_bound_indices()
-            .filter(|(_, word)| !is_whitespace_str(word))
-            .next_back()
+            .rfind(|(_, word)| !is_whitespace_str(word))
             .map(|(i, _)| i)
             .unwrap_or(0);
 


### PR DESCRIPTION
I noticed CI error when running clippy:
```
warning: called `filter(..).next_back()` on an `DoubleEndedIterator`. This is more succinctly expressed by calling `.rfind(..)` instead
   --> src/core_editor/line_buffer.rs:273:9
    |
273 | /         self.lines[..self.insertion_point]
274 | |             .split_word_bound_indices()
275 | |             .filter(|(_, word)| !is_whitespace_str(word))
276 | |             .next_back()
    | |________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#filter_next
    = note: `#[warn(clippy::filter_next)]` on by default
help: try
    |
273 ~         self.lines[..self.insertion_point]
274 +             .split_word_bound_indices().rfind(|(_, word)| !is_whitespace_str(word))
    |
```
This pr is going to fix it