### PR TITLE
fix(IdeMenu): Use width instead of bytes/chars

### DIFF
--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -496,7 +496,7 @@ impl IdeMenu {
             .unwrap_or_default();
 
         let padding_right = (self.working_details.completion_width as usize)
-            .saturating_sub(suggestion.value.chars().count() + border_width + padding);
+            .saturating_sub(suggestion.value.width() + border_width + padding);
 
         let max_string_width =
             (self.working_details.completion_width as usize).saturating_sub(border_width + padding);
@@ -631,7 +631,7 @@ impl Menu for IdeMenu {
                 let start = floor_char_boundary(editor.get_buffer(), range.start).min(end);
                 editor.get_buffer()[start..end].to_string()
             })
-            .min_by_key(|s| s.len())
+            .min_by_key(|s| s.width())
             .unwrap_or_default();
 
         self.reset_position();
@@ -677,13 +677,12 @@ impl Menu for IdeMenu {
                 | MenuEvent::NextPage => {}
             }
 
-            self.longest_suggestion = self.get_values().iter().fold(0, |prev, suggestion| {
-                if prev >= suggestion.value.len() {
-                    prev
-                } else {
-                    suggestion.value.len()
-                }
-            });
+            self.longest_suggestion = self
+                .get_values()
+                .iter()
+                .map(|s| s.value.width())
+                .max()
+                .unwrap_or_default();
 
             let terminal_width = painter.screen_width();
 


### PR DESCRIPTION
Fixes https://github.com/nushell/reedline/issues/997

We were looking at number of bytes/chars to get the width of the suggestion values and base strings. This didn't work with multibyte characters. The fix is to use the Unicode width of these strings.

This is what the IDE menu looks like with suggestions containing `验` (a multibyte character)
```
~/reedline| he
             ╭────────────────────────────────────────────────╮
             │hello another very large option for hello wor...│
             │hello world 1                                   │
             │hello world 2                                   │
             │hello world another                             │
             │hello world reedline验                          │
             │hello world something                           │
             │hello world验验验                               │
             ╰────────────────────────────────────────────────╯
```

```
~/reedline| hello wo
                   ╭──────────────────────╮
                   │hello world 1         │
                   │hello world 2         │
                   │hello world another   │
                   │hello world reedline验│
                   │hello world something │
                   │hello world验验验     │
                   ╰──────────────────────╯
```