### PR TITLE
revert osc133;P to osc133;A

### DIFF
--- a/examples/semantic_prompt_verify.rs
+++ b/examples/semantic_prompt_verify.rs
@@ -26,11 +26,11 @@ fn main() {
     println!();
 
     // Show expected sequence
-    println!("Expected Prompt Sequence: (133;A is oveerridden with P to avoid newline issues)");
+    println!("Expected Prompt Sequence: ");
     println!("------------------------");
     println!("For a prompt like: '~/src > ls -la'");
     println!();
-    println!("1. prompt_start(Primary)  -> OSC 133;P;k=i ST  (before '~/src ')");
+    println!("1. prompt_start(Primary)  -> OSC 133;A;k=i ST  (before '~/src ')");
     println!("2. [left prompt text]     -> '~/src '");
     println!("3. [indicator text]       -> '> '");
     println!("4. command_input_start()  -> OSC 133;B ST     (after indicator)");
@@ -43,7 +43,7 @@ fn main() {
     println!("----------------------");
     println!("For a multiline prompt continuation:");
     println!();
-    println!("1. prompt_start(Secondary) -> OSC 133;P;k=s ST (before '::: ')");
+    println!("1. prompt_start(Secondary) -> OSC 133;A;k=s ST (before '::: ')");
     println!("2. [continuation indicator] -> '::: '");
     println!("3. command_input_start()   -> OSC 133;B ST    (after indicator)");
     println!();
@@ -52,11 +52,11 @@ fn main() {
     println!("Raw Byte Sequences:");
     println!("------------------");
     print_raw(
-        "OSC 133;P;k=i ST",
+        "OSC 133;A;k=i ST",
         &osc133.prompt_start(PromptKind::Primary),
     );
     print_raw(
-        "OSC 133;P;k=s ST",
+        "OSC 133;A;k=s ST",
         &osc133.prompt_start(PromptKind::Secondary),
     );
     print_raw("OSC 133;P;k=r ST", &osc133.prompt_start(PromptKind::Right));
@@ -67,17 +67,12 @@ fn main() {
 }
 
 fn show_markers(markers: &dyn SemanticPromptMarkers, prefix: &str) {
-    let pre = match prefix {
-        "133" => "133;P",
-        "633" => "633;A",
-        _ => prefix,
-    };
     println!(
-        "  Primary prompt start:   OSC {pre};k=i ST = {}",
+        "  Primary prompt start:   OSC {prefix};A;k=i ST = {}",
         escape_for_display(&markers.prompt_start(PromptKind::Primary))
     );
     println!(
-        "  Secondary prompt start: OSC {pre};k=s ST = {}",
+        "  Secondary prompt start: OSC {prefix};A;k=s ST = {}",
         escape_for_display(&markers.prompt_start(PromptKind::Secondary))
     );
     println!(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2148,7 +2148,7 @@ mod tests {
 
         assert_eq!(
             markers.prompt_start(PromptKind::Primary).as_ref(),
-            "\x1b]133;P;k=i;click_events=1\x1b\\"
+            "\x1b]133;A;k=i;click_events=1\x1b\\"
         );
     }
 }

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -727,7 +727,7 @@ impl Painter {
         use_ansi_coloring: bool,
         layout: &PromptLayout,
     ) -> Result<()> {
-        // Emit prompt start marker (OSC 133;P;k=i for primary prompt)
+        // Emit prompt start marker (OSC 133;A;k=i for primary prompt)
         if let Some(markers) = &self.semantic_markers {
             self.stdout
                 .queue(Print(markers.prompt_start(PromptKind::Primary)))?;
@@ -798,7 +798,7 @@ impl Painter {
         let extra_rows = layout.extra_rows;
         let extra_rows_after_prompt = layout.extra_rows_after_prompt;
 
-        // Emit prompt start marker (OSC 133;P;k=i for primary prompt) only if prompt is visible
+        // Emit prompt start marker (OSC 133;A;k=i for primary prompt) only if prompt is visible
         if extra_rows == 0 {
             if let Some(markers) = &self.semantic_markers {
                 self.stdout

--- a/src/painting/styled_text.rs
+++ b/src/painting/styled_text.rs
@@ -311,7 +311,7 @@ mod test {
         // Without semantic markers, just get newline + multiline prompt
         let result = super::render_as_string(&renderable, &prompt_style, multiline_prompt, None);
         assert!(result.contains("\n::: "));
-        assert!(!result.contains("\x1b]133;P;k=s"));
+        assert!(!result.contains("\x1b]133;A;k=s"));
     }
 
     #[test]
@@ -327,7 +327,7 @@ mod test {
         let result =
             super::render_as_string(&renderable, &prompt_style, multiline_prompt, Some(&markers));
         // The result should contain the secondary prompt marker before ::: and B after
-        assert!(result.contains("\x1b]133;P;k=s\x1b\\"));
+        assert!(result.contains("\x1b]133;A;k=s\x1b\\"));
         assert!(result.contains("\x1b]133;B\x1b\\"));
     }
 
@@ -343,7 +343,7 @@ mod test {
         // Single line should not emit any markers
         let result =
             super::render_as_string(&renderable, &prompt_style, multiline_prompt, Some(&markers));
-        assert!(!result.contains("\x1b]133;P;k=s"));
+        assert!(!result.contains("\x1b]133;A;k=s"));
         assert!(!result.contains("\x1b]133;B"));
     }
 }

--- a/src/terminal_extensions/semantic_prompt.rs
+++ b/src/terminal_extensions/semantic_prompt.rs
@@ -9,12 +9,6 @@
 //! ## Protocol Overview
 //!
 //! - `A` - Marks the start of a prompt (with optional `k=` kind parameter)
-//!
-//!  Thanks to mitchellh for this tidbit, "The `A` is kind of weird: it does
-//!  a `\r\n` _if the cursor isn't at x=0_ and THEN does a `P`. If you want,
-//!  you can use `P` all the time instead of `A` for example if you're not
-//!  sure if the cursor will be at x=0." So, with that in mind, we'll use `P`
-//!  for right prompts and left prompts.
 //! - `B` - Marks the end of prompt and start of user input
 //! - `C` - Marks the start of command execution (emitted by shell, not reedline)
 //! - `D` - Marks the end of command execution with exit code (emitted by shell)
@@ -83,8 +77,8 @@ impl Osc133Markers {
 impl SemanticPromptMarkers for Osc133Markers {
     fn prompt_start(&self, kind: PromptKind) -> Cow<'_, str> {
         match kind {
-            PromptKind::Primary => Cow::Borrowed("\x1b]133;P;k=i\x1b\\"), // Normally this would be 'A', but using 'P' to avoid newline issues
-            PromptKind::Secondary => Cow::Borrowed("\x1b]133;P;k=s\x1b\\"), // Normally this would be 'A', but using 'P' to avoid newline issues
+            PromptKind::Primary => Cow::Borrowed("\x1b]133;A;k=i\x1b\\"), // Normally this would be 'A', but using 'P' to avoid newline issues
+            PromptKind::Secondary => Cow::Borrowed("\x1b]133;A;k=s\x1b\\"), // Normally this would be 'A', but using 'P' to avoid newline issues
             PromptKind::Right => Cow::Borrowed("\x1b]133;P;k=r\x1b\\"),
         }
     }
@@ -111,8 +105,8 @@ impl Osc133ClickEventsMarkers {
 impl SemanticPromptMarkers for Osc133ClickEventsMarkers {
     fn prompt_start(&self, kind: PromptKind) -> Cow<'_, str> {
         match kind {
-            PromptKind::Primary => Cow::Borrowed("\x1b]133;P;k=i;click_events=1\x1b\\"),
-            PromptKind::Secondary => Cow::Borrowed("\x1b]133;P;k=s;click_events=1\x1b\\"),
+            PromptKind::Primary => Cow::Borrowed("\x1b]133;A;k=i;click_events=1\x1b\\"),
+            PromptKind::Secondary => Cow::Borrowed("\x1b]133;A;k=s;click_events=1\x1b\\"),
             PromptKind::Right => Cow::Borrowed("\x1b]133;P;k=r\x1b\\"),
         }
     }
@@ -160,7 +154,7 @@ mod tests {
         let markers = Osc133Markers;
         assert_eq!(
             markers.prompt_start(PromptKind::Primary).as_ref(),
-            "\x1b]133;P;k=i\x1b\\" // Override 'A' with 'P' to avoid newline issues
+            "\x1b]133;A;k=i\x1b\\" // Override 'A' with 'P' to avoid newline issues
         );
     }
 
@@ -169,7 +163,7 @@ mod tests {
         let markers = Osc133Markers;
         assert_eq!(
             markers.prompt_start(PromptKind::Secondary).as_ref(),
-            "\x1b]133;P;k=s\x1b\\" // Override 'A' with 'P' to avoid newline issues
+            "\x1b]133;A;k=s\x1b\\" // Override 'A' with 'P' to avoid newline issues
         );
     }
 
@@ -193,7 +187,7 @@ mod tests {
         let markers = Osc133ClickEventsMarkers;
         assert_eq!(
             markers.prompt_start(PromptKind::Primary).as_ref(),
-            "\x1b]133;P;k=i;click_events=1\x1b\\"
+            "\x1b]133;A;k=i;click_events=1\x1b\\"
         );
     }
 
@@ -202,7 +196,7 @@ mod tests {
         let markers = Osc133ClickEventsMarkers;
         assert_eq!(
             markers.prompt_start(PromptKind::Secondary).as_ref(),
-            "\x1b]133;P;k=s;click_events=1\x1b\\"
+            "\x1b]133;A;k=s;click_events=1\x1b\\"
         );
     }
 


### PR DESCRIPTION
This change reverts the OSC133;P markers to OSC133;A so that click_events work in Ghostty and Kitty.