### PR TITLE
fix(menu): Don't apply selected_text style to matched text in suggestions

### DIFF
--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -444,7 +444,10 @@ pub fn style_suggestion(
             let is_match = match_indices.contains(&(i + offset));
 
             if is_match && !prev_matched {
+                res.push_str(RESET);
+                res.push_str(&text_style_prefix);
                 res.push_str(&match_style_prefix);
+                res.push_str(escape);
             } else if !is_match && prev_matched && i != 0 {
                 res.push_str(RESET);
                 res.push_str(&text_style_prefix);
@@ -848,12 +851,15 @@ mod tests {
         let style2 = Style::new().on(Color::Green);
 
         let expected = format!(
-            "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+            "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
             text_style.prefix(),
             selected_style.prefix(),
             style1.prefix(),
             "ab",
-            match_style.paint("汉"),
+            RESET,
+            text_style.prefix(),
+            match_style.prefix(),
+            style1.paint("汉"),
             text_style.prefix(),
             selected_style.prefix(),
             style1.prefix(),
@@ -866,7 +872,10 @@ mod tests {
             text_style.prefix(),
             selected_style.prefix(),
             style2.prefix(),
-            match_style.paint("y̆👩🏾"),
+            RESET,
+            text_style.prefix(),
+            match_style.prefix(),
+            style2.paint("y̆👩🏾"),
             text_style.prefix(),
             selected_style.prefix(),
             style2.prefix(),
@@ -875,7 +884,12 @@ mod tests {
             selected_style.prefix(),
             RESET,
             "b@",
-            match_style.paint("r"),
+            RESET,
+            text_style.prefix(),
+            match_style.prefix(),
+            RESET,
+            "r",
+            RESET,
         );
         let match_indices = &[
             2, // 汉
@@ -899,7 +913,14 @@ mod tests {
         let text_style = Style::new().on(Color::Blue).bold();
         let match_style = Style::new().underline();
 
-        let expected = format!("{}{}{}", text_style.prefix(), "go", match_style.paint("o"),);
+        let expected = format!(
+            "{}{}{}{}{}",
+            text_style.prefix(),
+            "go",
+            RESET,
+            text_style.prefix(),
+            match_style.paint("o"),
+        );
         assert_eq!(
             expected,
             style_suggestion("goo", &[2, 3, 4, 6], &text_style, &match_style, None)


### PR DESCRIPTION
#798 broke completion menu highlighting, which included making it so that the `selected_text` style was applied to matched text. #991 tried fixing #798 but missed the matched text problem. This PR makes it so that matched text only has the `text` and `match`/`selected_match` styles applied to it.

This is just a temporary fix. This works for now because suggestion values can't contain ANSI escapes, but once we start allowing suggestions to provide a separate display value with ANSI escapes, we need to handle the Reset attribute (0). It would also be good to handle consecutive ANSI escapes, but that one's not necessary.

## Testing

Here's what Nushell looks like after this PR:

<img width="1124" height="283" alt="image" src="https://github.com/user-attachments/assets/eb3203b9-dafd-461b-b810-25fab000a84c" />

Nushell config:
```nu
  {
    name: completion_menu
    only_buffer_difference: false
    marker: $" \n❯ (char -u '1f4ce') "
    type: {
      layout: columnar
      columns: 4
      col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
      col_padding: 2
      tab_traversal: "vertical"   # Direction in which pressing <Tab> will cycle through options, "horizontal" or "vertical"
    }
    style: {
      text: { fg: "#33ff00" }
      selected_text: {attr: r}
      description_text: yellow
      match_text: {attr: u}
      selected_match_text: {fg: darkorange attr: b}
    }
  }
```