### PR TITLE
feat(list_menu): add DescriptionPosition to control description place…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,8 +277,8 @@ pub use validator::{DefaultValidator, ValidationResult, Validator};
 
 mod menu;
 pub use menu::{
-    menu_functions, ColumnarMenu, DescriptionMenu, DescriptionMode, IdeMenu, ListMenu, Menu,
-    MenuBuilder, MenuEvent, MenuTextStyle, ReedlineMenu,
+    menu_functions, ColumnarMenu, DescriptionMenu, DescriptionMode, DescriptionPosition, IdeMenu,
+    ListMenu, Menu, MenuBuilder, MenuEvent, MenuTextStyle, ReedlineMenu,
 };
 
 mod terminal_extensions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,8 +291,8 @@ pub use validator::{DefaultValidator, ValidationResult, Validator};
 
 mod menu;
 pub use menu::{
-    menu_functions, ColumnarMenu, DescriptionMenu, DescriptionMode, IdeMenu, InputMode, ListMenu,
-    Menu, MenuBuilder, MenuEvent, MenuSettings, MenuTextStyle, OutputMode, ReedlineMenu,
+    menu_functions, ColumnarMenu, DescriptionMenu, DescriptionMode, DescriptionPosition, IdeMenu,
+    InputMode, ListMenu, Menu, MenuBuilder, MenuEvent, MenuTextStyle, OutputMode, ReedlineMenu,
     TraversalDirection,
 };
 

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -13,6 +13,19 @@ use {
 
 const SELECTION_CHAR: char = '!';
 
+/// Controls where the description is rendered relative to the completion value
+/// in a [`ListMenu`] row.
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub enum DescriptionPosition {
+    /// Description is shown **before** the value, wrapped in parentheses:
+    /// `(description) value`  — the original behaviour.
+    #[default]
+    Before,
+    /// Description is shown **after** the value with a leading space:
+    /// `value description`
+    After,
+}
+
 struct Page {
     size: usize,
     full: bool,
@@ -67,6 +80,8 @@ pub struct ListMenu {
     event: Option<MenuEvent>,
     /// String collected after the menu is activated
     input: Option<String>,
+    /// Controls where the description is rendered relative to the completion value
+    description_position: DescriptionPosition,
 }
 
 impl Default for ListMenu {
@@ -87,6 +102,7 @@ impl Default for ListMenu {
             pages: Vec::new(),
             event: None,
             input: None,
+            description_position: DescriptionPosition::default(),
         }
     }
 }
@@ -111,6 +127,15 @@ impl ListMenu {
     #[must_use]
     pub fn with_max_entry_lines(mut self, max_lines: u16) -> Self {
         self.max_lines = max_lines;
+        self
+    }
+
+    /// Menu builder to set where descriptions are rendered relative to the
+    /// completion value. Defaults to [`DescriptionPosition::Before`] for
+    /// backwards compatibility.
+    #[must_use]
+    pub fn with_description_position(mut self, position: DescriptionPosition) -> Self {
+        self.description_position = position;
         self
     }
 }
@@ -265,40 +290,80 @@ impl ListMenu {
         row_number: &str,
         use_ansi_coloring: bool,
     ) -> String {
-        let description = description.map_or("".to_string(), |desc| {
-            if use_ansi_coloring {
-                format!(
-                    "{}({}) {}",
-                    self.settings.color.description_style.prefix(),
-                    desc,
-                    RESET
-                )
-            } else {
-                format!("({desc}) ")
+        match self.description_position {
+            DescriptionPosition::Before => {
+                let description = description.map_or("".to_string(), |desc| {
+                    if use_ansi_coloring {
+                        format!(
+                            "{}({}) ",
+                            self.settings.color.description_style.prefix(),
+                            desc,
+                        )
+                    } else {
+                        format!("({desc}) ")
+                    }
+                });
+
+                if use_ansi_coloring {
+                    format!(
+                        "{}{}{}{}{}{}",
+                        row_number,
+                        description,
+                        self.text_style(index),
+                        &line,
+                        RESET,
+                        Self::end_of_line(),
+                    )
+                } else {
+                    // If no ansi coloring is found, then the selection word is
+                    // the line in uppercase
+                    let line_str = if index == self.index() {
+                        format!("{}{}>{}", row_number, description, line.to_uppercase())
+                    } else {
+                        format!("{row_number}{description}{line}")
+                    };
+
+                    // Final string with formatting
+                    format!("{}{}", line_str, Self::end_of_line())
+                }
             }
-        });
+            DescriptionPosition::After => {
+                let description = description.map_or("".to_string(), |desc| {
+                    if use_ansi_coloring {
+                        format!(
+                            " {}{}{}",
+                            self.settings.color.description_style.prefix(),
+                            desc,
+                            RESET
+                        )
+                    } else {
+                        format!(" {desc}")
+                    }
+                });
 
-        if use_ansi_coloring {
-            format!(
-                "{}{}{}{}{}{}",
-                row_number,
-                description,
-                self.text_style(index),
-                &line,
-                RESET,
-                Self::end_of_line(),
-            )
-        } else {
-            // If no ansi coloring is found, then the selection word is
-            // the line in uppercase
-            let line_str = if index == self.index() {
-                format!("{}{}>{}", row_number, description, line.to_uppercase())
-            } else {
-                format!("{row_number}{description}{line}")
-            };
+                if use_ansi_coloring {
+                    format!(
+                        "{}{}{}{}{}{}",
+                        row_number,
+                        self.text_style(index),
+                        &line,
+                        RESET,
+                        description,
+                        Self::end_of_line(),
+                    )
+                } else {
+                    // If no ansi coloring is found, then the selection word is
+                    // the line in uppercase
+                    let line_str = if index == self.index() {
+                        format!("{}>{}{}", row_number, line.to_uppercase(), description)
+                    } else {
+                        format!("{row_number}{line}{description}")
+                    };
 
-            // Final string with formatting
-            format!("{}{}", line_str, Self::end_of_line())
+                    // Final string with formatting
+                    format!("{}{}", line_str, Self::end_of_line())
+                }
+            }
         }
     }
 }

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -284,6 +284,8 @@ impl ListMenu {
     fn description_text(&self, description: Option<&str>, use_ansi_coloring: bool) -> String {
         description.map_or_else(String::new, |desc| match self.description_position {
             DescriptionPosition::Before => {
+                // Before keeps the historical `(description) value` shape; After intentionally
+                // leaves the description unwrapped as `value description`.
                 if use_ansi_coloring {
                     format!(
                         "{}({}){} ",
@@ -713,6 +715,26 @@ mod tests {
                 menu.settings.color.description_style.prefix(),
                 RESET,
             )
+        );
+    }
+
+    #[test]
+    fn description_before_formats_without_ansi() {
+        let menu = ListMenu::default();
+
+        assert_eq!(
+            menu.create_string("value", Some("desc"), 0, "", false),
+            "(desc) >VALUE\r\n"
+        );
+    }
+
+    #[test]
+    fn description_after_formats_without_ansi() {
+        let menu = ListMenu::default().with_description_position(DescriptionPosition::After);
+
+        assert_eq!(
+            menu.create_string("value", Some("desc"), 0, "", false),
+            ">VALUE desc\r\n"
         );
     }
 }

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -281,6 +281,35 @@ impl ListMenu {
         }
     }
 
+    fn description_text(&self, description: Option<&str>, use_ansi_coloring: bool) -> String {
+        description.map_or_else(String::new, |desc| match self.description_position {
+            DescriptionPosition::Before => {
+                if use_ansi_coloring {
+                    format!(
+                        "{}({}){} ",
+                        self.settings.color.description_style.prefix(),
+                        desc,
+                        RESET,
+                    )
+                } else {
+                    format!("({desc}) ")
+                }
+            }
+            DescriptionPosition::After => {
+                if use_ansi_coloring {
+                    format!(
+                        " {}{}{}",
+                        self.settings.color.description_style.prefix(),
+                        desc,
+                        RESET
+                    )
+                } else {
+                    format!(" {desc}")
+                }
+            }
+        })
+    }
+
     /// Creates default string that represents one line from a menu
     fn create_string(
         &self,
@@ -290,20 +319,10 @@ impl ListMenu {
         row_number: &str,
         use_ansi_coloring: bool,
     ) -> String {
+        let description = self.description_text(description, use_ansi_coloring);
+
         match self.description_position {
             DescriptionPosition::Before => {
-                let description = description.map_or("".to_string(), |desc| {
-                    if use_ansi_coloring {
-                        format!(
-                            "{}({}) ",
-                            self.settings.color.description_style.prefix(),
-                            desc,
-                        )
-                    } else {
-                        format!("({desc}) ")
-                    }
-                });
-
                 if use_ansi_coloring {
                     format!(
                         "{}{}{}{}{}{}",
@@ -328,19 +347,6 @@ impl ListMenu {
                 }
             }
             DescriptionPosition::After => {
-                let description = description.map_or("".to_string(), |desc| {
-                    if use_ansi_coloring {
-                        format!(
-                            " {}{}{}",
-                            self.settings.color.description_style.prefix(),
-                            desc,
-                            RESET
-                        )
-                    } else {
-                        format!(" {desc}")
-                    }
-                });
-
                 if use_ansi_coloring {
                     format!(
                         "{}{}{}{}{}{}",
@@ -714,5 +720,37 @@ mod tests {
 
         // There is an extra line showing ...
         assert_eq!(res, 4);
+    }
+
+    #[test]
+    fn description_before_resets_style_before_value() {
+        let menu = ListMenu::default();
+
+        assert_eq!(
+            menu.create_string("value", Some("desc"), 1, "", true),
+            format!(
+                "{}(desc){} {}value{}\r\n",
+                menu.settings.color.description_style.prefix(),
+                RESET,
+                menu.text_style(1),
+                RESET,
+            )
+        );
+    }
+
+    #[test]
+    fn description_after_resets_style_after_value() {
+        let menu = ListMenu::default().with_description_position(DescriptionPosition::After);
+
+        assert_eq!(
+            menu.create_string("value", Some("desc"), 1, "", true),
+            format!(
+                "{}value{} {}desc{}\r\n",
+                menu.text_style(1),
+                RESET,
+                menu.settings.color.description_style.prefix(),
+                RESET,
+            )
+        );
     }
 }

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -320,57 +320,19 @@ impl ListMenu {
         use_ansi_coloring: bool,
     ) -> String {
         let description = self.description_text(description, use_ansi_coloring);
+        let value = if use_ansi_coloring {
+            format!("{}{}{}", self.text_style(index), line, RESET)
+        } else if index == self.index() {
+            format!(">{}", line.to_uppercase())
+        } else {
+            line.to_string()
+        };
+        let line = match self.description_position {
+            DescriptionPosition::Before => format!("{description}{value}"),
+            DescriptionPosition::After => format!("{value}{description}"),
+        };
 
-        match self.description_position {
-            DescriptionPosition::Before => {
-                if use_ansi_coloring {
-                    format!(
-                        "{}{}{}{}{}{}",
-                        row_number,
-                        description,
-                        self.text_style(index),
-                        &line,
-                        RESET,
-                        Self::end_of_line(),
-                    )
-                } else {
-                    // If no ansi coloring is found, then the selection word is
-                    // the line in uppercase
-                    let line_str = if index == self.index() {
-                        format!("{}{}>{}", row_number, description, line.to_uppercase())
-                    } else {
-                        format!("{row_number}{description}{line}")
-                    };
-
-                    // Final string with formatting
-                    format!("{}{}", line_str, Self::end_of_line())
-                }
-            }
-            DescriptionPosition::After => {
-                if use_ansi_coloring {
-                    format!(
-                        "{}{}{}{}{}{}",
-                        row_number,
-                        self.text_style(index),
-                        &line,
-                        RESET,
-                        description,
-                        Self::end_of_line(),
-                    )
-                } else {
-                    // If no ansi coloring is found, then the selection word is
-                    // the line in uppercase
-                    let line_str = if index == self.index() {
-                        format!("{}>{}{}", row_number, line.to_uppercase(), description)
-                    } else {
-                        format!("{row_number}{line}{description}")
-                    };
-
-                    // Final string with formatting
-                    format!("{}{}", line_str, Self::end_of_line())
-                }
-            }
-        }
+        format!("{}{}{}", row_number, line, Self::end_of_line())
     }
 }
 

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -11,6 +11,7 @@ pub use columnar_menu::ColumnarMenu;
 pub use description_menu::DescriptionMenu;
 pub use ide_menu::DescriptionMode;
 pub use ide_menu::IdeMenu;
+pub use list_menu::DescriptionPosition;
 pub use list_menu::ListMenu;
 use nu_ansi_term::{Color, Style};
 

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -12,6 +12,7 @@ pub use columnar_menu::TraversalDirection;
 pub use description_menu::DescriptionMenu;
 pub use ide_menu::DescriptionMode;
 pub use ide_menu::IdeMenu;
+pub use list_menu::DescriptionPosition;
 pub use list_menu::ListMenu;
 use nu_ansi_term::{Color, Style};
 


### PR DESCRIPTION
Add a `DescriptionPosition` enum that lets callers choose whether the
completion description is rendered before or after the value in a
`ListMenu` row.

Previously the position was hardcoded as `(description) value`.
The new default keeps that behaviour (`Before`) for backwards
compatibility; setting `After` renders `value description` instead,
which is more natural for flag/option completions where the value
(e.g. `--regexp`) should visually come first.

Changes:
- `DescriptionPosition` enum with `Before` (default) and `After` variants
- `ListMenu::description_position` field (default: `Before`)
- `ListMenu::with_description_position()` builder method
- `create_string()` branches on `self.description_position`
- Re-export `DescriptionPosition` from `menu/mod.rs` and `lib.rs`

This mirrors the existing `IdeMenu::with_description_mode()` pattern.