### PR TITLE
refactor: Extract shared layout computation from painter

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2122,10 +2122,7 @@ mod tests {
             menu_start_row: None,
             large_buffer_extra_rows_after_prompt: None,
             large_buffer_offset: None,
-            right_prompt_rendered: false,
-            right_prompt_row: None,
-            right_prompt_start_col: None,
-            right_prompt_end_col: None,
+            right_prompt: None,
         });
 
         let result = reedline.handle_event(


### PR DESCRIPTION
- Introduce `PromptLayout` struct computed once per paint cycle in `compute_layout`, eliminating duplicated layout math across `print_large_buffer`, `print_right_prompt`, `print_menu`, and `render_snapshot`
- Fix bug where `render_snapshot` rendered the right prompt for large buffers even when the prompt had scrolled off-screen (`extra_rows > 0`), diverging from `print_large_buffer` which correctly suppressed it
- Add 7 unit tests covering `compute_layout` (small/large buffer, right prompt visibility, scrolling math, multi-line prompt)

## Motivation

`render_snapshot` duplicated layout calculations from `print_large_buffer`, `print_right_prompt`, and `print_menu`. Any change to one had to be mirrored in the other, and they had already drifted (the right-prompt suppression bug).

## Changes

### `src/painting/painter.rs`
- Add `PromptLayout` struct holding all layout values: extra rows, large buffer offset, right prompt bounds, menu start row, first buffer column
- Add `Painter::compute_layout()` that consolidates the 5 duplicated computations into a single call
- Add `Painter::last_layout` field storing the layout from the most recent paint cycle
- Update `repaint_buffer` to call `compute_layout` and thread the result through `print_large_buffer`, `print_small_buffer`, `print_right_prompt`, and `print_menu`
- Simplify `render_snapshot` to copy values from the layout instead of recomputing them
