### PR TITLE
fix(IdeMenu): Don't make description position depend on description width

### DIFF
--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -721,11 +721,13 @@ impl Menu for IdeMenu {
             self.working_details.completion_width = completion_width;
 
             // Columns at which completion box begins
-            let mut completion_pos = self
+            let mut completion_pos = (self
                 .working_details
                 .cursor_col
-                .saturating_add_signed(self.default_details.cursor_offset)
-                .saturating_sub(total_border_width / 2);
+                .saturating_sub(total_border_width / 2)
+                as i16
+                + self.default_details.cursor_offset)
+                .max(0) as u16;
 
             if self.default_details.correct_cursor_pos {
                 let base_string = &self.working_details.shortest_base_string;


### PR DESCRIPTION
Goes towards fixing https://github.com/nushell/reedline/issues/995 (description box can change sides for every suggestion with the IdeMenu, causing seizures for photosensitive users)

This PR makes it so that which side the description box is on is not influenced by the description itself (only applicable when the `description_mode` is `PreferRight`, the default). This means that when scrolling down the list of completions, it will never change sides. The PR also fixes a bug where, if the description menu was on the left, it would sometimes push the completions box to the right, causing more motion.

### Breaking change

However, a breaking change caused by this is the change in the meaning of `min_description_width`. Previously, it was set to 0 by default, and now I'm setting it to 15 (arbitrary choice, open to changing it). Opened https://github.com/nushell/nushell/pull/17280 to update this on the Nushell side. I'm unsure what exactly its purpose was before, but it's now used as the threshold for deciding when to switch the description box to the left.

For example, if `min_description_width` is 15, then as long as we have 15 columns available on the right of the completions box, the description box can stay on the right. Once we have 14 or fewer columns available, the description box switches to the left. <s>Setting `min_description_width` to 0 would effectively force the description box to stay on the right.</s>

### Recordings

Here's a recording of what the default IdeMenu looks like in Nushell (warning: I decreased the playback speed but the recording includes scrolling down the menu, not sure if that can trigger seizures. Recommendation from alicealysia is to decrease window size first if you're photosensitive):

[![asciicast](https://asciinema.org/a/Xp5dRxilcvWxy0slaORyLiXFk.svg)](https://asciinema.org/a/Xp5dRxilcvWxy0slaORyLiXFk?t=10)

And here it is with `correct_cursor_pos: true`:
[![asciicast](https://asciinema.org/a/Co0PA6qM9KsDBoMRYg4muQorh.svg)](https://asciinema.org/a/Co0PA6qM9KsDBoMRYg4muQorh?t=3)