### PR TITLE
fix: use LF instead of CRLF in insert_newline on Windows

### DIFF
--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -1117,6 +1117,32 @@ mod test {
     }
 
     #[rstest]
+    #[case("hello", 5, "hello\n", 6)]
+    #[case("hello", 0, "\nhello", 1)]
+    #[case("hello", 3, "hel\nlo", 4)]
+    #[case("line1\nline2", 11, "line1\nline2\n", 12)]
+    #[case("", 0, "\n", 1)]
+    fn insert_newline_inserts_lf_only(
+        #[case] input: &str,
+        #[case] in_location: usize,
+        #[case] output: &str,
+        #[case] out_location: usize,
+    ) {
+        let mut line_buffer = buffer_with(input);
+        line_buffer.set_insertion_point(in_location);
+
+        line_buffer.insert_newline();
+
+        assert_eq!(line_buffer.get_buffer(), output);
+        assert!(
+            !line_buffer.get_buffer().contains('\r'),
+            "Buffer should never contain CR"
+        );
+        assert_eq!(line_buffer.insertion_point(), out_location);
+        line_buffer.assert_valid();
+    }
+
+    #[rstest]
     #[case("new string", 10)]
     #[case("new line1\nnew line 2", 20)]
     fn set_buffer_updates_insertion_point_to_new_buffer_length(


### PR DESCRIPTION
`LineBuffer::insert_newline()` currently inserts CRLF (`\r\n`) on Windows and LF (`\n`) elsewhere.
This change makes it always insert LF on all platforms.

## Background

I use reedline as the line editor in [arf](https://github.com/eitsupi/arf), an R console. R's parser treats `\r` as an invalid token, so any CR characters in the input buffer cause parse errors.
I currently have to strip CR from the buffer after `read_line()` returns, but this is a workaround for what appears to be an unnecessary platform distinction in reedline itself.

## Why the CRLF insertion is unnecessary

The Windows-specific CRLF was introduced in #399 with the rationale of using the "system newline separator."
However, reedline's own architecture already handles the LF→CRLF conversion at the display layer, making the buffer-level CRLF both redundant and inconsistent with the rest of the codebase:

### 1. The painting layer already handles CRLF conversion

`coerce_crlf()` converts bare LF to CRLF right before writing to the terminal.
https://github.com/nushell/reedline/blob/99764ee6d6b05a3ce4b31eb8797c5d68b277d054/src/painting/utils.rs#L8-L33

This is applied to all `Print()` calls in `painter.rs`. The buffer is meant to store logical content (LF only), and the display layer adapts it for the terminal.

### 2. All line-counting logic assumes LF only

The rendering code exclusively uses `\n` for line operations:

- `skip_buffer_lines()` uses `string.match_indices('\n')` and `trim_end_matches('\n')`
  https://github.com/nushell/reedline/blob/99764ee6d6b05a3ce4b31eb8797c5d68b277d054/src/painting/painter.rs#L53-L54
- `estimate_required_lines()` uses `.lines()` (which splits on `\n`)
- `screen_to_buffer_offset()` checks `if grapheme == "\n"`
  https://github.com/nushell/reedline/blob/99764ee6d6b05a3ce4b31eb8797c5d68b277d054/src/painting/painter.rs#L640

A `\r` in the buffer is invisible to these calculations, which could lead to off-by-one errors in cursor positioning on Windows.

### 3. Previous fix established that CR in the buffer is harmful

#262 explicitly removed CRLF insertion from the hinter logic, noting:

> Carriage returns, that are not introduced at the end of the line as part of the painter or the OS convention, break the painting of multilines, as the cursor position might jump to the start of the multiline continuation prompt and start painting from there!

The same reasoning applies to `insert_newline()` — it inserts CR into the buffer outside the painting layer.

### 4. Nushell's parser works around this

Nushell's lexer explicitly ignores standalone `\r`:
https://github.com/nushell/nushell/blob/10a932e0c9e8e8715ccad006594a70fc83a492d3/crates/nu-parser/src/lex.rs#L633-L637

```rust
        } else if c == b'\r' {
            // Ignore a stand-alone carriage return
            curr_offset += 1;
        } else if c == b'\n' {
            // If the next character is a newline, we're looking at an EOL (end of line) token.
```

This suggests the CRLF in the buffer is not useful to nushell either — it's simply tolerated.

## What this changes

- `insert_newline()` now always inserts `\n`, removing the `#[cfg(target_os = "windows")]` branch
- No change to the painting layer — `coerce_crlf()` continues to handle terminal output