### PR TITLE
fix: preserve prompt position after ExternalBreak

### DIFF
--- a/examples/break_signal.rs
+++ b/examples/break_signal.rs
@@ -1,7 +1,10 @@
 // Demonstrates the external break signal feature.
-// A background thread sets the break signal after 3 seconds,
+//
+// A background thread sets the break signal every 5 seconds,
 // causing `read_line()` to return `Signal::ExternalBreak` with
-// the current buffer contents.
+// the current buffer contents. The example then resumes editing
+// by calling `read_line()` again — the prompt stays on the same
+// line thanks to suspended-state preservation.
 //
 // To run:
 // cargo run --example break_signal
@@ -23,15 +26,15 @@ fn main() -> io::Result<()> {
     let mut line_editor = Reedline::create().with_break_signal(break_signal.clone());
     let prompt = DefaultPrompt::default();
 
-    // Spawn a thread that triggers the break signal after 3 seconds
+    // Spawn a thread that triggers the break signal periodically
     let signal = break_signal.clone();
-    thread::spawn(move || {
-        thread::sleep(Duration::from_secs(3));
-        println!("\n[background] Setting break signal in...");
+    thread::spawn(move || loop {
+        thread::sleep(Duration::from_secs(5));
         signal.store(true, Ordering::Relaxed);
     });
 
-    println!("Type something. The break signal will fire in 3 seconds...");
+    println!("Type something. The break signal fires every 5 seconds.");
+    println!("The prompt will stay in place after each ExternalBreak.\n");
 
     loop {
         let sig = line_editor.read_line(&prompt)?;
@@ -44,8 +47,14 @@ fn main() -> io::Result<()> {
                 break Ok(());
             }
             Signal::ExternalBreak(buffer) => {
-                println!("\nExternalBreak received! Buffer contents: {buffer:?}");
-                break Ok(());
+                // The buffer contents are preserved across the break.
+                // Simply call read_line() again to let the user continue
+                // editing — the prompt stays on the same line because
+                // ExternalBreak now saves suspended state.
+                if !buffer.is_empty() {
+                    println!("\n[break] Buffer had: {buffer:?} — resuming prompt");
+                }
+                continue;
             }
             _ => {}
         }

--- a/examples/break_signal.rs
+++ b/examples/break_signal.rs
@@ -49,11 +49,10 @@ fn main() -> io::Result<()> {
             Signal::ExternalBreak(buffer) => {
                 // The buffer contents are preserved across the break.
                 // Simply call read_line() again to let the user continue
-                // editing — the prompt stays on the same line because
-                // ExternalBreak now saves suspended state.
-                if !buffer.is_empty() {
-                    println!("\n[break] Buffer had: {buffer:?} — resuming prompt");
-                }
+                // editing — the prompt stays on the same line as long as
+                // nothing is printed between the break and the next
+                // read_line() call.
+                eprintln!("[break] buffer: {buffer:?}");
                 continue;
             }
             _ => {}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -816,7 +816,7 @@ impl Reedline {
                 if signal.swap(false, std::sync::atomic::Ordering::Relaxed) {
                     let buffer = self.editor.get_buffer().to_string();
                     self.input_mode = InputMode::Regular;
-                    self.painter.move_cursor_to_end()?;
+                    self.suspended_state = Some(self.painter.state_before_suspension());
                     self.editor.reset_undo_stack();
                     return Ok(Signal::ExternalBreak(buffer));
                 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -797,7 +797,7 @@ impl Reedline {
         self.painter
             .initialize_prompt_position(self.suspended_state.as_ref())?;
         if self.suspended_state.is_some() {
-            // Last editor was suspended to run a ExecuteHostCommand event,
+            // Last editor was suspended (ExecuteHostCommand or ExternalBreak),
             // we are resuming operation now.
             self.suspended_state = None;
         }
@@ -816,6 +816,7 @@ impl Reedline {
                 if signal.swap(false, std::sync::atomic::Ordering::Relaxed) {
                     let buffer = self.editor.get_buffer().to_string();
                     self.input_mode = InputMode::Regular;
+                    self.last_render_snapshot = None;
                     self.suspended_state = Some(self.painter.state_before_suspension());
                     self.editor.reset_undo_stack();
                     return Ok(Signal::ExternalBreak(buffer));


### PR DESCRIPTION
Follow-up to #1035.

In #1035, when a caller handles `ExternalBreak` by calling `read_line()` again (e.g., to resume editing after inspecting the buffer), the prompt jumps down one line each time.
This is because `move_cursor_to_end()` unconditionally prints a CRLF before returning `ExternalBreak`.

This PR replaces `move_cursor_to_end()` with saving `suspended_state`, matching the pattern used by `ExecuteHostCommand`.
The updated example demonstrates resuming `read_line()` after `ExternalBreak`.