### PR TITLE
prompt: default prompt colors to the terminal foreground

### DIFF
--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -8,11 +8,12 @@ use {
     strum::EnumIter,
 };
 
-/// The default color for the prompt, indicator, and right prompt
-pub static DEFAULT_PROMPT_COLOR: Color = Color::Green;
-pub static DEFAULT_PROMPT_MULTILINE_COLOR: nu_ansi_term::Color = nu_ansi_term::Color::LightBlue;
-pub static DEFAULT_INDICATOR_COLOR: Color = Color::Cyan;
-pub static DEFAULT_PROMPT_RIGHT_COLOR: Color = Color::AnsiValue(5);
+/// Terminal-default colors for prompt implementations that do not opt into
+/// explicit styling.
+pub static BASE_PROMPT_COLOR: Color = Color::Reset;
+pub static BASE_PROMPT_MULTILINE_COLOR: nu_ansi_term::Color = nu_ansi_term::Color::Default;
+pub static BASE_INDICATOR_COLOR: Color = Color::Reset;
+pub static BASE_PROMPT_RIGHT_COLOR: Color = Color::Reset;
 
 /// The current success/failure of the history search
 pub enum PromptHistorySearchStatus {
@@ -98,21 +99,21 @@ pub trait Prompt: Send {
         &self,
         history_search: PromptHistorySearch,
     ) -> Cow<'_, str>;
-    /// Get the default prompt color
+    /// Get the base prompt color
     fn get_prompt_color(&self) -> Color {
-        DEFAULT_PROMPT_COLOR
+        BASE_PROMPT_COLOR
     }
-    /// Get the default multiline prompt color
+    /// Get the base multiline prompt color
     fn get_prompt_multiline_color(&self) -> nu_ansi_term::Color {
-        DEFAULT_PROMPT_MULTILINE_COLOR
+        BASE_PROMPT_MULTILINE_COLOR
     }
-    /// Get the default indicator color
+    /// Get the base indicator color
     fn get_indicator_color(&self) -> Color {
-        DEFAULT_INDICATOR_COLOR
+        BASE_INDICATOR_COLOR
     }
-    /// Get the default right prompt color
+    /// Get the base right prompt color
     fn get_prompt_right_color(&self) -> Color {
-        DEFAULT_PROMPT_RIGHT_COLOR
+        BASE_PROMPT_RIGHT_COLOR
     }
 
     /// Whether to render right prompt on the last line

--- a/src/prompt/default.rs
+++ b/src/prompt/default.rs
@@ -2,6 +2,7 @@ use crate::{Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStat
 
 use {
     chrono::Local,
+    crossterm::style::Color,
     std::{borrow::Cow, env},
 };
 
@@ -10,6 +11,11 @@ pub static DEFAULT_PROMPT_INDICATOR: &str = "〉";
 pub static DEFAULT_VI_INSERT_PROMPT_INDICATOR: &str = ": ";
 pub static DEFAULT_VI_NORMAL_PROMPT_INDICATOR: &str = "〉";
 pub static DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
+/// The default prompt colors
+pub static DEFAULT_PROMPT_COLOR: Color = Color::Green;
+pub static DEFAULT_PROMPT_MULTILINE_COLOR: nu_ansi_term::Color = nu_ansi_term::Color::LightBlue;
+pub static DEFAULT_INDICATOR_COLOR: Color = Color::Cyan;
+pub static DEFAULT_PROMPT_RIGHT_COLOR: Color = Color::AnsiValue(5);
 
 /// Simple [`Prompt`] displaying a configurable left and a right prompt.
 /// For more fine-tuned configuration, implement the [`Prompt`] trait.
@@ -88,6 +94,22 @@ impl Prompt for DefaultPrompt {
             "({}reverse-search: {}) ",
             prefix, history_search.term
         ))
+    }
+
+    fn get_prompt_color(&self) -> Color {
+        DEFAULT_PROMPT_COLOR
+    }
+
+    fn get_prompt_multiline_color(&self) -> nu_ansi_term::Color {
+        DEFAULT_PROMPT_MULTILINE_COLOR
+    }
+
+    fn get_indicator_color(&self) -> Color {
+        DEFAULT_INDICATOR_COLOR
+    }
+
+    fn get_prompt_right_color(&self) -> Color {
+        DEFAULT_PROMPT_RIGHT_COLOR
     }
 }
 


### PR DESCRIPTION
https://github.com/nushell/reedline/pull/992 reset stale sgr state before each repaint, which fixed prompt color bleed from previous command output. it did not fix the starship case reported in https://github.com/starship/starship/issues/6560 and https://github.com/nushell/nushell/issues/16384 because reedline still applied its own default prompt colors immediately before printing the prompt.

that meant a prompt implementation that returned ansi text without overriding `get_prompt_color()` still inherited reedline's defaults. for starship, `style = "none"` emits no color sequence at all, so the first visible character inherited reedline's green prompt color instead of the terminal's foreground color.

this patch changes the default prompt, multiline, indicator, and right-prompt colors to the terminal defaults. prompts that want explicit colors can still override the color methods, but unstyled prompts now stay unstyled and no longer need an extra reset sequence to avoid the green first character.
