### PR TITLE
Update default prompt to use > character

### DIFF
--- a/src/prompt/default.rs
+++ b/src/prompt/default.rs
@@ -6,9 +6,9 @@ use {
 };
 
 /// The default prompt indicator
-pub static DEFAULT_PROMPT_INDICATOR: &str = "〉";
+pub static DEFAULT_PROMPT_INDICATOR: &str = ">";
 pub static DEFAULT_VI_INSERT_PROMPT_INDICATOR: &str = ": ";
-pub static DEFAULT_VI_NORMAL_PROMPT_INDICATOR: &str = "〉";
+pub static DEFAULT_VI_NORMAL_PROMPT_INDICATOR: &str = ">";
 pub static DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
 
 /// Simple [`Prompt`] displaying a configurable left and a right prompt.

--- a/src/prompt/default.rs
+++ b/src/prompt/default.rs
@@ -6,9 +6,9 @@ use {
 };
 
 /// The default prompt indicator
-pub static DEFAULT_PROMPT_INDICATOR: &str = ">";
+pub static DEFAULT_PROMPT_INDICATOR: &str = "> ";
 pub static DEFAULT_VI_INSERT_PROMPT_INDICATOR: &str = ": ";
-pub static DEFAULT_VI_NORMAL_PROMPT_INDICATOR: &str = ">";
+pub static DEFAULT_VI_NORMAL_PROMPT_INDICATOR: &str = "> ";
 pub static DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
 
 /// Simple [`Prompt`] displaying a configurable left and a right prompt.


### PR DESCRIPTION
The previously used character `RIGHT ANGLE BRACKET` (3009) is not available in many fonts. The usual `GREATER-THAN SIGN` (003e) however is. (Plus it looks nicer).