### PR TITLE
fix: Always reset undo stack on Ctrl+C event

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1242,8 +1242,8 @@ impl Reedline {
             }
             ReedlineEvent::CtrlC => {
                 self.deactivate_menus();
+                self.editor.reset_undo_stack();
                 if self.editor.is_empty() {
-                    self.editor.reset_undo_stack();
                     Ok(EventStatus::Exits(Signal::CtrlC))
                 } else {
                     self.run_edit_commands(&[EditCommand::Clear]);


### PR DESCRIPTION
This follows up https://github.com/nushell/reedline/pull/1051#discussion_r3102333012