### PR TITLE
deprecate `get_reedline_reedline_events`, `get_reedline_edit_commands` and `get_reedline_prompt_edit_modes`

### DIFF
--- a/examples/list_bindings.rs
+++ b/examples/list_bindings.rs
@@ -1,8 +1,8 @@
 use reedline::{
-    get_reedline_default_keybindings, get_reedline_edit_commands,
-    get_reedline_keybinding_modifiers, get_reedline_keycodes, get_reedline_prompt_edit_modes,
-    get_reedline_reedline_events,
+    get_reedline_default_keybindings, get_reedline_keybinding_modifiers, get_reedline_keycodes,
+    EditCommandDiscriminants, PromptEditModeDiscriminants, ReedlineEventDiscriminants,
 };
+use strum::IntoEnumIterator;
 
 fn main() {
     get_all_keybinding_info();
@@ -17,8 +17,8 @@ fn get_all_keybinding_info() {
     }
 
     println!("\n--Modes--");
-    for modes in get_reedline_prompt_edit_modes().iter() {
-        println!("{modes}");
+    for modes in PromptEditModeDiscriminants::iter() {
+        println!("{modes:?}");
     }
 
     println!("\n--Key Codes--");
@@ -27,13 +27,13 @@ fn get_all_keybinding_info() {
     }
 
     println!("\n--Reedline Events--");
-    for rle in get_reedline_reedline_events().iter() {
-        println!("{rle}");
+    for rle in ReedlineEventDiscriminants::iter() {
+        println!("{rle:?}");
     }
 
     println!("\n--Edit Commands--");
-    for edit in get_reedline_edit_commands().iter() {
-        println!("{edit}");
+    for edit in EditCommandDiscriminants::iter() {
+        println!("{edit:?}");
     }
 
     println!("\n--Default Keybindings--");

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -492,7 +492,7 @@ pub enum EditCommand {
 // the users. Hence some are marked `Optional` and some have different parameter names.
 // This is also very hard to keep in sync with nushell.
 // So, recently its discriminants are exposed using the strum EnumDiscriminants, and downstream is
-// expected to use that if they want to display the list of availiable commands to their users.
+// expected to use that if they want to display the list of available commands to their users.
 impl Display for EditCommand {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
@@ -958,7 +958,7 @@ pub enum ReedlineEvent {
 // the users.
 // This is also very hard to keep in sync with nushell.
 // So, recently its discriminants are exposed using the strum EnumDiscriminants, and downstream is
-// expected to use that if they want to display the list of availiable commands to their users.
+// expected to use that if they want to display the list of available commands to their users.
 impl Display for ReedlineEvent {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -86,7 +86,7 @@ impl Default for TextObject {
 #[non_exhaustive]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, EnumDiscriminants, EnumIter)]
 #[strum_discriminants(doc = "This is the auto generated discriminant type for [`EditCommand`]")]
-#[strum_discriminants(derive(EnumString, VariantArray))]
+#[strum_discriminants(derive(EnumIter, EnumString, VariantArray))]
 #[strum_discriminants(strum(ascii_case_insensitive))]
 pub enum EditCommand {
     /// Move to the start of the buffer
@@ -487,6 +487,12 @@ pub enum EditCommand {
     },
 }
 
+// FIXME: This implementation makes no sense to be here, and should be removed in a future version
+// It was originally added for nushell to show all the available commands and their parameters to
+// the users. Hence some are marked `Optional` and some have different parameter names.
+// This is also very hard to keep in sync with nushell.
+// So, recently its discriminants are exposed using the strum EnumDiscriminants, and downstream is
+// expected to use that if they want to display the list of availiable commands to their users.
 impl Display for EditCommand {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
@@ -806,7 +812,7 @@ impl UndoBehavior {
 /// Reedline supported actions.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, EnumDiscriminants, EnumIter)]
 #[strum_discriminants(doc = "This is the auto generated discriminant type for [`ReedlineEvent`]")]
-#[strum_discriminants(derive(EnumString, VariantArray))]
+#[strum_discriminants(derive(EnumIter, EnumString, VariantArray))]
 #[strum_discriminants(strum(ascii_case_insensitive))]
 pub enum ReedlineEvent {
     /// No op event
@@ -947,6 +953,12 @@ pub enum ReedlineEvent {
     ViChangeMode(String),
 }
 
+// FIXME: This implementation makes no sense to be here, and should be removed in a future version
+// It was originally added for nushell to show all the available commands and their parameters to
+// the users.
+// This is also very hard to keep in sync with nushell.
+// So, recently its discriminants are exposed using the strum EnumDiscriminants, and downstream is
+// expected to use that if they want to display the list of availiable commands to their users.
 impl Display for ReedlineEvent {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,10 +305,12 @@ mod utils;
 
 mod external_printer;
 pub use utils::{
-    get_reedline_default_keybindings, get_reedline_edit_commands,
-    get_reedline_keybinding_modifiers, get_reedline_keycodes, get_reedline_prompt_edit_modes,
-    get_reedline_reedline_events,
+    get_reedline_default_keybindings, get_reedline_keybinding_modifiers, get_reedline_keycodes,
+    get_reedline_prompt_edit_modes,
 };
+
+#[expect(deprecated)]
+pub use utils::{get_reedline_edit_commands, get_reedline_reedline_events};
 
 // Reexport the key types to be independent from an explicit crossterm dependency.
 pub use crossterm::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,8 +264,8 @@ pub use history::{
 
 mod prompt;
 pub use prompt::{
-    DefaultPrompt, DefaultPromptSegment, Prompt, PromptEditMode, PromptHistorySearch,
-    PromptHistorySearchStatus, PromptViMode,
+    DefaultPrompt, DefaultPromptSegment, Prompt, PromptEditMode, PromptEditModeDiscriminants,
+    PromptHistorySearch, PromptHistorySearchStatus, PromptViMode,
 };
 
 mod edit_mode;
@@ -306,11 +306,12 @@ mod utils;
 mod external_printer;
 pub use utils::{
     get_reedline_default_keybindings, get_reedline_keybinding_modifiers, get_reedline_keycodes,
-    get_reedline_prompt_edit_modes,
 };
 
 #[expect(deprecated)]
-pub use utils::{get_reedline_edit_commands, get_reedline_reedline_events};
+pub use utils::{
+    get_reedline_edit_commands, get_reedline_prompt_edit_modes, get_reedline_reedline_events,
+};
 
 // Reexport the key types to be independent from an explicit crossterm dependency.
 pub use crossterm::{

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -99,17 +99,6 @@ impl From<PromptViMode> for PromptEditMode {
     }
 }
 
-impl TryFrom<PromptEditMode> for PromptViMode {
-    type Error = ();
-
-    fn try_from(value: PromptEditMode) -> Result<Self, Self::Error> {
-        match value {
-            PromptEditMode::Vi(vi_mode) => Ok(vi_mode),
-            _ => Err(()),
-        }
-    }
-}
-
 impl Display for PromptEditMode {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         use PromptViMode as Vi;

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -5,7 +5,7 @@ use {
         borrow::Cow,
         fmt::{Display, Formatter},
     },
-    strum::EnumIter,
+    strum::{EnumIter, EnumString, IntoDiscriminant},
 };
 
 /// The default color for the prompt, indicator, and right prompt
@@ -70,16 +70,74 @@ pub enum PromptViMode {
     Insert,
 }
 
-impl Display for PromptEditMode {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        match self {
-            PromptEditMode::Default => write!(f, "Default"),
-            PromptEditMode::Emacs => write!(f, "Emacs"),
-            PromptEditMode::Vi(_) => write!(f, "Vi_Normal\nVi_Insert"),
-            PromptEditMode::Custom(s) => write!(f, "Custom_{s}"),
+/// This is the discriminant type for [`PromptEditMode`]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, EnumIter, EnumString)]
+#[strum(ascii_case_insensitive)]
+pub enum PromptEditModeDiscriminants {
+    /// The default mode
+    #[default]
+    Default,
+
+    /// Emacs normal mode
+    Emacs,
+
+    /// Vi normal mode
+    #[strum(serialize = "ViNormal", serialize = "vi_normal")]
+    ViNormal,
+
+    /// Vi insert mode
+    #[strum(serialize = "ViInsert", serialize = "vi_insert")]
+    ViInsert,
+
+    /// A custom mode
+    Custom,
+}
+
+impl From<PromptViMode> for PromptEditMode {
+    fn from(value: PromptViMode) -> Self {
+        Self::Vi(value)
+    }
+}
+
+impl TryFrom<PromptEditMode> for PromptViMode {
+    type Error = ();
+
+    fn try_from(value: PromptEditMode) -> Result<Self, Self::Error> {
+        match value {
+            PromptEditMode::Vi(vi_mode) => Ok(vi_mode),
+            _ => Err(()),
         }
     }
 }
+
+impl Display for PromptEditMode {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        use PromptViMode as Vi;
+        match self {
+            Self::Default => write!(f, "Default"),
+            Self::Emacs => write!(f, "Emacs"),
+            Self::Vi(Vi::Normal) => write!(f, "Vi_Normal"),
+            Self::Vi(Vi::Insert) => write!(f, "Vi_Insert"),
+            Self::Custom(s) => write!(f, "Custom_{s}"),
+        }
+    }
+}
+
+impl IntoDiscriminant for PromptEditMode {
+    type Discriminant = PromptEditModeDiscriminants;
+
+    fn discriminant(&self) -> Self::Discriminant {
+        use PromptViMode as Vi;
+        match self {
+            Self::Default => Self::Discriminant::Default,
+            Self::Emacs => Self::Discriminant::Emacs,
+            Self::Vi(Vi::Normal) => Self::Discriminant::ViNormal,
+            Self::Vi(Vi::Insert) => Self::Discriminant::ViInsert,
+            Self::Custom(_) => Self::Discriminant::Custom,
+        }
+    }
+}
+
 /// API to provide a custom prompt.
 ///
 /// Implementors have to provide [`str`]-based content which will be

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -2,7 +2,8 @@ mod base;
 mod default;
 
 pub use base::{
-    Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode,
+    Prompt, PromptEditMode, PromptEditModeDiscriminants, PromptHistorySearch,
+    PromptHistorySearchStatus, PromptViMode,
 };
 
 pub use default::{DefaultPrompt, DefaultPromptSegment};

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,8 +3,9 @@ pub(crate) mod text_manipulation;
 
 pub use query::{
     get_reedline_default_keybindings, get_reedline_keybinding_modifiers, get_reedline_keycodes,
-    get_reedline_prompt_edit_modes,
 };
 
 #[expect(deprecated)]
-pub use query::{get_reedline_edit_commands, get_reedline_reedline_events};
+pub use query::{
+    get_reedline_edit_commands, get_reedline_prompt_edit_modes, get_reedline_reedline_events,
+};

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,7 +2,9 @@ mod query;
 pub(crate) mod text_manipulation;
 
 pub use query::{
-    get_reedline_default_keybindings, get_reedline_edit_commands,
-    get_reedline_keybinding_modifiers, get_reedline_keycodes, get_reedline_prompt_edit_modes,
-    get_reedline_reedline_events,
+    get_reedline_default_keybindings, get_reedline_keybinding_modifiers, get_reedline_keycodes,
+    get_reedline_prompt_edit_modes,
 };
+
+#[expect(deprecated)]
+pub use query::{get_reedline_edit_commands, get_reedline_reedline_events};

--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -90,6 +90,7 @@ pub fn get_reedline_keybinding_modifiers() -> Vec<String> {
 }
 
 /// Return a `Vec<String>` of the Reedline [`PromptEditMode`]s
+#[deprecated = "use PromptEditModeDiscriminants::iter() to display them"]
 pub fn get_reedline_prompt_edit_modes() -> Vec<String> {
     PromptEditMode::iter().map(|em| em.to_string()).collect()
 }

--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -102,11 +102,13 @@ pub fn get_reedline_keycodes() -> Vec<String> {
 }
 
 /// Return a `Vec<String>` of the Reedline [`ReedlineEvent`]s
+#[deprecated = "use ReedlineEventDiscriminants::iter() to display them"]
 pub fn get_reedline_reedline_events() -> Vec<String> {
     ReedlineEvent::iter().map(|rle| rle.to_string()).collect()
 }
 
 /// Return a `Vec<String>` of the Reedline [`EditCommand`]s
+#[deprecated = "use EditCommandDiscriminants::iter() to display them"]
 pub fn get_reedline_edit_commands() -> Vec<String> {
     EditCommand::iter().map(|edit| edit.to_string()).collect()
 }


### PR DESCRIPTION
deprecate `get_reedline_reedline_events`, `get_reedline_edit_commands` and `get_reedline_prompt_edit_modes`

Display implementations of these enums were a hack. The strings were supposed represent how nushell (a downstream dependency) parses user inputs. And it often goes out of sync.
But now nushell uses the enum discriminants to display the values.