### PR TITLE
add EnumDiscriminants to ReedlineEvent and EditCommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -647,7 +647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -766,7 +766,6 @@ dependencies = [
  "serde_json",
  "strip-ansi-escapes",
  "strum",
- "strum_macros",
  "tempfile",
  "thiserror",
  "unicase",
@@ -886,12 +885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
-
-[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,20 +986,22 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,7 @@ rusqlite = { version = "0.37.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.79", optional = true }
 strip-ansi-escapes = "0.2.0"
-strum = "0.26"
-strum_macros = "0.26"
+strum = { version = "0.27", features = ["derive"] }
 thiserror = "2.0.12"
 unicase = "2.8.0"
 unicode-segmentation = "1.9.0"

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,7 +1,7 @@
 use crossterm::event::{Event, KeyEvent, KeyEventKind};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
-use strum_macros::EnumIter;
+use strum::{EnumDiscriminants, EnumIter, EnumString, VariantArray};
 
 /// Which mouse button was pressed.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -80,7 +80,10 @@ impl Default for TextObject {
 ///
 /// Executed by `Reedline::run_edit_commands()`
 #[non_exhaustive]
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, EnumIter)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, EnumDiscriminants, EnumIter)]
+#[strum_discriminants(doc = "This is the auto generated discriminant type for [`EditCommand`]")]
+#[strum_discriminants(derive(EnumString, VariantArray))]
+#[strum_discriminants(strum(ascii_case_insensitive))]
 pub enum EditCommand {
     /// Move to the start of the buffer
     MoveToStart {
@@ -781,7 +784,10 @@ impl UndoBehavior {
 }
 
 /// Reedline supported actions.
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, EnumIter)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, EnumDiscriminants, EnumIter)]
+#[strum_discriminants(doc = "This is the auto generated discriminant type for [`ReedlineEvent`]")]
+#[strum_discriminants(derive(EnumString, VariantArray))]
+#[strum_discriminants(strum(ascii_case_insensitive))]
 pub enum ReedlineEvent {
     /// No op event
     None,
@@ -828,6 +834,7 @@ pub enum ReedlineEvent {
     SubmitOrNewline,
 
     /// Esc event
+    #[strum_discriminants(strum(serialize = "Esc", serialize = "Escape"))]
     Esc,
 
     /// Mouse click event with screen coordinates

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,8 +240,8 @@ pub use core_editor::LineBuffer;
 
 mod enums;
 pub use enums::{
-    EditCommand, MouseButton, ReedlineEvent, ReedlineRawEvent, Signal, TextObject, TextObjectScope,
-    TextObjectType, UndoBehavior,
+    EditCommand, EditCommandDiscriminants, MouseButton, ReedlineEvent, ReedlineEventDiscriminants,
+    ReedlineRawEvent, Signal, TextObject, TextObjectScope, TextObjectType, UndoBehavior,
 };
 
 mod painting;

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -5,7 +5,7 @@ use {
         borrow::Cow,
         fmt::{Display, Formatter},
     },
-    strum_macros::EnumIter,
+    strum::EnumIter,
 };
 
 /// The default color for the prompt, indicator, and right prompt


### PR DESCRIPTION
The main purpose of this PR is to facilitate nushell to make its own display implementation for `ReedlineEvent` and `EditCommand`. Currently, nushell determines which fields are optional and which field is required. But for some reason, the display for that is defined in reedline. As a result it causes confussion (see https://github.com/nushell/reedline/pull/953#discussion_r2698499834)

I will make a follow up PR to this in nushell implementing that change.

Also, I would also like to remove the `Display` impl of the mentioned enums. But I am hesitant to do so because that would be a breaking change.

/cc @fdncred  