### PR TITLE
refactor!: graceful handle ReedlineEvent::CtrlC

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1241,8 +1241,8 @@ impl Reedline {
                 }
             }
             ReedlineEvent::CtrlC => {
+                self.deactivate_menus();
                 if self.editor.is_empty() {
-                    self.deactivate_menus();
                     self.editor.reset_undo_stack();
                     Ok(EventStatus::Exits(Signal::CtrlC))
                 } else {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1241,10 +1241,14 @@ impl Reedline {
                 }
             }
             ReedlineEvent::CtrlC => {
-                self.deactivate_menus();
-                self.run_edit_commands(&[EditCommand::Clear]);
-                self.editor.reset_undo_stack();
-                Ok(EventStatus::Exits(Signal::CtrlC))
+                if self.editor.is_empty() {
+                    self.deactivate_menus();
+                    self.editor.reset_undo_stack();
+                    Ok(EventStatus::Exits(Signal::CtrlC))
+                } else {
+                    self.run_edit_commands(&[EditCommand::Clear]);
+                    Ok(EventStatus::Handled)
+                }
             }
             ReedlineEvent::ClearScreen => {
                 self.deactivate_menus();


### PR DESCRIPTION
This closes https://github.com/nushell/reedline/issues/1050

This aligns the manner of `ReedlineEvent::CtrlD`. I don't know what `self.deactivate_menus();` does so do my guess to put it in the `if self.editor.is_empty()` branch.