### PR TITLE
refactor: move jump-to-buffer start/end bindings to common navigation

### DIFF
--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -86,8 +86,6 @@ pub fn default_emacs_keybindings() -> Keybindings {
             edit_bind(EC::MoveWordRight { select: false }),
         ]),
     );
-    kb.add_binding(KM::ALT, KC::Char('<'), ReedlineEvent::ToStart);
-    kb.add_binding(KM::ALT, KC::Char('>'), ReedlineEvent::ToEnd);
     // Edits
     kb.add_binding(KM::ALT, KC::Delete, edit_bind(EC::DeleteWord));
     kb.add_binding(KM::ALT, KC::Backspace, edit_bind(EC::BackspaceWord));

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -198,6 +198,13 @@ pub fn add_common_navigation_bindings(kb: &mut Keybindings) {
         KC::Char('n'),
         ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuDown, ReedlineEvent::Down]),
     );
+
+    // Jump to the start/end of the buffer
+    kb.add_binding(KM::ALT, KC::Char('<'), ReedlineEvent::ToStart);
+    kb.add_binding(KM::ALT, KC::Char('>'), ReedlineEvent::ToEnd);
+    // For kitty keyboard protocol
+    kb.add_binding(KM::SHIFT | KM::ALT, KC::Char(','), ReedlineEvent::ToStart);
+    kb.add_binding(KM::SHIFT | KM::ALT, KC::Char('.'), ReedlineEvent::ToEnd);
 }
 
 /// Add basic functionality to edit


### PR DESCRIPTION
Relocates ALT+< and ALT+> from emacs to common.
Also adds SHIFT+ALT+, and SHIFT+ALT+. to support the Kitty keyboard protocol

cc @weirdan