### PR TITLE
feat(emacs): add keybindings for moving to start and end of buffer

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -86,6 +86,16 @@ pub fn default_emacs_keybindings() -> Keybindings {
             edit_bind(EC::MoveWordRight { select: false }),
         ]),
     );
+    kb.add_binding(
+        KM::ALT,
+        KC::Char('<'),
+        edit_bind(EC::MoveToStart { select: false }),
+    );
+    kb.add_binding(
+        KM::ALT,
+        KC::Char('>'),
+        edit_bind(EC::MoveToEnd { select: false }),
+    );
     // Edits
     kb.add_binding(KM::ALT, KC::Delete, edit_bind(EC::DeleteWord));
     kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));


### PR DESCRIPTION
Implements the standard Emacs shortcuts `Alt+<` and `Alt+>` to quickly navigate the cursor.

- Alt+<: Move to the start of the buffer
- Alt+>: Move to the end of the buffer