### PR TITLE
feat: accept templated command for `OpenEditor`

### DIFF
--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -95,7 +95,7 @@ impl LineBuffer {
     /// Zero-based index
     pub fn col(&self) -> usize {
         self.lines[self.line_start()..self.insertion_point]
-            .chars()
+            .grapheme_indices(true)
             .count()
     }
 

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -90,6 +90,15 @@ impl LineBuffer {
         self.lines[..self.insertion_point].matches('\n').count()
     }
 
+    /// Calculates the character index in the line the user is on
+    ///
+    /// Zero-based index
+    pub fn col(&self) -> usize {
+        self.lines[self.line_start()..self.insertion_point]
+            .chars()
+            .count()
+    }
+
     /// Counts the number of lines in the buffer
     pub fn num_lines(&self) -> usize {
         self.lines.split('\n').count()

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -83,7 +83,7 @@ impl LineBuffer {
         self.insertion_point = self.lines.len();
     }
 
-    /// Calculates the current the user is on
+    /// Calculates the current line the user is on
     ///
     /// Zero-based index
     pub fn line(&self) -> usize {
@@ -105,20 +105,21 @@ impl LineBuffer {
         self.insertion_point = 0;
     }
 
+    fn line_start(&self) -> usize {
+        self.lines[..self.insertion_point]
+            .rfind('\n')
+            .map_or(0, |offset| offset + 1)
+        // str is guaranteed to be utf8, thus \n is safe to assume 1 byte long
+    }
+
     /// Move the cursor before the first character of the line
     pub fn move_to_line_start(&mut self) {
-        self.insertion_point = self.lines[..self.insertion_point]
-            .rfind('\n')
-            .map_or(0, |offset| offset + 1);
-        // str is guaranteed to be utf8, thus \n is safe to assume 1 byte long
+        self.insertion_point = self.line_start();
     }
 
     /// Move the cursor before the first non whitespace character of the line
     pub fn move_to_line_non_blank_start(&mut self) {
-        let line_start = self.lines[..self.insertion_point]
-            .rfind('\n')
-            .map_or(0, |offset| offset + 1);
-        // str is guaranteed to be utf8, thus \n is safe to assume 1 byte long
+        let line_start = self.line_start();
 
         self.insertion_point = self.lines[line_start..]
             .find(|c: char| !c.is_whitespace() || c == '\n')
@@ -535,9 +536,7 @@ impl LineBuffer {
     /// extending beyond the potential carriage return and line feed characters
     /// terminating the line
     pub fn current_line_range(&self) -> Range<usize> {
-        let left_index = self.lines[..self.insertion_point]
-            .rfind('\n')
-            .map_or(0, |offset| offset + 1);
+        let left_index = self.line_start();
         let right_index = self.lines[self.insertion_point..]
             .find('\n')
             .map_or_else(|| self.lines.len(), |i| i + self.insertion_point + 1);

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -196,6 +196,15 @@ impl LineBuffer {
         self.lines[..self.cursor.head()].matches('\n').count()
     }
 
+    /// Calculates the grapheme index in the line the cursor head is on.
+    ///
+    /// Zero-based index
+    pub fn col(&self) -> usize {
+        self.lines[self.line_start_index()..self.cursor.head()]
+            .grapheme_indices(true)
+            .count()
+    }
+
     /// Counts the number of lines in the buffer
     pub fn num_lines(&self) -> usize {
         self.lines.split('\n').count()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2214,6 +2214,7 @@ mod tests {
     use super::*;
     use crate::terminal_extensions::semantic_prompt::PromptKind;
     use crate::DefaultPrompt;
+    use rstest::rstest;
 
     #[test]
     fn test_cursor_position_after_multiline_history_navigation() {
@@ -2394,5 +2395,60 @@ mod tests {
             Signal::ExternalBreak(buf) => assert_eq!(buf, buffer_content),
             _ => panic!("Expected Signal::ExternalBreak"),
         }
+    }
+
+    fn command_from_strs(command: &[&str]) -> Command {
+        let (program, args) = command.split_first().unwrap();
+
+        let mut command = Command::new(program);
+        command.args(args);
+        command
+    }
+
+    fn command_into_string(command: Command) -> String {
+        use itertools::Itertools;
+        use std::iter::once;
+
+        once(command.get_program())
+            .chain(command.get_args())
+            .map(|os_str| os_str.to_str().unwrap())
+            .join(" ")
+    }
+
+    #[rstest]
+    #[case(&["nano"], "nano foo.rs")]
+    #[case(&["code", "--goto", "{file}:{line}:{col}"], "code --goto foo.rs:2:4")]
+    #[case(&["hx", "{file}:{line}:{col}"], "hx foo.rs:2:4")]
+    #[case(&["nvim", "{file}", "\"call cursor({line}, {col})\""], "nvim foo.rs \"call cursor(2, 4)\"")]
+    #[case(&["vim", "+{line}", "{file}"], "vim +2 foo.rs")]
+    #[case(&["emacs", "+{line}:{col}", "{file}"], "emacs +2:4 foo.rs")]
+    fn render_editor_command_with_pattern(#[case] command: &[&str], #[case] expected: &str) {
+        // we're not actually spawning anything,
+        // so no need to create an actual file
+        let temp_file = PathBuf::from("foo.rs");
+
+        let buffer_editor = BufferEditor {
+            command: command_from_strs(command),
+            temp_file,
+        };
+
+        let line_buffer = {
+            let mut line_buffer = LineBuffer::new();
+
+            line_buffer.insert_str("a mulatto\n");
+            line_buffer.insert_str("an albino\n");
+            line_buffer.insert_str("a mosquito\n");
+            line_buffer.insert_str("my libido\n");
+            line_buffer.move_line_up();
+            line_buffer.move_line_up();
+            line_buffer.move_word_left();
+
+            line_buffer
+        };
+
+        let actual = Reedline::render_editor_command(&buffer_editor, &line_buffer);
+        let actual = command_into_string(actual);
+
+        assert_eq!(actual, expected);
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
-
 use itertools::Itertools;
 use nu_ansi_term::{Color, Style};
+use std::ffi::OsStr;
+use std::path::PathBuf;
 
 use crate::{enums::ReedlineRawEvent, CursorConfig};
 #[cfg(feature = "bashisms")]
@@ -47,6 +47,7 @@ use {
         terminal, QueueableCommand,
     },
     std::{
+        ffi::OsString,
         fs::File,
         io,
         io::Result,
@@ -559,10 +560,6 @@ impl Reedline {
     /// ```
     #[must_use]
     pub fn with_buffer_editor(mut self, editor: Command, temp_file: PathBuf) -> Self {
-        let mut editor = editor;
-        if !editor.get_args().contains(&temp_file.as_os_str()) {
-            editor.arg(&temp_file);
-        }
         self.buffer_editor = Some(BufferEditor {
             command: editor,
             temp_file,
@@ -1359,7 +1356,15 @@ impl Reedline {
                 }
                 Ok(EventStatus::Handled)
             }
-            ReedlineEvent::OpenEditor => self.open_editor().map(|_| EventStatus::Handled),
+            ReedlineEvent::OpenEditor => {
+                if let Some(buffer_editor) = &self.buffer_editor {
+                    let new_buffer = self.open_editor(buffer_editor)?;
+                    self.editor
+                        .set_buffer(new_buffer, UndoBehavior::CreateUndoPoint);
+                }
+
+                Ok(EventStatus::Handled)
+            }
             ReedlineEvent::Resize(width, height) => {
                 self.last_render_snapshot = None;
                 self.painter.handle_resize(width, height);
@@ -1872,30 +1877,69 @@ impl Reedline {
         }
     }
 
-    fn open_editor(&mut self) -> Result<()> {
-        match &mut self.buffer_editor {
-            Some(BufferEditor {
-                ref mut command,
-                ref temp_file,
-            }) => {
-                {
-                    let mut file = File::create(temp_file)?;
-                    write!(file, "{}", self.editor.get_buffer())?;
-                }
-                {
-                    let mut child = command.spawn()?;
-                    child.wait()?;
-                }
+    /// opens the current buffer in the editor described in [`buffer_editor`]
+    /// returns the new buffer, after processing the changes via the editor
+    fn open_editor(&self, buffer_editor: &BufferEditor) -> Result<String> {
+        let mut command = Self::render_editor_command(buffer_editor, self.editor.line_buffer());
 
-                let res = std::fs::read_to_string(temp_file)?;
-                let res = res.trim_end().to_string();
-
-                self.editor.set_buffer(res, UndoBehavior::CreateUndoPoint);
-
-                Ok(())
-            }
-            _ => Ok(()),
+        // flush buffer to temp file, so it can be read by the editor
+        {
+            let mut file = File::create(&buffer_editor.temp_file)?;
+            write!(file, "{}", self.editor.get_buffer())?;
         }
+
+        command.spawn()?.wait()?;
+
+        // fetch contents of buffer after editor is done
+        let mut buffer = std::fs::read_to_string(&buffer_editor.temp_file)?;
+        let content_len = buffer.trim_end().len();
+        buffer.truncate(content_len);
+
+        Ok(buffer)
+    }
+
+    /// renders the template command described in [`buffer_editor`],
+    /// by substituting the placeholders in the pattern, if any
+    fn render_editor_command(buffer_editor: &BufferEditor, line_buffer: &LineBuffer) -> Command {
+        use std::ops::Add as _;
+
+        let mut cmd = Command::new(buffer_editor.command.get_program());
+
+        const FILE: &str = "{file}";
+        const LINE: &str = "{line}";
+        const COL: &str = "{col}";
+
+        // kind of a wonky check, but it's enough to know
+        // that we have somewhere to stick that temp_file path in
+        let is_template = buffer_editor
+            .command
+            .get_args()
+            .map(OsStr::to_string_lossy)
+            .any(|arg| arg.contains(FILE));
+
+        if is_template {
+            // TODO: there are more efficient ways to do this.
+            // e.g. "format args"-style structs
+
+            let file = buffer_editor.temp_file.to_string_lossy();
+            let line = line_buffer.line().add(1).to_string();
+            let col = line_buffer.col().add(1).to_string();
+
+            let actual_args = buffer_editor
+                .command
+                .get_args()
+                .map(OsStr::to_string_lossy)
+                .map(|arg| arg.replace(FILE, &file))
+                .map(|arg| arg.replace(LINE, &line))
+                .map(|arg| arg.replace(COL, &col));
+
+            cmd.args(actual_args);
+        } else {
+            cmd.args(buffer_editor.command.get_args());
+            cmd.arg(&buffer_editor.temp_file);
+        }
+
+        cmd
     }
 
     /// Repaint logic for the history reverse search

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use nu_ansi_term::{Color, Style};
 
 use crate::{enums::ReedlineRawEvent, CursorConfig};

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -542,19 +542,29 @@ impl Reedline {
     ///
     /// # Example
     /// ```rust,no_run
-    /// // Create a reedline object with vim as editor
-    ///
     /// use reedline::Reedline;
     /// use std::env::temp_dir;
     /// use std::process::Command;
     ///
-    /// let temp_file = std::env::temp_dir().join("my-random-unique.file");
+    /// let temp = temp_dir().join("my-random-unique.file");
+    ///
     /// let mut command = Command::new("vim");
     /// // you can provide additional flags:
     /// command.arg("-p"); // open in a vim tab (just for demonstration)
-    /// // you don't have to pass the filename to the command
-    /// let mut line_editor =
-    /// Reedline::create().with_buffer_editor(command, temp_file);
+    /// // ...and the filename will be appended at the end of the command
+    /// let mut line_editor = Reedline::create().with_buffer_editor(command, temp.clone());
+    ///
+    /// // optionally, {file}, {line}, and {col} placeholders can used.
+    /// // they will be replaced with the corresponding filename and current cursor position
+    /// let mut command = Command::new("hx");
+    /// command.args(["+{line}:{col}", "{file}"]);
+    /// let mut line_editor = Reedline::create().with_buffer_editor(command, temp.clone());
+    ///
+    /// // if {file} is omitted, the filename is still appended at the end,
+    /// // as in the above example
+    /// let mut command = Command::new("emacs");
+    /// command.arg("+{line}:{col}");
+    /// let mut line_editor = Reedline::create().with_buffer_editor(command, temp);
     /// ```
     #[must_use]
     pub fn with_buffer_editor(mut self, editor: Command, temp_file: PathBuf) -> Self {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,5 @@
 use itertools::Itertools;
 use nu_ansi_term::{Color, Style};
-use std::ffi::OsStr;
-use std::path::PathBuf;
 
 use crate::{enums::ReedlineRawEvent, CursorConfig};
 #[cfg(feature = "bashisms")]
@@ -47,11 +45,12 @@ use {
         terminal, QueueableCommand,
     },
     std::{
-        ffi::OsString,
+        ffi::OsStr,
         fs::File,
         io,
         io::Result,
         io::Write,
+        path::PathBuf,
         process::Command,
         sync::{atomic::AtomicBool, Arc},
         time::Duration,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1907,33 +1907,30 @@ impl Reedline {
         const LINE: &str = "{line}";
         const COL: &str = "{col}";
 
-        // kind of a wonky check, but it's enough to know
-        // that we have somewhere to stick that temp_file path in
-        let is_template = buffer_editor
+        let has_file_placholder = buffer_editor
             .command
             .get_args()
             .map(OsStr::to_string_lossy)
             .any(|arg| arg.contains(FILE));
 
-        if is_template {
-            // TODO: there are more efficient ways to do this.
-            // e.g. "format args"-style structs
+        // there are more efficient ways to do this.
+        // e.g. "format args"-style structs
 
-            let file = buffer_editor.temp_file.to_string_lossy();
-            let line = line_buffer.line().add(1).to_string();
-            let col = line_buffer.col().add(1).to_string();
+        let file = buffer_editor.temp_file.to_string_lossy();
+        let line = line_buffer.line().add(1).to_string();
+        let col = line_buffer.col().add(1).to_string();
 
-            let actual_args = buffer_editor
-                .command
-                .get_args()
-                .map(OsStr::to_string_lossy)
-                .map(|arg| arg.replace(FILE, &file))
-                .map(|arg| arg.replace(LINE, &line))
-                .map(|arg| arg.replace(COL, &col));
+        let args = buffer_editor
+            .command
+            .get_args()
+            .map(OsStr::to_string_lossy)
+            .map(|arg| arg.replace(FILE, &file))
+            .map(|arg| arg.replace(LINE, &line))
+            .map(|arg| arg.replace(COL, &col));
 
-            cmd.args(actual_args);
-        } else {
-            cmd.args(buffer_editor.command.get_args());
+        cmd.args(args);
+
+        if !has_file_placholder {
             cmd.arg(&buffer_editor.temp_file);
         }
 
@@ -2422,6 +2419,7 @@ mod tests {
     #[case(&["nvim", "{file}", "\"call cursor({line}, {col})\""], "nvim foo.rs \"call cursor(2, 4)\"")]
     #[case(&["vim", "+{line}", "{file}"], "vim +2 foo.rs")]
     #[case(&["emacs", "+{line}:{col}", "{file}"], "emacs +2:4 foo.rs")]
+    #[case(&["emacs", "+{line}:{col}"], "emacs +2:4 foo.rs")]
     fn render_editor_command_with_pattern(#[case] command: &[&str], #[case] expected: &str) {
         // we're not actually spawning anything,
         // so no need to create an actual file

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, ffi::OsStr, ops::ControlFlow, path::PathBuf};
 
-use itertools::Itertools;
 use nu_ansi_term::{Color, Style};
 
 use crate::{enums::ReedlineRawEvent, CursorConfig};
@@ -745,7 +744,7 @@ impl Reedline {
     /// // ...and the filename will be appended at the end of the command
     /// let mut line_editor = Reedline::create().with_buffer_editor(command, temp.clone());
     ///
-    /// // optionally, {file}, {line}, and {col} placeholders can used.
+    /// // optionally, {file}, {line}, and {col} placeholders can be used.
     /// // they will be replaced with the corresponding filename and current cursor position
     /// let mut command = Command::new("hx");
     /// command.args(["+{line}:{col}", "{file}"]);
@@ -2768,6 +2767,7 @@ mod tests {
         ColumnarMenu, CompletionOrigin, CompletionResult, DefaultPrompt, MenuBuilder, PromptViMode,
         Span, Suggestion,
     };
+    use itertools::Itertools;
     use rstest::rstest;
 
     fn seam_engine(edit_mode: Box<dyn EditMode>) -> Reedline {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -246,6 +246,13 @@ impl BufferEditor {
     pub(crate) fn render_command(&self, line_buffer: &LineBuffer) -> Command {
         let mut cmd = Command::new(self.command.get_program());
 
+        for (key, value) in self.command.get_envs() {
+            match value {
+                Some(value) => cmd.env(key, value),
+                None => cmd.env_remove(key),
+            };
+        }
+
         const FILE: &str = "{file}";
         const LINE: &str = "{line}";
         const COL: &str = "{col}";

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ops::ControlFlow, path::PathBuf};
+use std::{collections::HashMap, ffi::OsStr, ops::ControlFlow, path::PathBuf};
 
 use itertools::Itertools;
 use nu_ansi_term::{Color, Style};
@@ -239,6 +239,43 @@ pub struct Reedline {
 struct BufferEditor {
     command: Command,
     temp_file: PathBuf,
+}
+
+impl BufferEditor {
+    /// Renders the editor command template,
+    /// substituting `{file}`, `{line}`, and `{col}` where present.
+    pub(crate) fn render_command(&self, line_buffer: &LineBuffer) -> Command {
+        let mut cmd = Command::new(self.command.get_program());
+
+        const FILE: &str = "{file}";
+        const LINE: &str = "{line}";
+        const COL: &str = "{col}";
+
+        let has_file_placeholder = self
+            .command
+            .get_args()
+            .map(OsStr::to_string_lossy)
+            .any(|arg| arg.contains(FILE));
+
+        let file = self.temp_file.to_string_lossy();
+        let line = (line_buffer.line() + 1).to_string();
+        let col = (line_buffer.col() + 1).to_string();
+
+        let args = self
+            .command
+            .get_args()
+            .map(OsStr::to_string_lossy)
+            .map(|arg| arg.replace(FILE, &file))
+            .map(|arg| arg.replace(LINE, &line))
+            .map(|arg| arg.replace(COL, &col));
+
+        cmd.args(args);
+        if !has_file_placeholder {
+            cmd.arg(&self.temp_file);
+        }
+
+        cmd
+    }
 }
 
 /// The completions the [`Menu`](ReedlineEvent::Menu) event could not decide, because the
@@ -685,20 +722,27 @@ impl Reedline {
     /// use std::env::temp_dir;
     /// use std::process::Command;
     ///
-    /// let temp_file = std::env::temp_dir().join("my-random-unique.file");
+    /// let temp = std::env::temp_dir().join("my-random-unique.file");
     /// let mut command = Command::new("vim");
     /// // you can provide additional flags:
-    /// command.arg("-p"); // open in a vim tab (just for demonstration)
-    /// // you don't have to pass the filename to the command
-    /// let mut line_editor =
-    /// Reedline::create().with_buffer_editor(command, temp_file);
+    /// command.arg("-p"); // open in a new vim tab
+    /// // ...and the filename will be appended at the end of the command
+    /// let mut line_editor = Reedline::create().with_buffer_editor(command, temp.clone());
+    ///
+    /// // optionally, {file}, {line}, and {col} placeholders can used.
+    /// // they will be replaced with the corresponding filename and current cursor position
+    /// let mut command = Command::new("hx");
+    /// command.args(["+{line}:{col}", "{file}"]);
+    /// let mut line_editor = Reedline::create().with_buffer_editor(command, temp.clone());
+    ///
+    /// // if {file} is omitted, the filename is still appended at the end,
+    /// // as in the above example
+    /// let mut command = Command::new("emacs");
+    /// command.arg("+{line}:{col}");
+    /// let mut line_editor = Reedline::create().with_buffer_editor(command, temp);
     /// ```
     #[must_use]
     pub fn with_buffer_editor(mut self, editor: Command, temp_file: PathBuf) -> Self {
-        let mut editor = editor;
-        if !editor.get_args().contains(&temp_file.as_os_str()) {
-            editor.arg(&temp_file);
-        }
         self.buffer_editor = Some(BufferEditor {
             command: editor,
             temp_file,
@@ -2363,7 +2407,9 @@ impl Reedline {
         // below the old one.
         let suspended_state = self.painter.state_before_suspension();
         {
-            let mut child = buffer_editor.command.spawn()?;
+            let mut child = buffer_editor
+                .render_command(self.editor.line_buffer())
+                .spawn()?;
             // The child owns the tty now; invalidate eagerly so
             // any `?` early-return below still leaves the
             // painter in a safe state.
@@ -2382,8 +2428,9 @@ impl Reedline {
             .painter
             .initialize_prompt_position(Some(&suspended_state));
 
-        let res = std::fs::read_to_string(&buffer_editor.temp_file)?;
-        let res = res.trim_end().to_string();
+        let mut res = std::fs::read_to_string(&buffer_editor.temp_file)?;
+        let content_len = res.trim_end().len();
+        res.truncate(content_len);
 
         self.editor.set_buffer(res, UndoBehavior::CreateUndoPoint);
 
@@ -4781,5 +4828,51 @@ mod tests {
         assert_eq!(rl.editor.insertion_point(), 1);
         drive(&mut rl, &[ch('l')]); // crosses down to 'c' (start of line 2)
         assert_eq!(rl.editor.insertion_point(), 3);
+    }
+
+    fn command_from_strs(command: &[&str]) -> Command {
+        let (program, args) = command.split_first().unwrap();
+        let mut command = Command::new(program);
+        command.args(args);
+        command
+    }
+
+    fn command_into_string(command: Command) -> String {
+        use std::iter::once;
+
+        once(command.get_program())
+            .chain(command.get_args())
+            .map(|os_str| os_str.to_str().unwrap())
+            .join(" ")
+    }
+
+    #[rstest]
+    #[case(&["nano"], "nano foo.rs")]
+    #[case(&["code", "--goto", "{file}:{line}:{col}"], "code --goto foo.rs:2:4")]
+    #[case(&["hx", "{file}:{line}:{col}"], "hx foo.rs:2:4")]
+    #[case(&["nvim", "{file}", "\"call cursor({line}, {col})\""], "nvim foo.rs \"call cursor(2, 4)\"")]
+    #[case(&["vim", "+{line}", "{file}"], "vim +2 foo.rs")]
+    #[case(&["emacs", "+{line}:{col}", "{file}"], "emacs +2:4 foo.rs")]
+    #[case(&["emacs", "+{line}:{col}"], "emacs +2:4 foo.rs")]
+    fn render_editor_command_with_pattern(#[case] command: &[&str], #[case] expected: &str) {
+        let buffer_editor = BufferEditor {
+            command: command_from_strs(command),
+            temp_file: PathBuf::from("foo.rs"),
+        };
+
+        let line_buffer = {
+            let mut line_buffer = LineBuffer::new();
+            line_buffer.insert_str("a mulatto\n");
+            line_buffer.insert_str("an albino\n");
+            line_buffer.insert_str("a mosquito\n");
+            line_buffer.insert_str("my libido\n");
+            line_buffer.move_line_up();
+            line_buffer.move_line_up();
+            line_buffer.move_left_before(' ', false);
+            line_buffer
+        };
+
+        let actual = buffer_editor.render_command(&line_buffer);
+        assert_eq!(command_into_string(actual), expected);
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -253,29 +253,23 @@ impl BufferEditor {
             };
         }
 
-        const FILE: &str = "{file}";
-        const LINE: &str = "{line}";
-        const COL: &str = "{col}";
-
-        let has_file_placeholder = self
-            .command
-            .get_args()
-            .map(OsStr::to_string_lossy)
-            .any(|arg| arg.contains(FILE));
-
         let file = self.temp_file.to_string_lossy();
         let line = (line_buffer.line() + 1).to_string();
         let col = (line_buffer.col() + 1).to_string();
 
-        let args = self
-            .command
-            .get_args()
-            .map(OsStr::to_string_lossy)
-            .map(|arg| arg.replace(FILE, &file))
-            .map(|arg| arg.replace(LINE, &line))
-            .map(|arg| arg.replace(COL, &col));
+        let mut has_file_placeholder = false;
 
-        cmd.args(args);
+        for arg in self.command.get_args().map(OsStr::to_string_lossy) {
+            has_file_placeholder |= arg.contains("{file}");
+
+            let arg = arg
+                .replace("{file}", &file)
+                .replace("{line}", &line)
+                .replace("{col}", &col);
+
+            cmd.arg(arg);
+        }
+
         if !has_file_placeholder {
             cmd.arg(&self.temp_file);
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -241,15 +241,15 @@ struct BufferEditor {
 }
 
 impl BufferEditor {
-    /// Renders the editor command template,
+    /// renders the editor command template,
     /// substituting `{file}`, `{line}`, and `{col}` where present.
     pub(crate) fn render_command(&self, line_buffer: &LineBuffer) -> Command {
-        let mut cmd = Command::new(self.command.get_program());
+        let mut rendered = Command::new(self.command.get_program());
 
         for (key, value) in self.command.get_envs() {
             match value {
-                Some(value) => cmd.env(key, value),
-                None => cmd.env_remove(key),
+                Some(value) => rendered.env(key, value),
+                None => rendered.env_remove(key),
             };
         }
 
@@ -267,14 +267,14 @@ impl BufferEditor {
                 .replace("{line}", &line)
                 .replace("{col}", &col);
 
-            cmd.arg(arg);
+            rendered.arg(arg);
         }
 
         if !has_file_placeholder {
-            cmd.arg(&self.temp_file);
+            rendered.arg(&self.temp_file);
         }
 
-        cmd
+        rendered
     }
 
     /// writes the buffer to the temp file,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -276,6 +276,22 @@ impl BufferEditor {
 
         cmd
     }
+
+    /// writes the buffer to the temp file,
+    /// in preparation for spawning the buffer editor
+    pub(crate) fn write_current_buffer(&self, buffer_contents: &str) -> Result<()> {
+        let mut file = File::create(&self.temp_file)?;
+        write!(file, "{buffer_contents}")
+    }
+
+    /// reads the buffer from the temp file,
+    /// expected to be called after the buffer editor exits
+    pub(crate) fn get_edited_buffer(&mut self) -> Result<String> {
+        let mut res = std::fs::read_to_string(&self.temp_file)?;
+        let content_len = res.trim_end().len();
+        res.truncate(content_len);
+        Ok(res)
+    }
 }
 
 /// The completions the [`Menu`](ReedlineEvent::Menu) event could not decide, because the
@@ -2396,10 +2412,8 @@ impl Reedline {
             return Ok(());
         };
 
-        {
-            let mut file = File::create(&buffer_editor.temp_file)?;
-            write!(file, "{}", self.editor.get_buffer())?;
-        }
+        buffer_editor.write_current_buffer(self.editor.get_buffer())?;
+
         // Capture the prompt's screen range so that an editor
         // that leaves the cursor untouched (e.g. an editor that
         // uses the alternate screen only) re-uses the existing
@@ -2428,9 +2442,7 @@ impl Reedline {
             .painter
             .initialize_prompt_position(Some(&suspended_state));
 
-        let mut res = std::fs::read_to_string(&buffer_editor.temp_file)?;
-        let content_len = res.trim_end().len();
-        res.truncate(content_len);
+        let res = buffer_editor.get_edited_buffer()?;
 
         self.editor.set_buffer(res, UndoBehavior::CreateUndoPoint);
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2348,50 +2348,46 @@ impl Reedline {
     }
 
     fn open_editor(&mut self) -> Result<()> {
-        match &mut self.buffer_editor {
-            Some(BufferEditor {
-                ref mut command,
-                ref temp_file,
-            }) => {
-                {
-                    let mut file = File::create(temp_file)?;
-                    write!(file, "{}", self.editor.get_buffer())?;
-                }
-                // Capture the prompt's screen range so that an editor
-                // that leaves the cursor untouched (e.g. an editor that
-                // uses the alternate screen only) re-uses the existing
-                // prompt rows instead of starting a new prompt a row
-                // below the old one.
-                let suspended_state = self.painter.state_before_suspension();
-                {
-                    let mut child = command.spawn()?;
-                    // The child owns the tty now; invalidate eagerly so
-                    // any `?` early-return below still leaves the
-                    // painter in a safe state.
-                    self.painter.invalidate_prompt_start_row();
-                    child.wait()?;
-                }
+        let Some(buffer_editor) = &mut self.buffer_editor else {
+            return Ok(());
+        };
 
-                // On the success path, re-initialize position and size
-                // (covers a resize-during-editor with no SIGWINCH). If
-                // the editor moved the cursor out of the prompt's rows
-                // (it printed output), a fresh prompt starts below that
-                // output. On query failure, the eager invalidate above
-                // is our floor — losing the size refresh is acceptable;
-                // losing the user's edited buffer below is not.
-                let _ = self
-                    .painter
-                    .initialize_prompt_position(Some(&suspended_state));
-
-                let res = std::fs::read_to_string(temp_file)?;
-                let res = res.trim_end().to_string();
-
-                self.editor.set_buffer(res, UndoBehavior::CreateUndoPoint);
-
-                Ok(())
-            }
-            _ => Ok(()),
+        {
+            let mut file = File::create(&buffer_editor.temp_file)?;
+            write!(file, "{}", self.editor.get_buffer())?;
         }
+        // Capture the prompt's screen range so that an editor
+        // that leaves the cursor untouched (e.g. an editor that
+        // uses the alternate screen only) re-uses the existing
+        // prompt rows instead of starting a new prompt a row
+        // below the old one.
+        let suspended_state = self.painter.state_before_suspension();
+        {
+            let mut child = buffer_editor.command.spawn()?;
+            // The child owns the tty now; invalidate eagerly so
+            // any `?` early-return below still leaves the
+            // painter in a safe state.
+            self.painter.invalidate_prompt_start_row();
+            child.wait()?;
+        }
+
+        // On the success path, re-initialize position and size
+        // (covers a resize-during-editor with no SIGWINCH). If
+        // the editor moved the cursor out of the prompt's rows
+        // (it printed output), a fresh prompt starts below that
+        // output. On query failure, the eager invalidate above
+        // is our floor — losing the size refresh is acceptable;
+        // losing the user's edited buffer below is not.
+        let _ = self
+            .painter
+            .initialize_prompt_position(Some(&suspended_state));
+
+        let res = std::fs::read_to_string(&buffer_editor.temp_file)?;
+        let res = res.trim_end().to_string();
+
+        self.editor.set_buffer(res, UndoBehavior::CreateUndoPoint);
+
+        Ok(())
     }
 
     /// Repaint logic for the history reverse search


### PR DESCRIPTION
this PR extends `OpenEditor` in the following way:
- `BufferEditor`'s `command` field can now contain the following patterns: `{file}`, `{line}`, `{col}`
- reedline will automatically instantiate the fields from current position when `OpenEditor` is invoked

the usecase here is that pressing Ctrl+O in nushell would open the editor in the current position of the cursor. this branch works as-is in nushell without additional changes to nushell itself, other than the user needing to use a different format for `buffer_editor`.  it is (or _should be_) backward-compatible with existing `buffer_editor` commands.

I tested this with:
- `$env.config.buffer_editor = ["hx" "{file}:{line}:{col}"]`
- `$env.config.buffer_editor = ["code" "--wait" "--goto" "{file}:{line}:{col}"]`

TODOs in the code will be removed in subsequent commits - they're just potential areas of discussion for the PR process.