### PR TITLE
feat(history): export HistoryItemExtraInfo etc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ unicode-width = "0.2"
 gethostname = "0.4.0"
 pretty_assertions = "1.4.0"
 rstest = { version = "0.23.0", default-features = false }
+serde_json = "1.0"
 tempfile = "3.3.0"
 
 [features]

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -121,3 +121,91 @@ impl HistoryItem {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Example custom extra info for testing.
+    /// Downstream crates can implement their own types like this.
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+    struct CustomExtraInfo {
+        mode: String,
+        tags: Vec<String>,
+    }
+
+    impl HistoryItemExtraInfo for CustomExtraInfo {}
+
+    #[test]
+    fn test_history_item_with_default_extra_info() {
+        let item = HistoryItem::from_command_line("echo hello");
+        assert_eq!(item.command_line, "echo hello");
+        assert!(item.more_info.is_none());
+    }
+
+    #[test]
+    fn test_history_item_with_custom_extra_info() {
+        let item: HistoryItem<CustomExtraInfo> = HistoryItem {
+            id: None,
+            start_timestamp: None,
+            command_line: "echo hello".to_string(),
+            session_id: None,
+            hostname: None,
+            cwd: None,
+            duration: None,
+            exit_status: None,
+            more_info: Some(CustomExtraInfo {
+                mode: "shell".to_string(),
+                tags: vec!["test".to_string()],
+            }),
+        };
+
+        assert_eq!(item.command_line, "echo hello");
+        let extra = item.more_info.unwrap();
+        assert_eq!(extra.mode, "shell");
+        assert_eq!(extra.tags, vec!["test".to_string()]);
+    }
+
+    #[test]
+    fn test_custom_extra_info_serialization() {
+        let item: HistoryItem<CustomExtraInfo> = HistoryItem {
+            id: Some(HistoryItemId::new(1)),
+            start_timestamp: None,
+            command_line: "ls -la".to_string(),
+            session_id: None,
+            hostname: None,
+            cwd: Some("/home/user".to_string()),
+            duration: None,
+            exit_status: Some(0),
+            more_info: Some(CustomExtraInfo {
+                mode: "r".to_string(),
+                tags: vec!["data".to_string(), "analysis".to_string()],
+            }),
+        };
+
+        // Serialize to JSON
+        let json = serde_json::to_string(&item).expect("serialization should succeed");
+        assert!(json.contains("\"mode\":\"r\""));
+        assert!(json.contains("\"tags\":[\"data\",\"analysis\"]"));
+
+        // Deserialize back
+        let deserialized: HistoryItem<CustomExtraInfo> =
+            serde_json::from_str(&json).expect("deserialization should succeed");
+        assert_eq!(deserialized.command_line, "ls -la");
+        assert_eq!(deserialized.more_info.as_ref().unwrap().mode, "r");
+    }
+
+    #[test]
+    fn test_ignore_all_extra_info_serialization() {
+        let item = HistoryItem::from_command_line("pwd");
+
+        // Serialize - more_info should be null
+        let json = serde_json::to_string(&item).expect("serialization should succeed");
+        assert!(json.contains("\"more_info\":null"));
+
+        // Deserialize back
+        let deserialized: HistoryItem =
+            serde_json::from_str(&json).expect("deserialization should succeed");
+        assert_eq!(deserialized.command_line, "pwd");
+    }
+}

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -11,6 +11,8 @@ pub use base::{
     CommandLineSearch, History, HistoryNavigationQuery, SearchDirection, SearchFilter, SearchQuery,
 };
 pub use cursor::HistoryCursor;
-pub use item::{HistoryItem, HistoryItemId, HistorySessionId};
+pub use item::{
+    HistoryItem, HistoryItemExtraInfo, HistoryItemId, HistorySessionId, IgnoreAllExtraInfo,
+};
 
 pub use file_backed::{FileBackedHistory, HISTORY_SIZE};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,9 +257,9 @@ mod history;
 #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
 pub use history::SqliteBackedHistory;
 pub use history::{
-    CommandLineSearch, FileBackedHistory, History, HistoryItem, HistoryItemId,
-    HistoryNavigationQuery, HistorySessionId, SearchDirection, SearchFilter, SearchQuery,
-    HISTORY_SIZE,
+    CommandLineSearch, FileBackedHistory, History, HistoryItem, HistoryItemExtraInfo,
+    HistoryItemId, HistoryNavigationQuery, HistorySessionId, IgnoreAllExtraInfo, SearchDirection,
+    SearchFilter, SearchQuery, HISTORY_SIZE,
 };
 
 mod prompt;


### PR DESCRIPTION
Hello, thank you for maintaining this great package.

I'm using this to create a console app, and I noticed that some things aren't currently publicly available, so I can't create a history of using `more_info` in downstream.
I suspect this was probably overlooked during development.

I'd appreciate it if you could make they public.