### PR TITLE
fix: only check for kitty support when it's enabled

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -240,7 +240,7 @@ impl Reedline {
             buffer_editor: None,
             cursor_shapes: None,
             bracketed_paste: BracketedPasteGuard::default(),
-            kitty_protocol: KittyProtocolGuard::new(),
+            kitty_protocol: KittyProtocolGuard::default(),
             immediately_accept: false,
             #[cfg(feature = "external_printer")]
             external_printer: None,


### PR DESCRIPTION
_Resolves #987, which explains the full context for the behavioral change between 0.43 and 0.44. This seemed like a relatively non-invasive change, but please do let me know if there are other approaches you'd prefer that we pursue. I'm happy to take feedback and iterate._

Only invokes `kitty_protocol_available()` when `KittyProtocolGuard::set()` is called with `enable = true`. This avoids terminal interactions to detect protocol availability when the protocol is not _explicitly_ enabled by the `Reedline` client. We still cache the support/availability information within the `support_kitty_protocol` field added in #920.

Also reverts back to previous usage using `KittyProtocolGuard::default()`, now that we're just using default field values.