### PR TITLE
fix: Correctly handle longer first suggestion in find_common_string

### DIFF
--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -187,7 +187,7 @@ pub fn find_common_string(values: &[Suggestion]) -> Option<(&Suggestion, usize)>
                 .char_indices()
                 .zip(current_suggestion.value.chars())
                 .find_map(|((idx, lhs), rhs)| (rhs != lhs).then_some(idx))
-                .unwrap_or(max_len);
+                .unwrap_or(current_suggestion.value.len());
             if new_common_prefix_len == 0 {
                 Done(0)
             } else {
@@ -764,6 +764,7 @@ mod tests {
     // https://github.com/nushell/nushell/pull/16765#issuecomment-3384411809
     #[case::unsorted(vec!["a", "b", "ab"], 0)]
     #[case::should_be_case_sensitive(vec!["a", "A"], 0)]
+    #[case::first_suggestion_longest(vec!["foobar", "foo"], 3)]
     fn test_find_common_string(#[case] input: Vec<&str>, #[case] expected: usize) {
         let input: Vec<_> = input
             .into_iter()


### PR DESCRIPTION
Fixes https://github.com/nushell/nushell/issues/17326

The problem was that in `find_common_string`, if all your suggestions were prefixes of the first suggestion, then it would say that the entire prefix was the first suggestion.

This happens because for every suggestion (apart from the first), it tries to find a character that doesn't match the corresponding char in the first suggestion. However, if one of the suggestions is a prefix of the first suggestion, no such character will be found. In this case, it uses the first suggestion's length as the length of the shared prefix rather than the length of the suggestion currently being compared.

The fix is to use that other suggestion's length as the length of the shared prefix. This then goes into `cumulated_min.min()` to make sure that it's not longer than the previously computed shared prefix length.

## Testing

I typed in `foo qwer<TAB>` in Nushell and got the expected result:
<img width="948" height="156" alt="image" src="https://github.com/user-attachments/assets/1f332e5f-7c1e-4de8-846c-ddf1b6352b43" />
