### PR TITLE
feat: Allow for user-defined "chord" / multi-key keybindings (and correct `vi` motions when targeting <space> char)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,7 @@ insert_keybindings.add_sequence_binding(
       key_code: KeyCode::Char('j'),
     },
   ],
-  ReedlineEvent::Multiple(vec![
-    ReedlineEvent::Esc,
-    ReedlineEvent::ViChangeMode("normal".into()),
-    ReedlineEvent::Repaint,
-  ]),
+  ReedlineEvent::ViExitToNormalMode,
 );
 
 let edit_mode = Box::new(Vi::new(

--- a/README.md
+++ b/README.md
@@ -84,6 +84,45 @@ let edit_mode = Box::new(Emacs::new(keybindings));
 let mut line_editor = Reedline::create().with_edit_mode(edit_mode);
 ```
 
+### Integrate with key sequences
+
+```rust
+// Configure reedline with key sequence bindings (like "jj" in vi insert mode)
+
+use {
+  crossterm::event::{KeyCode, KeyModifiers},
+  reedline::{
+    default_vi_insert_keybindings, default_vi_normal_keybindings, KeyCombination, Reedline,
+    ReedlineEvent, Vi,
+  },
+};
+
+let mut insert_keybindings = default_vi_insert_keybindings();
+insert_keybindings.add_sequence_binding(
+  vec![
+    KeyCombination {
+      modifier: KeyModifiers::NONE,
+      key_code: KeyCode::Char('j'),
+    },
+    KeyCombination {
+      modifier: KeyModifiers::NONE,
+      key_code: KeyCode::Char('j'),
+    },
+  ],
+  ReedlineEvent::Multiple(vec![
+    ReedlineEvent::Esc,
+    ReedlineEvent::ViChangeMode("normal".into()),
+    ReedlineEvent::Repaint,
+  ]),
+);
+
+let edit_mode = Box::new(Vi::new(
+  insert_keybindings,
+  default_vi_normal_keybindings(),
+));
+let mut line_editor = Reedline::create().with_edit_mode(edit_mode);
+```
+
 ### Integrate with `History`
 
 ```rust,no_run

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -1445,6 +1445,7 @@ mod test {
     }
 
     #[rstest]
+    #[case("abc def", 0, ' ', true, 3)]
     #[case("abc def ghi", 0, 'c', true, 2)]
     #[case("abc def ghi", 0, 'a', true, 0)]
     #[case("abc def ghi", 0, 'z', true, 0)]
@@ -1471,6 +1472,7 @@ mod test {
     }
 
     #[rstest]
+    #[case("abc def", 0, ' ', true, 2)]
     #[case("abc def ghi", 0, 'd', true, 3)]
     #[case("abc def ghi", 3, 'd', true, 3)]
     #[case("a😇c", 0, 'c', true, 1)]
@@ -1513,6 +1515,7 @@ mod test {
     }
 
     #[rstest]
+    #[case("abc def", 0, ' ', true, " def")]
     #[case("abc def ghi", 0, 'b', true, "bc def ghi")]
     #[case("abc def ghi", 0, 'i', true, "i")]
     #[case("abc def ghi", 0, 'z', true, "abc def ghi")]

--- a/src/edit_mode/base.rs
+++ b/src/edit_mode/base.rs
@@ -18,4 +18,14 @@ pub trait EditMode: Send {
     fn handle_mode_specific_event(&mut self, _event: ReedlineEvent) -> EventStatus {
         EventStatus::Inapplicable
     }
+
+    /// Whether a key sequence is currently pending
+    fn has_pending_sequence(&self) -> bool {
+        false
+    }
+
+    /// Flush any pending key sequence and return the resulting event
+    fn flush_pending_sequence(&mut self) -> Option<ReedlineEvent> {
+        None
+    }
 }

--- a/src/edit_mode/base.rs
+++ b/src/edit_mode/base.rs
@@ -1,7 +1,10 @@
 use crate::{
     enums::{EventStatus, ReedlineEvent, ReedlineRawEvent},
-    PromptEditMode,
+    EditCommand, PromptEditMode,
 };
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+use super::{keybindings, KeyCombination};
 
 /// Define the style of parsing for the edit events
 /// Available default options:
@@ -9,7 +12,56 @@ use crate::{
 /// - Vi
 pub trait EditMode: Send {
     /// Translate the given user input event into what the `LineEditor` understands
-    fn parse_event(&mut self, event: ReedlineRawEvent) -> ReedlineEvent;
+    fn parse_event(&mut self, event: ReedlineRawEvent) -> ReedlineEvent {
+        match event.into() {
+            Event::Key(KeyEvent {
+                code, modifiers, ..
+            }) => self.parse_key_event(modifiers, code),
+            other => self.parse_non_key_event(other),
+        }
+    }
+
+    /// Translate key events into what the `LineEditor` understands
+    fn parse_key_event(&mut self, modifiers: KeyModifiers, code: KeyCode) -> ReedlineEvent;
+
+    /// Resolve a key combination using keybindings with a fallback to insertable characters.
+    fn default_key_event(
+        &self,
+        keybindings: &keybindings::Keybindings,
+        combo: KeyCombination,
+    ) -> ReedlineEvent {
+        match combo.key_code {
+            KeyCode::Char(c) => keybindings
+                .find_binding(combo.modifier, KeyCode::Char(c))
+                .unwrap_or_else(|| {
+                    if combo.modifier == KeyModifiers::NONE
+                        || combo.modifier == KeyModifiers::SHIFT
+                        || combo.modifier == KeyModifiers::CONTROL | KeyModifiers::ALT
+                        || combo.modifier
+                            == KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
+                    {
+                        ReedlineEvent::Edit(vec![EditCommand::InsertChar(
+                            if combo.modifier == KeyModifiers::SHIFT {
+                                c.to_ascii_uppercase()
+                            } else {
+                                c
+                            },
+                        )])
+                    } else {
+                        ReedlineEvent::None
+                    }
+                }),
+            code => keybindings
+                .find_binding(combo.modifier, code)
+                .unwrap_or_else(|| {
+                    if combo.modifier == KeyModifiers::NONE && code == KeyCode::Enter {
+                        ReedlineEvent::Enter
+                    } else {
+                        ReedlineEvent::None
+                    }
+                }),
+        }
+    }
 
     /// What to display in the prompt indicator
     fn edit_mode(&self) -> PromptEditMode;
@@ -17,6 +69,45 @@ pub trait EditMode: Send {
     /// Handles events that apply only to specific edit modes (e.g changing vi mode)
     fn handle_mode_specific_event(&mut self, _event: ReedlineEvent) -> EventStatus {
         EventStatus::Inapplicable
+    }
+
+    /// Translate non-key events into what the `LineEditor` understands
+    fn parse_non_key_event(&mut self, event: Event) -> ReedlineEvent {
+        match event {
+            Event::Key(KeyEvent {
+                code, modifiers, ..
+            }) => self.parse_key_event(modifiers, code),
+            Event::Mouse(_) => self.with_flushed_sequence(ReedlineEvent::Mouse),
+            Event::Resize(width, height) => {
+                self.with_flushed_sequence(ReedlineEvent::Resize(width, height))
+            }
+            Event::FocusGained => self.with_flushed_sequence(ReedlineEvent::None),
+            Event::FocusLost => self.with_flushed_sequence(ReedlineEvent::None),
+            Event::Paste(body) => {
+                self.with_flushed_sequence(ReedlineEvent::Edit(vec![EditCommand::InsertString(
+                    body.replace("\r\n", "\n").replace('\r', "\n"),
+                )]))
+            }
+        }
+    }
+
+    /// Flush pending sequences and combine them with an incoming event.
+    fn with_flushed_sequence(&mut self, event: ReedlineEvent) -> ReedlineEvent {
+        let Some(flush_event) = self.flush_pending_sequence() else {
+            return event;
+        };
+
+        if matches!(event, ReedlineEvent::None) {
+            return flush_event;
+        }
+
+        match flush_event {
+            ReedlineEvent::Multiple(mut events) => {
+                events.push(event);
+                ReedlineEvent::Multiple(events)
+            }
+            other => ReedlineEvent::Multiple(vec![other, event]),
+        }
     }
 
     /// Whether a key sequence is currently pending

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -126,10 +126,11 @@ impl EditMode for Emacs {
             }) => {
                 let combo = Self::normalize_key_combo(modifiers, code);
                 let keybindings = &self.keybindings;
-                self.sequence_state
-                    .process_combo(keybindings, combo, |combo| {
-                        Self::single_key_event(keybindings, combo)
-                    })
+                let resolution = self
+                    .sequence_state
+                    .process_combo(keybindings, combo);
+                resolution
+                    .into_event(|combo| Self::single_key_event(keybindings, combo))
                     .unwrap_or(ReedlineEvent::None)
             }
 
@@ -157,8 +158,8 @@ impl EditMode for Emacs {
 
     fn flush_pending_sequence(&mut self) -> Option<ReedlineEvent> {
         let keybindings = &self.keybindings;
-        self.sequence_state
-            .flush(|combo| Self::single_key_event(keybindings, combo))
+        let resolution = self.sequence_state.flush_with_combos();
+        resolution.into_event(|combo| Self::single_key_event(keybindings, combo))
     }
 }
 

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use crossterm::event::{KeyCode, KeyModifiers};
 
-
 /// Returns the current default emacs keybindings
 pub fn default_emacs_keybindings() -> Keybindings {
     use EditCommand as EC;

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -226,12 +226,7 @@ impl KeySequenceState {
         self.buffer.push(combo);
         let mut resolution = SequenceResolution::default();
 
-        loop {
-            match self.process_step(keybindings, &mut resolution) {
-                StepOutcome::Continue => continue,
-                StepOutcome::EmitDone | StepOutcome::Pending | StepOutcome::Done => break,
-            }
-        }
+        while let StepOutcome::Continue = self.process_step(keybindings, &mut resolution) { }
 
         if self.buffer.is_empty() {
             self.pending_exact = None;

--- a/src/edit_mode/mod.rs
+++ b/src/edit_mode/mod.rs
@@ -7,5 +7,5 @@ mod vi;
 pub use base::EditMode;
 pub use cursors::CursorConfig;
 pub use emacs::{default_emacs_keybindings, Emacs};
-pub use keybindings::Keybindings;
+pub use keybindings::{KeyCombination, KeySequence, KeySequenceState, Keybindings};
 pub use vi::{default_vi_insert_keybindings, default_vi_normal_keybindings, Vi};

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -12,9 +12,7 @@ use self::motion::ViCharSearch;
 
 use super::EditMode;
 use crate::{
-    edit_mode::{keybindings::Keybindings, vi::parser::parse, KeyCombination, KeySequenceState},
-    enums::{EventStatus, ReedlineEvent},
-    PromptEditMode, PromptViMode,
+    edit_mode::{keybindings::Keybindings, vi::parser::parse, KeyCombination, KeySequenceState}, enums::{EventStatus, ReedlineEvent}, PromptEditMode, PromptViMode
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -66,7 +64,7 @@ impl Vi {
         visual_keybindings.add_binding(
             KeyModifiers::NONE,
             KeyCode::Esc,
-            ReedlineEvent::ViExitToNormalMode,
+            ReedlineEvent::ViChangeMode("normal".into()),
         );
         let _ = visual_keybindings.remove_binding(KeyModifiers::NONE, KeyCode::Char('v'));
 
@@ -129,7 +127,6 @@ impl EditMode for Vi {
             ReedlineEvent::ViChangeMode(mode_str) => ViMode::from_str(&mode_str)
                 .map(|mode| self.set_mode(mode))
                 .unwrap_or(EventStatus::Inapplicable),
-            ReedlineEvent::ViExitToNormalMode => self.set_mode(ViMode::Normal),
             _ => EventStatus::Inapplicable,
         }
     }
@@ -239,7 +236,7 @@ mod test {
                 .unwrap();
         let result = vi.parse_event(esc);
 
-        assert_eq!(result, ReedlineEvent::ViExitToNormalMode);
+        assert_eq!(result, ReedlineEvent::ViChangeMode("normal".into()));
     }
 
     #[test]
@@ -357,7 +354,7 @@ mod test {
     #[test]
     fn insert_sequence_binding_emits_event() {
         let mut insert_keybindings = default_vi_insert_keybindings();
-        let exit_event = ReedlineEvent::ViExitToNormalMode;
+        let exit_event = ReedlineEvent::ViChangeMode("normal".into());
         insert_keybindings.add_sequence_binding(
             vec![
                 KeyCombination {

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -12,7 +12,9 @@ use self::motion::ViCharSearch;
 
 use super::EditMode;
 use crate::{
-    edit_mode::{keybindings::Keybindings, vi::parser::parse, KeyCombination, KeySequenceState}, enums::{EventStatus, ReedlineEvent}, PromptEditMode, PromptViMode
+    edit_mode::{keybindings::Keybindings, vi::parser::parse, KeyCombination, KeySequenceState},
+    enums::{EventStatus, ReedlineEvent},
+    PromptEditMode, PromptViMode,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -52,7 +52,11 @@ pub fn default_vi_insert_keybindings() -> Keybindings {
     add_common_navigation_bindings(&mut kb);
     add_common_edit_bindings(&mut kb);
     add_common_selection_bindings(&mut kb);
-    kb.add_binding(KM::NONE, KC::Esc, ReedlineEvent::ViChangeMode("normal".into()));
+    kb.add_binding(
+        KM::NONE,
+        KC::Esc,
+        ReedlineEvent::ViChangeMode("normal".into()),
+    );
 
     kb
 }

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         Keybindings,
     },
-    EditCommand,
+    EditCommand, ReedlineEvent,
 };
 
 /// Default Vi normal keybindings
@@ -28,6 +28,16 @@ pub fn default_vi_normal_keybindings() -> Keybindings {
         edit_bind(EC::MoveLeft { select: false }),
     );
     kb.add_binding(KM::NONE, KC::Delete, edit_bind(EC::Delete));
+    kb.add_binding(KM::NONE, KC::Esc, ReedlineEvent::Repaint);
+    kb.add_binding(
+        KM::NONE,
+        KC::Char('v'),
+        ReedlineEvent::Multiple(vec![
+            ReedlineEvent::Esc,
+            ReedlineEvent::ViChangeMode("visual".to_string()),
+            ReedlineEvent::Repaint,
+        ]),
+    );
 
     kb
 }
@@ -35,11 +45,14 @@ pub fn default_vi_normal_keybindings() -> Keybindings {
 /// Default Vi insert keybindings
 pub fn default_vi_insert_keybindings() -> Keybindings {
     let mut kb = Keybindings::new();
+    use KeyCode as KC;
+    use KeyModifiers as KM;
 
     add_common_control_bindings(&mut kb);
     add_common_navigation_bindings(&mut kb);
     add_common_edit_bindings(&mut kb);
     add_common_selection_bindings(&mut kb);
+    kb.add_binding(KM::NONE, KC::Esc, ReedlineEvent::ViExitToNormalMode);
 
     kb
 }

--- a/src/edit_mode/vi/vi_keybindings.rs
+++ b/src/edit_mode/vi/vi_keybindings.rs
@@ -52,7 +52,7 @@ pub fn default_vi_insert_keybindings() -> Keybindings {
     add_common_navigation_bindings(&mut kb);
     add_common_edit_bindings(&mut kb);
     add_common_selection_bindings(&mut kb);
-    kb.add_binding(KM::NONE, KC::Esc, ReedlineEvent::ViExitToNormalMode);
+    kb.add_binding(KM::NONE, KC::Esc, ReedlineEvent::ViChangeMode("normal".into()));
 
     kb
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -833,9 +833,6 @@ pub enum ReedlineEvent {
 
     /// Change mode (vi mode only)
     ViChangeMode(String),
-
-    /// Exit vi insert/visual mode to normal
-    ViExitToNormalMode,
 }
 
 impl Display for ReedlineEvent {
@@ -880,7 +877,6 @@ impl Display for ReedlineEvent {
             ReedlineEvent::ExecuteHostCommand(_) => write!(f, "ExecuteHostCommand"),
             ReedlineEvent::OpenEditor => write!(f, "OpenEditor"),
             ReedlineEvent::ViChangeMode(_) => write!(f, "ViChangeMode mode: <string>"),
-            ReedlineEvent::ViExitToNormalMode => write!(f, "ViExitToNormalMode"),
         }
     }
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -833,6 +833,9 @@ pub enum ReedlineEvent {
 
     /// Change mode (vi mode only)
     ViChangeMode(String),
+
+    /// Exit vi insert/visual mode to normal
+    ViExitToNormalMode,
 }
 
 impl Display for ReedlineEvent {
@@ -877,6 +880,7 @@ impl Display for ReedlineEvent {
             ReedlineEvent::ExecuteHostCommand(_) => write!(f, "ExecuteHostCommand"),
             ReedlineEvent::OpenEditor => write!(f, "OpenEditor"),
             ReedlineEvent::ViChangeMode(_) => write!(f, "ViChangeMode mode: <string>"),
+            ReedlineEvent::ViExitToNormalMode => write!(f, "ViExitToNormalMode"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,11 +84,7 @@
 //!       key_code: KeyCode::Char('j'),
 //!     },
 //!   ],
-//!   ReedlineEvent::Multiple(vec![
-//!     ReedlineEvent::Esc,
-//!     ReedlineEvent::ViChangeMode("normal".into()),
-//!     ReedlineEvent::Repaint,
-//!   ]),
+//!   ReedlineEvent::ViExitToNormalMode,
 //! );
 //!
 //! let edit_mode = Box::new(Vi::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
 //!       key_code: KeyCode::Char('j'),
 //!     },
 //!   ],
-//!   ReedlineEvent::ViExitToNormalMode,
+//!   ReedlineEvent::ViChangeMode("normal".into()),
 //! );
 //!
 //! let edit_mode = Box::new(Vi::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,45 @@
 //! let mut line_editor = Reedline::create().with_edit_mode(edit_mode);
 //! ```
 //!
+//! ## Integrate with key sequences
+//!
+//! ```rust
+//! // Configure reedline with key sequence bindings (like "jj" in vi insert mode)
+//!
+//! use {
+//!   crossterm::event::{KeyCode, KeyModifiers},
+//!   reedline::{
+//!     default_vi_insert_keybindings, default_vi_normal_keybindings, KeyCombination, Reedline,
+//!     ReedlineEvent, Vi,
+//!   },
+//! };
+//!
+//! let mut insert_keybindings = default_vi_insert_keybindings();
+//! insert_keybindings.add_sequence_binding(
+//!   vec![
+//!     KeyCombination {
+//!       modifier: KeyModifiers::NONE,
+//!       key_code: KeyCode::Char('j'),
+//!     },
+//!     KeyCombination {
+//!       modifier: KeyModifiers::NONE,
+//!       key_code: KeyCode::Char('j'),
+//!     },
+//!   ],
+//!   ReedlineEvent::Multiple(vec![
+//!     ReedlineEvent::Esc,
+//!     ReedlineEvent::ViChangeMode("normal".into()),
+//!     ReedlineEvent::Repaint,
+//!   ]),
+//! );
+//!
+//! let edit_mode = Box::new(Vi::new(
+//!   insert_keybindings,
+//!   default_vi_normal_keybindings(),
+//! ));
+//! let mut line_editor = Reedline::create().with_edit_mode(edit_mode);
+//! ```
+//!
 //! ## Integrate with [`History`]
 //!
 //! ```rust,no_run
@@ -262,7 +301,7 @@ pub use prompt::{
 mod edit_mode;
 pub use edit_mode::{
     default_emacs_keybindings, default_vi_insert_keybindings, default_vi_normal_keybindings,
-    CursorConfig, EditMode, Emacs, Keybindings, Vi,
+    CursorConfig, EditMode, Emacs, KeyCombination, KeySequence, Keybindings, Vi,
 };
 
 mod highlighter;


### PR DESCRIPTION
I care a great deal about nushell's vi mode support. I got myself addicted to "jj" to exit vi normal mode in basically all cli tools with a vi mode -- without it, I feel like I've lost my fingers!

A while back, I proposed https://github.com/nushell/reedline/pull/670. Since `reedline` does not support multi-key "chords," I special-cased logic into `vi/mod.rs` to listen for repeated keypresses in insert mode for a designated "exit-insert-mode" trigger. 

The feedback led to a [broader discussion](https://github.com/nushell/reedline/issues/853). The main gist (as I understood it at the time) was that we should not _special-case_ this logic; ideally, we would generalize this functionality to enable other kinds of user-defined key chords.

In the meantime, I've been maintaining a personal `reedline` fork with this special-case logic. It's fulfilled my needs, but is kind of a PITA. So: I thought why not take another stab?

_Full disclosure: I've been trying to experiment with LSP-informed LLM code generation for languages with well-developed type systems (eg through something like rust LSP w/ opencode). The first draft of this PR was predominantly LLM generated, but I have reviewed the changes & [am test-driving this as my daily-driver shell](https://github.com/benvansleen/nix/commit/d1a19a96690b1cbdaaaaeab25273c6c8d10b3111)._

## User-facing changes
- Update `ReedlineEvent:ViChangeMode` handling to better mimic vi/vim behavior (eg when moving from insert -> normal modes, the cursor should move left 1 char)
- Editors (both `emacs` and `vi`) now track a sequence state of keypresses
  - When a chord prefix is entered, the editor now holds this input awaiting the next key in the chord
  - If no key is pressed (after a configurable timeout) or the chord is not successfully completed, the buffered key combinations are flushed to the line
- (Tangentially related bugfix) vi mode parsing is modified s.t. pending commands (eg. f, t, d) always consume the next character as a motion target -- **even when it's a space**
  - Right now, `f<space>` does not behave as expected in nushell; it basically inserts a space at b.o.l. and jacks up the undo buffer

### What does this achieve for `nushell`?
in `nu-cli/src/reedline_config.rs`, you could:
```rust
    let mut insert_keybindings = default_vi_insert_keybindings();
    insert_keybindings.add_sequence_binding(
        vec![
            KeyCombination {
                modifier: KeyModifiers::NONE,
                key_code: KeyCode::Char('j'),
            },
            KeyCombination {
                modifier: KeyModifiers::NONE,
                key_code: KeyCode::Char('j'),
            },
        ],
        ReedlineEvent::ViChangeMode("normal".into()),
    );
```

Obviously, this would be better configured as part of the user's nushell startup script. If this PR is approved / we like this direction, I'll submit work on the nushell side to allow for configuring `$env.config.keybindings` accordingly.

### How does it work?

```
                        +-------------------------+
                        |        Keybindings      |
                        |-------------------------|
                        | bindings (single-key)   |
                        | sequence_bindings       |
                        +-----------+-------------+
                                    |
                                    | sequence_match(&[KeyCombination])
                                    v
+-------------------------+   process_combo()   +----------------------+
|     KeySequenceState    |------------------------------->|  SequenceResolution  |
|-------------------------|                                |----------------------|
| buffer: Vec<KeyCombination>                              | events: Vec<ReedlineEvent>
| pending_exact: Option<(usize, ReedlineEvent)>            | combos: Vec<KeyCombination>
+-------------------------+                                +----------+-----------+
                                                                      |
                                                                      | into_event(fallback)
                                                                      v
                                                             +------------------+
                                                             |  ReedlineEvent   |
                                                             | (None / Edit /   |
                                                             |  Multiple / ...) |
                                                             +------------------+
```

Key event flow (Emacs / Vi):
  KeyEvent -> normalize -> KeyCombination
         -> KeySequenceState.process_combo(...)
         -> SequenceResolution.into_event(|combo| fallback(combo))
         -> ReedlineEvent returned to engine
Notes:
- `pending_exact` holds an exact match that is also a prefix of a longer sequence.
  If the longer sequence fails, we emit the saved event and keep trailing keys.
- `SequenceResolution.events` = matched sequences
- `SequenceResolution.combos` = raw keys to replay through fallback
- `into_event` combines both into a single ReedlineEvent
Vi specifics:
- fallback(combo) routes into vi parser when a command is pending,
  so `combos` can be re-fed into vi’s grammar instead of becoming edits.
Timeout path:
  Engine timeout -> EditMode.flush_pending_sequence()
                 -> KeySequenceState.flush_with_combos()
                 -> SequenceResolution.into_event(...)
                 -> ReedlineEvent

<details><summary>Walking through an example!</summary>
<p>

Scenario: insert mode, sequence binding `j j` → `ViChangeMode("normal".into())`
Initial state:
- `KeySequenceState.buffer = []`
- `pending_exact = None`
- `sequence_bindings contains [j, j] -> ViChangeMode("normal".into())`
```
Step 1: user presses j

process_combo([j])
  buffer = [j]
  sequence_match([j]) -> Prefix (matches the start of [j,j])
  resolution:
    events = []
    combos = []
  buffer not empty → pending state is implicit
into_event(fallback) -> None
Result:
- No event yet; editor waits for more input.
```
Step 2: user presses j again
```
process_combo([j, j])
  buffer = [j, j]
  sequence_match([j, j]) -> Exact
  resolution:
    events = [ViChangeMode("normal".into())]
    combos = []
  buffer cleared
into_event(fallback) -> ViChangeMode("normal".into())
```
Result:
- `ViChangeMode("normal".into())` is emitted immediately.
- Engine handles it: clears selection/menus, switches mode to normal, repaints, and (if coming from insert) moves cursor left.
Step 3: If the user doesn’t press another key
- The engine’s timeout will flush any pending sequence.
- Since the buffer is empty after the exact match, nothing else happens.
Failure/timeout example:
- If user presses a single j and waits beyond the timeout:
  - flush_with_combos() returns combos = [j].
  - into_event(fallback) maps that combo through the normal insert fallback, inserting j.

</p>
</details> 