### PR TITLE
Add `libc` feature to enable crossterm's libc backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "libc",
  "mio",
  "parking_lot",
  "rustix 1.1.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ external_printer = ["crossbeam"]
 sqlite = ["rusqlite/bundled", "serde_json"]
 sqlite-dynlib = ["rusqlite", "serde_json"]
 system_clipboard = ["arboard"]
+libc = ["crossterm/libc"]
 
 [[example]]
 name = "cwd_aware_hinter"


### PR DESCRIPTION
This adds a `libc` feature that enables crossterm's `libc` feature, allowing reedline to work in environments where rustix's raw syscall approach fails.

## Motivation

When running under x86 emulation (e.g., CheerpX/WebVM, QEMU user-mode), reedline fails with:

```
Reedline error: Invalid argument (os error 22)
```

The root cause is that rustix uses the `TCGETS2` ioctl via raw syscalls, which some emulators don't implement. See:
- https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2133804

Crossterm has a `libc` feature that uses libc's `tcgetattr` instead, which falls back to `TCGETS` and works in these environments.

## Changes

- Adds `libc` feature that enables `crossterm/libc`

## Usage

```toml
reedline = { version = "...", features = ["libc"] }
```
