### PR TITLE
fix: Strip ANSI before computing suggestion width in completion menus

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -438,8 +438,8 @@ impl ColumnarMenu {
                         format!(
                             "{}{}{}{}{}",
                             styled_value,
-                            RESET,
                             " ".repeat(padding),
+                            RESET,
                             self.settings.color.description_style.paint(desc_trunc),
                             RESET,
                         )
@@ -568,7 +568,7 @@ impl Menu for ColumnarMenu {
         self.display_widths = self
             .values
             .iter()
-            .map(|sugg| sugg.display_value().width())
+            .map(|sugg| strip_ansi_escapes::strip_str(sugg.display_value()).width())
             .collect();
         self.working_details.shortest_base_string = base_ranges
             .iter()
@@ -579,6 +579,7 @@ impl Menu for ColumnarMenu {
             })
             .min_by_key(|s| s.width())
             .unwrap_or_default();
+        self.longest_suggestion = *self.display_widths.iter().max().unwrap_or(&0);
 
         self.reset_position();
     }
@@ -630,7 +631,6 @@ impl Menu for ColumnarMenu {
                 .any(|suggestion| suggestion.description.is_some());
 
             let screen_width = painter.screen_width() as usize;
-            self.longest_suggestion = *self.display_widths.iter().max().unwrap_or(&0);
             if exist_description {
                 self.working_details.columns = 1;
                 self.working_details.col_width = screen_width;

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -145,6 +145,8 @@ pub struct IdeMenu {
     working_details: IdeMenuDetails,
     /// Menu cached values
     values: Vec<Suggestion>,
+    /// Cached display width of each suggestion in `values`
+    display_widths: Vec<usize>,
     /// Selected value. Starts at 0
     selected: u16,
     /// Number of values that are skipped when printing,
@@ -166,6 +168,7 @@ impl Default for IdeMenu {
             default_details: DefaultIdeMenuDetails::default(),
             working_details: IdeMenuDetails::default(),
             values: Vec::new(),
+            display_widths: Vec::new(),
             selected: 0,
             skip_values: 0,
             event: None,
@@ -498,7 +501,7 @@ impl IdeMenu {
         let display_value = suggestion.display_value();
 
         let padding_right = (self.working_details.completion_width as usize)
-            .saturating_sub(display_value.width() + border_width + padding);
+            .saturating_sub(self.display_widths[index] + border_width + padding);
 
         let max_string_width =
             (self.working_details.completion_width as usize).saturating_sub(border_width + padding);
@@ -630,6 +633,11 @@ impl Menu for IdeMenu {
         let (values, base_ranges) = completer.complete_with_base_ranges(&input, pos);
 
         self.values = values;
+        self.display_widths = self
+            .values
+            .iter()
+            .map(|sugg| strip_ansi_escapes::strip_str(sugg.display_value()).width())
+            .collect();
         self.working_details.shortest_base_string = base_ranges
             .iter()
             .map(|range| {
@@ -639,6 +647,7 @@ impl Menu for IdeMenu {
             })
             .min_by_key(|s| s.width())
             .unwrap_or_default();
+        self.longest_suggestion = *self.display_widths.iter().max().unwrap_or(&0);
 
         self.reset_position();
     }
@@ -675,13 +684,6 @@ impl Menu for IdeMenu {
                 | MenuEvent::PreviousPage
                 | MenuEvent::NextPage => {}
             }
-
-            self.longest_suggestion = self
-                .get_values()
-                .iter()
-                .map(|s| s.display_value().width())
-                .max()
-                .unwrap_or_default();
 
             let terminal_width = painter.screen_width();
 


### PR DESCRIPTION
We don't strip ANSI escapes when computing suggestion width, which means that the padding is off when the suggestion has `display_override` set to a string containing ANSI escapes. I didn't detect this during testing because all of the suggestions I tested always had the same number of ANSI escapes.

## Screenshots

### Before

Columnar menu:
<img width="416" height="79" alt="image" src="https://github.com/user-attachments/assets/cd9062b6-51b4-4cc0-8f78-515b07837102" />

IDE menu:
<img width="629" height="151" alt="image" src="https://github.com/user-attachments/assets/5283cee6-40c7-4e86-a482-57286645514f" />


### After

Columnar menu:
<img width="442" height="96" alt="image" src="https://github.com/user-attachments/assets/a78b6edb-57c7-4fd1-8a28-35c9b94cfb65" />

IDE menu:
<img width="516" height="148" alt="image" src="https://github.com/user-attachments/assets/225f05cd-7d5f-48de-8e6b-f649c9b8301b" />

Completer used:
```nu
def comp [] {
    [
        {
            value: "Cookies",
            description: "A great healthy snack",
        },
        {
            value: "Spinach",
            display_override: $"gah(ansi green)blech(ansi s)hurgh",
            description: "A poisonous leaf",
            style: red
        },
    ]
}
def foo [commit: string@comp] {}
```