### PR TITLE
Minimal scaffolding for feature-gated Helix Mode implementation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         rust:
           - stable
         # Define the feature sets that will be built here (for caching you define a separate name)
-        style: [bashisms, default, sqlite, basqlite, external_printer]
+        style: [bashisms, default, sqlite, basqlite, external_printer, helix]
         include:
           - style: bashisms
             flags: "--features bashisms"
@@ -27,6 +27,9 @@ jobs:
             flags: "--features sqlite"
           - style: basqlite
             flags: "--features bashisms,sqlite"
+          - style: helix
+            flags: "--features helix"
+
 
     runs-on: ${{ matrix.platform }}
 
@@ -37,7 +40,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
             components: clippy, rustfmt
-        
+
       - name: Setup nextest
         uses: taiki-e/install-action@nextest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tempfile = "3.3.0"
 bashisms = []
 external_printer = ["crossbeam"]
 idle_callback = []
+helix = []
 sqlite = ["rusqlite/bundled", "serde_json"]
 sqlite-dynlib = ["rusqlite", "serde_json"]
 system_clipboard = ["arboard"]
@@ -59,6 +60,10 @@ required-features = ["sqlite"]
 [[example]]
 name = "external_printer"
 required-features = ["external_printer"]
+
+[[example]]
+name = "helix"
+required-features = ["helix"]
 
 [package.metadata.docs.rs]
 # Whether to pass `--all-features` to Cargo (default: false)

--- a/examples/helix.rs
+++ b/examples/helix.rs
@@ -1,0 +1,28 @@
+// Create a reedline object with the experimental Helix edit mode.
+// cargo run --example helix --features helix
+//
+// The current Helix example maps Ctrl-D to exit and uses the default prompt,
+// which renders the active custom mode indicator as "(helix)".
+
+use reedline::{DefaultPrompt, Helix, Reedline, Signal};
+use std::io;
+
+fn main() -> io::Result<()> {
+    println!("Helix edit mode demo:\nAbort with Ctrl-C");
+
+    let prompt = DefaultPrompt::default();
+    let mut line_editor = Reedline::create().with_edit_mode(Box::new(Helix));
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {buffer}");
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+        }
+    }
+}

--- a/src/edit_mode/helix.rs
+++ b/src/edit_mode/helix.rs
@@ -1,0 +1,64 @@
+use crate::{
+    enums::{EventStatus, ReedlineEvent, ReedlineRawEvent},
+    PromptEditMode, PromptViMode,
+};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+use super::EditMode;
+
+/// A minimal custom edit mode example for Helix-style integrations.
+#[derive(Default)]
+pub struct Helix;
+
+impl EditMode for Helix {
+    fn parse_event(&mut self, event: ReedlineRawEvent) -> ReedlineEvent {
+        match Event::from(event) {
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('c'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            }) => ReedlineEvent::CtrlC,
+            _ => ReedlineEvent::None,
+        }
+    }
+
+    fn edit_mode(&self) -> PromptEditMode {
+        PromptEditMode::Vi(PromptViMode::Normal)
+    }
+
+    fn handle_mode_specific_event(&mut self, _event: ReedlineEvent) -> EventStatus {
+        EventStatus::Inapplicable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PromptViMode;
+
+    #[test]
+    fn helix_edit_mode_defaults_to_normal_mode() {
+        let helix_mode = Helix;
+
+        let edit_mode = helix_mode.edit_mode();
+
+        assert!(matches!(
+            edit_mode,
+            PromptEditMode::Vi(PromptViMode::Normal)
+        ));
+    }
+
+    #[test]
+    fn helix_edit_mode_parses_ctrl_c_event() {
+        let mut helix_mode = Helix;
+        let ctrl_c_raw_event = ReedlineRawEvent::try_from(Event::Key(KeyEvent::new(
+            KeyCode::Char('c'),
+            KeyModifiers::CONTROL,
+        )));
+
+        assert_eq!(
+            helix_mode.parse_event(ctrl_c_raw_event.unwrap()),
+            ReedlineEvent::CtrlC
+        );
+    }
+}

--- a/src/edit_mode/mod.rs
+++ b/src/edit_mode/mod.rs
@@ -1,11 +1,15 @@
 mod base;
 mod cursors;
 mod emacs;
+#[cfg(feature = "helix")]
+mod helix;
 mod keybindings;
 mod vi;
 
 pub use base::EditMode;
 pub use cursors::CursorConfig;
 pub use emacs::{default_emacs_keybindings, Emacs};
+#[cfg(feature = "helix")]
+pub use helix::Helix;
 pub use keybindings::Keybindings;
 pub use vi::{default_vi_insert_keybindings, default_vi_normal_keybindings, Vi};

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2281,4 +2281,17 @@ mod tests {
             "\x1b]133;A;k=i;click_events=1\x1b\\"
         );
     }
+
+    #[test]
+    #[cfg(feature = "helix")]
+    fn with_edit_mode_builder_accepts_custom_helix_mode() {
+        use crate::PromptViMode;
+
+        let reedline = Reedline::create().with_edit_mode(Box::new(crate::Helix));
+
+        assert!(matches!(
+            reedline.prompt_edit_mode(),
+            PromptEditMode::Vi(PromptViMode::Normal)
+        ));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,8 @@ pub use prompt::{
 };
 
 mod edit_mode;
+#[cfg(feature = "helix")]
+pub use edit_mode::Helix;
 pub use edit_mode::{
     default_emacs_keybindings, default_vi_insert_keybindings, default_vi_normal_keybindings,
     CursorConfig, EditMode, Emacs, Keybindings, Vi,


### PR DESCRIPTION
This is an attempt at a clean, minimal PR following from the work in #960 to provide baseline scaffolding for future work on a Helix Mode feature, mainly through a new EditMode variant that is passed to the main Reedline engine/controller.

### Goals / Design choices
- minimal HelixMode implementation that can be passed to the main Reedline object constructor in `engine.rs`
- all modifications to existing rust modules/objects are hidden behind a cargo feature flag `helix` to guard against accidental regressions to existing emacs/vi implementations
- provide clear "entrypoints" for the new HelixMode variant into existing Reedline structures/event processing so that new helix-based tests, examples, features, etc have a clear, vetted, and narrow interface with the existing architecture

### Tests
- Tests `Reedline.with_edit_mode` builder method provided with the new `Helix` EditMode variant.
- A minimal test for Ctrl+C processing to provide a safe exit from an application and demonstrate a generic keybinding action

The code in this PR has not been tested in the context of usage in a live Reedline application, although a minimal interactive example is provided. The main purpose of this PR is to confirm feature flag isolation and some test structure for future work on the feature.

This PR should be considered ready for merge when reviewing; however if maintainers would like to see more features and demonstrated functionality beyond tests before merging, they may be added incrementally to this PR.