### PR TITLE
Add vi normal mode `o` and `O` command

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -81,6 +81,8 @@ impl Editor {
             EditCommand::Complete => {}
             EditCommand::InsertString(str) => self.insert_str(str),
             EditCommand::InsertNewline => self.insert_newline(),
+            EditCommand::InsertNewlineAbove => self.insert_newline_above(),
+            EditCommand::InsertNewlineBelow => self.insert_newline_below(),
             EditCommand::ReplaceChar(chr) => self.replace_char(*chr),
             EditCommand::ReplaceChars(n_chars, str) => self.replace_chars(*n_chars, str),
             EditCommand::Backspace => self.backspace(),
@@ -773,6 +775,21 @@ impl Editor {
 
     fn insert_newline(&mut self) {
         self.delete_selection();
+        self.line_buffer.insert_newline();
+    }
+
+    fn insert_newline_above(&mut self) {
+        let index = self.line_buffer.find_char_left('\n', false).unwrap_or(0);
+        self.line_buffer.set_insertion_point(index);
+        self.line_buffer.insert_newline();
+    }
+
+    fn insert_newline_below(&mut self) {
+        let index = self
+            .line_buffer
+            .find_char_right('\n', false)
+            .unwrap_or(self.line_buffer.len());
+        self.line_buffer.set_insertion_point(index);
         self.line_buffer.insert_newline();
     }
 

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -155,7 +155,7 @@ where
         Some(&&o @ ('o' | 'O')) => match mode {
             ViMode::Normal => {
                 let _ = input.next();
-                if o == 'o' {
+                if o.is_ascii_lowercase() {
                     Some(Command::NewlineBelow)
                 } else {
                     Some(Command::NewlineAbove)

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -3,7 +3,7 @@ use crate::enums::{TextObject, TextObjectScope, TextObjectType};
 use crate::{EditCommand, ReedlineEvent, Vi};
 use std::iter::Peekable;
 
-pub fn parse_command<'iter, I>(input: &mut Peekable<I>) -> Option<Command>
+pub fn parse_command<'iter, I>(mode: ViMode, input: &mut Peekable<I>) -> Option<Command>
 where
     I: Iterator<Item = &'iter char>,
 {
@@ -152,10 +152,22 @@ where
             let _ = input.next();
             Some(Command::RepeatLastAction)
         }
-        Some('o') => {
-            let _ = input.next();
-            Some(Command::SwapCursorAndAnchor)
-        }
+        Some(&&o @ ('o' | 'O')) => match mode {
+            ViMode::Normal => {
+                let _ = input.next();
+                if o == 'o' {
+                    Some(Command::NewlineBelow)
+                } else {
+                    Some(Command::NewlineAbove)
+                }
+            }
+            ViMode::Visual => {
+                let _ = input.next();
+                Some(Command::SwapCursorAndAnchor)
+            }
+            // This arm should be unreachable
+            ViMode::Insert => None,
+        },
         _ => None,
     }
 }
@@ -167,6 +179,8 @@ pub enum Command {
     DeleteChar,
     ReplaceChar(char),
     SubstituteCharWithInsert,
+    NewlineAbove,
+    NewlineBelow,
     PasteAfter,
     PasteBefore,
     EnterViAppend,
@@ -214,6 +228,8 @@ impl Command {
             Self::EnterViAppend => vec![ReedlineOption::Edit(EditCommand::MoveRight {
                 select: false,
             })],
+            Self::NewlineAbove => vec![ReedlineOption::Edit(EditCommand::InsertNewlineAbove)],
+            Self::NewlineBelow => vec![ReedlineOption::Edit(EditCommand::InsertNewlineBelow)],
             Self::PasteAfter => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferAfter)],
             Self::PasteBefore => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferBefore)],
             Self::Undo => vec![ReedlineOption::Edit(EditCommand::Undo)],

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -98,7 +98,7 @@ impl EditMode for Vi {
                             c
                         });
 
-                        let res = parse(&mut self.cache.iter().peekable());
+                        let res = parse(self.mode, &mut self.cache.iter().peekable());
 
                         if !res.is_valid() {
                             self.cache.clear();

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -100,6 +100,8 @@ impl ParsedViSequence {
         match (&self.command, &self.motion) {
             (Some(Command::EnterViInsert), ParseResult::Incomplete)
             | (Some(Command::EnterViAppend), ParseResult::Incomplete)
+            | (Some(Command::NewlineAbove), ParseResult::Incomplete)
+            | (Some(Command::NewlineBelow), ParseResult::Incomplete)
             | (Some(Command::ChangeToLineEnd), ParseResult::Incomplete)
             | (Some(Command::AppendToEnd), ParseResult::Incomplete)
             | (Some(Command::PrependToStart), ParseResult::Incomplete)
@@ -181,12 +183,12 @@ where
     }
 }
 
-pub fn parse<'iter, I>(input: &mut Peekable<I>) -> ParsedViSequence
+pub fn parse<'iter, I>(mode: ViMode, input: &mut Peekable<I>) -> ParsedViSequence
 where
     I: Iterator<Item = &'iter char>,
 {
     let multiplier = parse_number(input);
-    let command = parse_command(input);
+    let command = parse_command(mode, input);
     let count = parse_number(input);
     let motion = parse_motion(input, command.as_ref().and_then(Command::whole_line_char));
 
@@ -205,7 +207,7 @@ mod tests {
     use rstest::rstest;
 
     fn vi_parse(input: &[char]) -> ParsedViSequence {
-        parse(&mut input.iter().peekable())
+        parse(ViMode::Normal, &mut input.iter().peekable())
     }
 
     #[test]

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -205,6 +205,18 @@ pub enum EditCommand {
     /// - On Windows CRLF (`"\r\n"`)
     InsertNewline,
 
+    /// Inserts a new line above the current line
+    ///
+    /// - On Unix systems LF (`"\n"`)
+    /// - On Windows CRLF (`"\r\n"`)
+    InsertNewlineAbove,
+
+    /// Inserts a new line below the current line
+    ///
+    /// - On Unix systems LF (`"\n"`)
+    /// - On Windows CRLF (`"\r\n"`)
+    InsertNewlineBelow,
+
     /// Replace a character
     ReplaceChar(char),
 
@@ -536,6 +548,8 @@ impl Display for EditCommand {
             EditCommand::InsertChar(_) => write!(f, "InsertChar  Value: <char>"),
             EditCommand::InsertString(_) => write!(f, "InsertString Value: <string>"),
             EditCommand::InsertNewline => write!(f, "InsertNewline"),
+            EditCommand::InsertNewlineAbove => write!(f, "InsertNewlineAbove"),
+            EditCommand::InsertNewlineBelow => write!(f, "InsertNewlineBelow"),
             EditCommand::ReplaceChar(_) => write!(f, "ReplaceChar <char>"),
             EditCommand::ReplaceChars(_, _) => write!(f, "ReplaceChars <int> <string>"),
             EditCommand::Backspace => write!(f, "Backspace"),
@@ -661,6 +675,8 @@ impl EditCommand {
             | EditCommand::CutChar
             | EditCommand::InsertString(_)
             | EditCommand::InsertNewline
+            | EditCommand::InsertNewlineAbove
+            | EditCommand::InsertNewlineBelow
             | EditCommand::ReplaceChar(_)
             | EditCommand::ReplaceChars(_, _)
             | EditCommand::BackspaceWord


### PR DESCRIPTION
This add two new vi mode command
- `o`: inserts a newline below the cursor and enters insert mode
- `O`: inserts a newline above the cursor and enters insert mode