### PR TITLE
feat: add initial support for multi-stroke chord keybindings in emacs mode

### DIFF
--- a/examples/chords.rs
+++ b/examples/chords.rs
@@ -1,0 +1,81 @@
+// Example demonstrating multi-keystroke chord support in reedline
+//
+// This example shows how to configure key chords (multi-key sequences)
+// that trigger actions. For example, pressing Ctrl+X followed by Ctrl+C
+// can be bound to a specific event.
+
+use crossterm::event::{KeyCode, KeyModifiers};
+use reedline::{
+    default_emacs_keybindings, DefaultPrompt, Emacs, KeyCombination, Reedline,
+    ReedlineEvent, Signal,
+};
+use std::io;
+
+/// Helper to create a KeyCombination for Ctrl+<char>
+fn ctrl(c: char) -> KeyCombination {
+    KeyCombination {
+        modifier: KeyModifiers::CONTROL,
+        key_code: KeyCode::Char(c),
+    }
+}
+
+fn main() -> io::Result<()> {
+    println!("Reedline Chord Example");
+    println!("======================");
+    println!();
+    println!("This example demonstrates multi-keystroke chord bindings.");
+    println!();
+    println!("Available chords:");
+    println!("  Ctrl+X Ctrl+C - Quit");
+    println!("  Ctrl+X Ctrl+Y Ctrl+Z Ctrl+Z Ctrl+Y - Report that nothing happens");
+    println!();
+    println!("Regular keys and single-key bindings still work normally.");
+    println!("You may also type 'exit' or press Ctrl+D to quit.");
+    println!();
+
+    // Start with the default Emacs keybindings
+    let mut keybindings = default_emacs_keybindings();
+
+    // Add chord bindings
+    // Ctrl+X Ctrl+C: Quit
+    keybindings.add_sequence_binding(
+        &[ctrl('x'), ctrl('c')],
+        ReedlineEvent::CtrlD,
+    );
+
+    // Ctrl+X Ctrl+Y Ctrl+Z Ctrl+Z Ctrl+Y: Quit
+    keybindings.add_sequence_binding(
+        &[ctrl('x'), ctrl('y'), ctrl('z'), ctrl('z'), ctrl('y')],
+        ReedlineEvent::ExecuteHostCommand(String::from("Nothing happens"))
+    );
+
+    // Create the Emacs edit mode with our custom keybindings
+    let edit_mode = Box::new(Emacs::new(keybindings));
+
+    // Create the line editor
+    let mut line_editor = Reedline::create().with_edit_mode(edit_mode);
+
+    let prompt = DefaultPrompt::default();
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                if buffer == "exit" {
+                    println!("Goodbye!");
+                    break;
+                }
+                println!("You typed: {buffer}");
+            }
+            Signal::CtrlD => {
+                println!("\nQuitting.");
+                break;
+            }
+            Signal::CtrlC => {
+                println!("Ctrl+C pressed");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/examples/chords.rs
+++ b/examples/chords.rs
@@ -6,8 +6,8 @@
 
 use crossterm::event::{KeyCode, KeyModifiers};
 use reedline::{
-    default_emacs_keybindings, DefaultPrompt, Emacs, KeyCombination, Reedline,
-    ReedlineEvent, Signal,
+    default_emacs_keybindings, DefaultPrompt, Emacs, KeyCombination, Reedline, ReedlineEvent,
+    Signal,
 };
 use std::io;
 
@@ -38,15 +38,12 @@ fn main() -> io::Result<()> {
 
     // Add chord bindings
     // Ctrl+X Ctrl+C: Quit
-    keybindings.add_sequence_binding(
-        &[ctrl('x'), ctrl('c')],
-        ReedlineEvent::CtrlD,
-    );
+    keybindings.add_sequence_binding(&[ctrl('x'), ctrl('c')], ReedlineEvent::CtrlD);
 
     // Ctrl+X Ctrl+Y Ctrl+Z Ctrl+Z Ctrl+Y: Quit
     keybindings.add_sequence_binding(
         &[ctrl('x'), ctrl('y'), ctrl('z'), ctrl('z'), ctrl('y')],
-        ReedlineEvent::ExecuteHostCommand(String::from("Nothing happens"))
+        ReedlineEvent::ExecuteHostCommand(String::from("Nothing happens")),
     );
 
     // Create the Emacs edit mode with our custom keybindings

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -5,17 +5,48 @@ use {
     std::collections::HashMap,
 };
 
+/// Representation of a key combination: modifier + key code
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct KeyCombination {
+    /// Modifier keys
     pub modifier: KeyModifiers,
+    /// The key code
     pub key_code: KeyCode,
 }
 
 /// Main definition of editor keybindings
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Keybindings {
-    /// Defines a keybinding for a reedline event
-    pub bindings: HashMap<KeyCombination, ReedlineEvent>,
+    /// Trie mapping key combination sequences to their corresponding events.
+    root: KeyBindingNode,
+}
+
+/// Target that a key combination may be bound to.
+pub enum KeyBindingTarget {
+    /// Indicates a binding to an event.
+    Event(ReedlineEvent),
+    /// Indicates that this is a prefix to other bindings.
+    ChordPrefix,
+}
+
+// TODO: Implement Serialize for Keybindings
+// TODO: Implement Deserialize for Keybindings
+
+/// Trie node that represents a key combination's binding. The key
+/// combination may *only* be bound to an event, or may be a
+/// strict prefix of a chord of key combinations.
+#[derive(Clone, Debug)]
+enum KeyBindingNode {
+    /// Indicates a binding to an event.
+    Event(ReedlineEvent),
+    /// Indicates that this is a prefix to other bindings.
+    Prefix(HashMap<KeyCombination, KeyBindingNode>),
+}
+
+impl KeyBindingNode {
+    fn new_prefix() -> Self {
+        KeyBindingNode::Prefix(HashMap::new())
+    }
 }
 
 impl Default for Keybindings {
@@ -25,14 +56,14 @@ impl Default for Keybindings {
 }
 
 impl Keybindings {
-    /// New keybining
+    /// Returns a new, empty keybinding set
     pub fn new() -> Self {
         Self {
-            bindings: HashMap::new(),
+            root: KeyBindingNode::new_prefix(),
         }
     }
 
-    /// Defines an empty keybinding object
+    /// Returns a new, empty keybinding set
     pub fn empty() -> Self {
         Self::new()
     }
@@ -56,16 +87,97 @@ impl Keybindings {
         }
 
         let key_combo = KeyCombination { modifier, key_code };
-        self.bindings.insert(key_combo, command);
+
+        self.add_sequence_binding(&[key_combo], command);
     }
 
-    /// Find a keybinding based on the modifier and keycode
+    /// Binds a sequence of key combinations to an event. This allows binding a single
+    /// key combination, as well as binding a chord of multiple key combinations.
+    pub fn add_sequence_binding(&mut self, sequence: &[KeyCombination], event: ReedlineEvent) {
+        if sequence.len() == 0 {
+            return;
+        }
+
+        let mut current_target = &mut self.root;
+
+        for i in 0..(sequence.len() - 1) {
+            match current_target {
+                KeyBindingNode::Prefix(ref mut map) => {
+                    let combo = &sequence[i];
+
+                    current_target = map
+                        .entry(combo.clone())
+                        .or_insert_with(KeyBindingNode::new_prefix);
+                }
+                KeyBindingNode::Event(_) => {
+                    // Overwrite existing event binding with a prefix
+                    *current_target = KeyBindingNode::new_prefix();
+                }
+            }
+        }
+
+        let final_combo = &sequence[sequence.len() - 1];
+
+        match current_target {
+            KeyBindingNode::Prefix(ref mut map) => {
+                map.insert(final_combo.clone(), KeyBindingNode::Event(event));
+            }
+            KeyBindingNode::Event(_) => {
+                // Overwrite existing event binding with a prefix initialized with the event.
+                let prefix = KeyBindingNode::Prefix(HashMap::from([(
+                    final_combo.clone(),
+                    KeyBindingNode::Event(event),
+                )]));
+                *current_target = prefix;
+            }
+        }
+    }
+
+    /// Find a keybinding based on the modifier and keycode.
     pub fn find_binding(&self, modifier: KeyModifiers, key_code: KeyCode) -> Option<ReedlineEvent> {
         let key_combo = KeyCombination { modifier, key_code };
-        self.bindings.get(&key_combo).cloned()
+        self.find_sequence_binding(&[key_combo]).and_then(|target| {
+            if let KeyBindingTarget::Event(event) = target {
+                Some(event)
+            } else {
+                None
+            }
+        })
     }
 
-    /// Remove a keybinding
+    /// Find a keybinding based on a sequence of key combinations.
+    ///
+    /// Returns `Some(KeyBindingTarget::Event(ReedlineEvent))` if the sequence is bound to a
+    /// particular [`ReedlineEvent`].
+    ///
+    /// Returns `Some(KeyBindingTarget::ChordPrefix)` if the sequence is a strict prefix
+    /// of other bindings.
+    ///
+    /// Returns `None` if the sequence is not bound.
+    pub fn find_sequence_binding(&self, sequence: &[KeyCombination]) -> Option<KeyBindingTarget> {
+        let mut current_target = &self.root;
+
+        for i in 0..sequence.len() {
+            match current_target {
+                KeyBindingNode::Prefix(map) => {
+                    if let Some(next_target) = map.get(&sequence[i]) {
+                        current_target = next_target;
+                    } else {
+                        return None;
+                    }
+                }
+                KeyBindingNode::Event(_) => return None,
+            }
+        }
+
+        match current_target {
+            KeyBindingNode::Prefix(_) => Some(KeyBindingTarget::ChordPrefix),
+            KeyBindingNode::Event(event) => Some(KeyBindingTarget::Event(event.clone())),
+        }
+    }
+
+    /// Remove a single-key keybinding. If the indicated key combination is a strict prefix
+    /// of chord bindings, those latter bindings are preserved.
     ///
     /// Returns `Some(ReedlineEvent)` if the key combination was previously bound to a particular [`ReedlineEvent`]
     pub fn remove_binding(
@@ -74,12 +186,74 @@ impl Keybindings {
         key_code: KeyCode,
     ) -> Option<ReedlineEvent> {
         let key_combo = KeyCombination { modifier, key_code };
-        self.bindings.remove(&key_combo)
+        self.remove_sequence_binding(&[key_combo])
     }
 
-    /// Get assigned keybindings
-    pub fn get_keybindings(&self) -> &HashMap<KeyCombination, ReedlineEvent> {
-        &self.bindings
+    /// Unbind a sequence of key combinations. If the given sequence is a strict prefix
+    /// of other bindings, those bindings are preserved.
+    ///
+    /// Returns `Some(ReedlineEvent)` if the sequence was previously bound to a particular [`ReedlineEvent`]
+    pub fn remove_sequence_binding(
+        &mut self,
+        sequence: &[KeyCombination],
+    ) -> Option<ReedlineEvent> {
+        let mut current_target = &mut self.root;
+
+        if sequence.len() == 0 {
+            return None;
+        }
+
+        for i in 0..(sequence.len() - 1) {
+            match current_target {
+                KeyBindingNode::Prefix(map) => {
+                    if let Some(next_target) = map.get_mut(&sequence[i]) {
+                        current_target = next_target;
+                    } else {
+                        return None;
+                    }
+                }
+                KeyBindingNode::Event(_) => return None,
+            }
+        }
+
+        let final_combo = &sequence[sequence.len() - 1];
+
+        match current_target {
+            KeyBindingNode::Prefix(map) => {
+                if map
+                    .get(final_combo)
+                    .is_none_or(|target| matches!(target, KeyBindingNode::Prefix(_)))
+                {
+                    None
+                } else if let Some(KeyBindingNode::Event(old_event)) = map.remove(final_combo) {
+                    Some(old_event)
+                } else {
+                    None
+                }
+            }
+            KeyBindingNode::Event(_) => None,
+        }
+    }
+
+    /// Get assigned single-key keybindings.
+    pub fn get_keybindings(&self) -> impl IntoIterator<Item = (&KeyCombination, &ReedlineEvent)> {
+        self.get_sequence_bindings()
+            .into_iter()
+            .filter_map(|(seq, event)| {
+                if let [first, ..] = seq {
+                    Some((first, event))
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// Get all bindings for key sequences, including single-key bindings and chords.
+    pub fn get_sequence_bindings(
+        &self,
+    ) -> impl IntoIterator<Item = (&[KeyCombination], &ReedlineEvent)> {
+        // TODO
+        []
     }
 }
 

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -464,7 +464,6 @@ pub fn add_common_selection_bindings(kb: &mut Keybindings) {
     );
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -494,16 +493,16 @@ mod tests {
 
         // Make sure we can find the binding.
         let found_binding = kb.find_sequence_binding(&sequence);
-        assert_eq!(
-            found_binding,
-            Some(KeyBindingTarget::Event(BOUND_EVENT))
-        );
+        assert_eq!(found_binding, Some(KeyBindingTarget::Event(BOUND_EVENT)));
 
         // Make sure we can't find some non-existent binding.
-        let not_found = kb.find_sequence_binding(&[sequence[0].clone(), KeyCombination {
-            modifier: KeyModifiers::CONTROL,
-            key_code: KeyCode::Char('z'),
-        }]);
+        let not_found = kb.find_sequence_binding(&[
+            sequence[0].clone(),
+            KeyCombination {
+                modifier: KeyModifiers::CONTROL,
+                key_code: KeyCode::Char('z'),
+            },
+        ]);
         assert_eq!(not_found, None);
     }
 }

--- a/src/edit_mode/mod.rs
+++ b/src/edit_mode/mod.rs
@@ -7,5 +7,5 @@ mod vi;
 pub use base::EditMode;
 pub use cursors::CursorConfig;
 pub use emacs::{default_emacs_keybindings, Emacs};
-pub use keybindings::Keybindings;
+pub use keybindings::{KeyCombination, Keybindings};
 pub use vi::{default_vi_insert_keybindings, default_vi_normal_keybindings, Vi};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ pub use prompt::{
 mod edit_mode;
 pub use edit_mode::{
     default_emacs_keybindings, default_vi_insert_keybindings, default_vi_normal_keybindings,
-    CursorConfig, EditMode, Emacs, Keybindings, Vi,
+    CursorConfig, EditMode, Emacs, KeyCombination, Keybindings, Vi,
 };
 
 mod highlighter;

--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -133,7 +133,7 @@ fn get_keybinding_strings(
 ) -> Vec<(String, String, String, String)> {
     let mut data: Vec<(String, String, String, String)> = keybindings
         .get_keybindings()
-        .iter()
+        .into_iter()
         .map(|(combination, event)| {
             (
                 mode.to_string(),


### PR DESCRIPTION
Adds basic support for adding multi-stroke (chord) keybindings, e.g.:

```rust
// Add chord bindings
// Ctrl+X Ctrl+C: Quit
keybindings.add_sequence_binding(
    &[ctrl('x'), ctrl('c')],
    ReedlineEvent::CtrlD,
);
```

Changes to public API:

* _(Breaking change)_ Remove the existing `pub` field of `Keybindings` so we can unify the implementation between single-keystroke bindings and multi-keystroke bindings.

  I did some [searching on GitHub](https://github.com/search?q=%22.keybindings%22+%22reedline%22+lang%3Arust+path%3A**%2F*.rs+%28NOT+is%3Afork%29+%28NOT+is%3Aarchived%29+-repo%3Anushell%2Fnushell+-repo%3Anushell%2Freedline&type=code) and couldn't immediately find specific cases that would be broken by this -- but of course, that doesn't prove it won't break a client. (Most of the search hits that came up seemed to be vendored/forked copies of `reedline` or `nushell`, or similar field names in different types.)
* Adds `Keybindings::add_sequence_binding()` and `Keybindings::remove_sequence_binding()` to bind (or unbind) a _sequence_ of 1 or more `KeyCombination`s to a `ReedlineEvent`; this supports both single-keystroke bindings and multi-keystroke chord-style bindings.
* Retains `Keybinding::add_binding()` and `Keybinding::remove_binding()` for backwards compatibility, replacing their bodies with simple wrapping calls to the new sequence-enlightened calls.

General approach:

* Do not allow a registered keystroke to be a strict prefix of another registered keystroke.
* Support arbitrarily long chords.
* Use a trie to store key bindings for efficient matching.
* Unify handling of single-keystroke keybindings with multiple-keystroke keybindings (do not special-case one vs. the other).
* Focus on `emacs` mode first; do not worry about aligning with existing multi-keystroke processing already present in vi mode for handling commands.

I'm looking for feedback on the general approach as well as the implementation before getting any deeper into this. For reference, I've demonstrated how this support could be used in `nushell` via [this commit in my `nushell` fork](https://github.com/reubeno/nushell/commit/ae4f46c2000459b767788f426d748c3f97269947). There's also a new example included in this draft PR to demonstrate and test.

_(Aside: This is my first feature-level contribution. I'm eager to get as much feedback as I can!)_
