### PR TITLE
feat: add support for fish-like abbreviations

### DIFF
--- a/examples/abbreviations.rs
+++ b/examples/abbreviations.rs
@@ -1,0 +1,31 @@
+// Create a default reedline object to handle user input
+// cargo run --example abbreviations
+//
+// You can browse the local (non persistent) history using Up/Down or Ctrl n/p.
+
+use reedline::{DefaultPrompt, Reedline, Signal};
+use std::{collections::HashMap, io};
+
+fn main() -> io::Result<()> {
+    let mut abbrevs = HashMap::new();
+    abbrevs.insert(String::from("ll"), String::from("ls -l"));
+    abbrevs.insert(String::from("gs"), String::from("git status"));
+    // Create a new Reedline engine with a local History that is not synchronized to a file and our
+    // abbreviations
+    let mut line_editor = Reedline::create().with_abbreviations(abbrevs);
+    let prompt = DefaultPrompt::default();
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {buffer}");
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -273,6 +273,59 @@ impl Editor {
         self.line_buffer.get_buffer()
     }
 
+    /// Check if a position in the buffer is inside an unclosed string literal
+    pub fn is_inside_string_literal(&self, position: usize) -> bool {
+        let buffer = self.get_buffer();
+
+        if buffer.is_empty() || position == 0 {
+            return false;
+        }
+        if !buffer.contains('"') && !buffer.contains('\'') {
+            return false;
+        }
+
+        let target_byte_pos = buffer
+            .char_indices()
+            .nth(position)
+            .map(|(byte_idx, _)| byte_idx)
+            .unwrap_or(buffer.len());
+
+        let bytes = buffer.as_bytes();
+        let mut in_single_quote = false;
+        let mut in_double_quote = false;
+        let mut escaped = false;
+        let mut byte_pos = 0;
+
+        for &byte in bytes {
+            if byte_pos > target_byte_pos {
+                break;
+            }
+
+            if escaped {
+                escaped = false;
+                byte_pos += 1;
+                continue;
+            }
+
+            match byte {
+                b'\\' => {
+                    escaped = true;
+                }
+                b'\'' if !in_double_quote => {
+                    in_single_quote = !in_single_quote;
+                }
+                b'"' if !in_single_quote => {
+                    in_double_quote = !in_double_quote;
+                }
+                _ => {}
+            }
+
+            byte_pos += 1;
+        }
+
+        in_single_quote || in_double_quote
+    }
+
     /// Edit the [`LineBuffer`] in an undo-safe manner.
     pub fn edit_buffer<F>(&mut self, func: F, undo_behavior: UndoBehavior)
     where

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -273,7 +273,7 @@ impl Editor {
         self.line_buffer.get_buffer()
     }
 
-    /// Check if a position in the buffer is inside an unclosed string literal
+    /// Check if `position` (a byte offset) is inside an unclosed string literal.
     pub fn is_inside_string_literal(&self, position: usize) -> bool {
         let buffer = self.get_buffer();
 
@@ -284,12 +284,6 @@ impl Editor {
             return false;
         }
 
-        let target_byte_pos = buffer
-            .char_indices()
-            .nth(position)
-            .map(|(byte_idx, _)| byte_idx)
-            .unwrap_or(buffer.len());
-
         let bytes = buffer.as_bytes();
         let mut in_single_quote = false;
         let mut in_double_quote = false;
@@ -297,7 +291,7 @@ impl Editor {
         let mut byte_pos = 0;
 
         for &byte in bytes {
-            if byte_pos > target_byte_pos {
+            if byte_pos > position {
                 break;
             }
 

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -2241,6 +2241,23 @@ mod test {
     #[case("'say \"hi\"'", 6, true)]
     // Position 0 is never inside a string
     #[case(r#""open"#, 0, false)]
+    // Cyrillic (2-byte UTF-8 chars): char boundary positions
+    #[case("Сегодня хороший день.", 14, false)]
+    #[case("Сегодня 'хороший' день.", 16, true)]
+    #[case("Сегодня 'хороший' день.", 31, false)]
+    #[case("'Сегодня хороший день.", 2, true)]
+    // Emoji (4-byte UTF-8 chars): char boundary positions
+    #[case("this is fire 🔥", 3, false)]
+    #[case("'hello there' 👋🏼", 13, false)]
+    #[case("'this is fire 🔥", 14, true)]
+    #[case("'hello there 👋🏼", 13, true)]
+    // Japanese (3-byte UTF-8 chars): char boundary and mid-char positions
+    #[case("今日はいい日だ。", 6, false)]
+    #[case("'今日はいい日だ。", 6, true)]
+    #[case("'今日はいい日だ。", 7, true)]
+    // Mid-char byte positions within multi-byte sequences are also handled correctly
+    #[case("Сегодня 'хороший' день.", 19, true)]
+    #[case("'hello there 👋🏼", 14, true)]
     fn test_is_inside_string_literal(
         #[case] buffer: &str,
         #[case] position: usize,

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -2215,4 +2215,38 @@ mod test {
         assert_eq!(bracket_result, expected_bracket);
         assert_eq!(quote_result, expected_quote);
     }
+
+    #[rstest]
+    // Not inside any string
+    #[case("hello world", 5, false)]
+    #[case("", 0, false)]
+    #[case("no quotes here", 0, false)]
+    // Closed double-quoted string — position is after the closing quote
+    #[case(r#""hello" world"#, 8, false)]
+    // Inside an unclosed double-quoted string
+    #[case(r#""hello world"#, 5, true)]
+    // Closed double-quoted string — position is inside it
+    #[case(r#""hello" world"#, 3, true)]
+    // Inside an unclosed single-quoted string
+    #[case("'hello world", 5, true)]
+    // Closed single-quoted string
+    #[case("'hello' world", 8, false)]
+    // Escaped quote does not open/close a string
+    #[case(r#"say \"hello"#, 6, false)]
+    // Escaped quote inside an open string — still inside
+    #[case(r#""say \"hello"#, 9, true)]
+    // Mixed: single inside double (single quote is literal)
+    #[case(r#""it's fine""#, 5, true)]
+    // Mixed: double inside single (double quote is literal)
+    #[case("'say \"hi\"'", 6, true)]
+    // Position 0 is never inside a string
+    #[case(r#""open"#, 0, false)]
+    fn test_is_inside_string_literal(
+        #[case] buffer: &str,
+        #[case] position: usize,
+        #[case] expected: bool,
+    ) {
+        let editor = editor_with(buffer);
+        assert_eq!(editor.is_inside_string_literal(position), expected);
+    }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -187,7 +187,7 @@ pub struct Reedline {
     // Engine Menus
     menus: Vec<ReedlineMenu>,
 
-    abbreviations: HashMap<Vec<u8>, Vec<u8>>,
+    abbreviations: HashMap<String, String>,
 
     // Text editor used to open the line buffer for editing
     buffer_editor: Option<BufferEditor>,
@@ -625,7 +625,7 @@ impl Reedline {
     /// A builder that adds abbreviations to the Reedline engine
     ///
     /// Overwrites any existing abbreviations with the same key.
-    pub fn with_abbreviations(mut self, abbreviations: HashMap<Vec<u8>, Vec<u8>>) -> Self {
+    pub fn with_abbreviations(mut self, abbreviations: HashMap<String, String>) -> Self {
         self.abbreviations.extend(abbreviations);
         self
     }
@@ -1767,8 +1767,8 @@ impl Reedline {
 
         let chars: Vec<char> = buffer.chars().collect();
         let (offset, suffix) = match submitted {
-            true => (0, ""),
-            false => (1, " "),
+            true => (0, ""),   // expand on <enter>
+            false => (1, " "), // expand on <space>
         };
 
         let mut word_start = cursor_position_in_buffer - 1;
@@ -1780,13 +1780,14 @@ impl Reedline {
         if word_start >= word_end {
             // The first char in the buffer is a space or there are consecutive spaces
             return None;
-        } else if self.editor.is_inside_string_literal(word_start) {
+        }
+        if self.editor.is_inside_string_literal(word_start) {
             return None;
         }
 
         let word: String = chars[word_start..word_end].iter().collect();
-        if let Some(expansion) = self.abbreviations.get(word.as_bytes()) {
-            let commands = vec![
+        if let Some(expansion) = self.abbreviations.get(&word) {
+            return Some(ReedlineEvent::Edit(vec![
                 EditCommand::MoveToPosition {
                     position: word_start,
                     select: false,
@@ -1795,14 +1796,8 @@ impl Reedline {
                     position: word_end,
                     select: true,
                 },
-                EditCommand::InsertString(format!(
-                    "{}{}",
-                    String::from_utf8_lossy(expansion),
-                    suffix
-                )),
-            ];
-
-            return Some(ReedlineEvent::Edit(commands));
+                EditCommand::InsertString(format!("{}{}", expansion, suffix)),
+            ]));
         }
 
         None

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use itertools::Itertools;
 use nu_ansi_term::{Color, Style};
@@ -187,6 +187,8 @@ pub struct Reedline {
     // Engine Menus
     menus: Vec<ReedlineMenu>,
 
+    abbreviations: HashMap<Vec<u8>, Vec<u8>>,
+
     // Text editor used to open the line buffer for editing
     buffer_editor: Option<BufferEditor>,
 
@@ -287,6 +289,7 @@ impl Reedline {
             mouse_click_mode: MouseClickMode::default(),
             cwd: None,
             menus: Vec::new(),
+            abbreviations: HashMap::new(),
             buffer_editor: None,
             cursor_shapes: None,
             bracketed_paste: BracketedPasteGuard::default(),
@@ -616,6 +619,14 @@ impl Reedline {
     #[must_use]
     pub fn clear_menus(mut self) -> Self {
         self.menus = Vec::new();
+        self
+    }
+
+    /// A builder that adds abbreviations to the Reedline engine
+    ///
+    /// Overwrites any existing abbreviations with the same key.
+    pub fn with_abbreviations(mut self, abbreviations: HashMap<Vec<u8>, Vec<u8>>) -> Self {
+        self.abbreviations.extend(abbreviations);
         self
     }
 
@@ -1278,6 +1289,9 @@ impl Reedline {
                 if let Some(event) = self.parse_bang_command() {
                     return self.handle_editor_event(prompt, event);
                 }
+                if let Some(event) = self.try_expand_abbreviation_at_cursor(true) {
+                    return self.handle_editor_event(prompt, event);
+                }
 
                 let buffer = self.editor.get_buffer().to_string();
                 match self.validator.as_mut().map(|v| v.validate(&buffer)) {
@@ -1294,6 +1308,10 @@ impl Reedline {
                 if let Some(event) = self.parse_bang_command() {
                     return self.handle_editor_event(prompt, event);
                 }
+                if let Some(event) = self.try_expand_abbreviation_at_cursor(true) {
+                    return self.handle_editor_event(prompt, event);
+                }
+
                 Ok(self.submit_buffer(prompt)?)
             }
             ReedlineEvent::SubmitOrNewline => {
@@ -1301,6 +1319,10 @@ impl Reedline {
                 if let Some(event) = self.parse_bang_command() {
                     return self.handle_editor_event(prompt, event);
                 }
+                if let Some(event) = self.try_expand_abbreviation_at_cursor(true) {
+                    return self.handle_editor_event(prompt, event);
+                }
+
                 let cursor_position_in_buffer = self.editor.insertion_point();
                 let buffer = self.editor.get_buffer().to_string();
                 if cursor_position_in_buffer < buffer.len() {
@@ -1323,6 +1345,13 @@ impl Reedline {
             }
             ReedlineEvent::Edit(commands) => {
                 self.run_edit_commands(&commands);
+
+                // Check if a space was just inserted and try to expand abbreviations
+                if let Some(EditCommand::InsertChar(' ')) = commands.first() {
+                    if let Some(event) = self.try_expand_abbreviation_at_cursor(false) {
+                        return self.handle_editor_event(prompt, event);
+                    }
+                }
                 if let Some(menu) = self.menus.iter_mut().find(|men| men.is_active()) {
                     if self.quick_completions && menu.can_quick_complete() {
                         match commands.first() {
@@ -1727,6 +1756,58 @@ impl Reedline {
         } else {
             self.buffer_paint(prompt)
         }
+    }
+
+    /// Expands an abbreviation at the word before the cursor, if any exists
+    ///
+    /// Note, expansion does not occur when inside a string.
+    fn try_expand_abbreviation_at_cursor(&mut self, submitted: bool) -> Option<ReedlineEvent> {
+        let buffer = self.editor.get_buffer();
+        let cursor_position_in_buffer = self.editor.insertion_point();
+
+        let chars: Vec<char> = buffer.chars().collect();
+        let (offset, suffix) = match submitted {
+            true => (0, ""),
+            false => (1, " "),
+        };
+
+        let mut word_start = cursor_position_in_buffer - 1;
+        while word_start > 0 && !chars[word_start - 1].is_whitespace() {
+            word_start -= 1;
+        }
+        let word_end = cursor_position_in_buffer - offset;
+
+        if word_start >= word_end {
+            // The first char in the buffer is a space or there are consecutive spaces
+            return None;
+        }
+
+        let word: String = chars[word_start..word_end].iter().collect();
+        if let Some(expansion) = self.abbreviations.get(word.as_bytes()) {
+            if self.editor.is_inside_string_literal(word_start) {
+                return None;
+            }
+
+            let commands = vec![
+                EditCommand::MoveToPosition {
+                    position: word_start,
+                    select: false,
+                },
+                EditCommand::MoveToPosition {
+                    position: word_end,
+                    select: true,
+                },
+                EditCommand::InsertString(format!(
+                    "{}{}",
+                    String::from_utf8_lossy(expansion),
+                    suffix
+                )),
+            ];
+
+            return Some(ReedlineEvent::Edit(commands));
+        }
+
+        None
     }
 
     #[cfg(feature = "bashisms")]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1780,14 +1780,12 @@ impl Reedline {
         if word_start >= word_end {
             // The first char in the buffer is a space or there are consecutive spaces
             return None;
+        } else if self.editor.is_inside_string_literal(word_start) {
+            return None;
         }
 
         let word: String = chars[word_start..word_end].iter().collect();
         if let Some(expansion) = self.abbreviations.get(word.as_bytes()) {
-            if self.editor.is_inside_string_literal(word_start) {
-                return None;
-            }
-
             let commands = vec![
                 EditCommand::MoveToPosition {
                     position: word_start,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1764,18 +1764,23 @@ impl Reedline {
     fn try_expand_abbreviation_at_cursor(&mut self, submitted: bool) -> Option<ReedlineEvent> {
         let buffer = self.editor.get_buffer();
         let cursor_position_in_buffer = self.editor.insertion_point();
+        if cursor_position_in_buffer == 0 {
+            return None;
+        }
 
-        let chars: Vec<char> = buffer.chars().collect();
         let (offset, suffix) = match submitted {
             true => (0, ""),   // expand on <enter>
             false => (1, " "), // expand on <space>
         };
 
-        let mut word_start = cursor_position_in_buffer - 1;
-        while word_start > 0 && !chars[word_start - 1].is_whitespace() {
-            word_start -= 1;
-        }
         let word_end = cursor_position_in_buffer - offset;
+        let prefix = &buffer[..word_end];
+        let word_start = prefix
+            .char_indices()
+            .rev()
+            .find(|(_, ch)| ch.is_whitespace())
+            .map(|(idx, ch)| idx + ch.len_utf8())
+            .unwrap_or(0); // byte offset of word start
 
         if word_start >= word_end {
             // The first char in the buffer is a space or there are consecutive spaces
@@ -1785,8 +1790,8 @@ impl Reedline {
             return None;
         }
 
-        let word: String = chars[word_start..word_end].iter().collect();
-        if let Some(expansion) = self.abbreviations.get(&word) {
+        let word = &buffer[word_start..word_end];
+        if let Some(expansion) = self.abbreviations.get(word) {
             return Some(ReedlineEvent::Edit(vec![
                 EditCommand::MoveToPosition {
                     position: word_start,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1344,14 +1344,13 @@ impl Reedline {
                 Ok(EventStatus::Exits(Signal::HostCommand(host_command)))
             }
             ReedlineEvent::Edit(commands) => {
-                self.run_edit_commands(&commands);
-
                 // Check if a space was just inserted and try to expand abbreviations
                 if let Some(EditCommand::InsertChar(' ')) = commands.first() {
                     if let Some(event) = self.try_expand_abbreviation_at_cursor(false) {
                         return self.handle_editor_event(prompt, event);
                     }
                 }
+                self.run_edit_commands(&commands);
                 if let Some(menu) = self.menus.iter_mut().find(|men| men.is_active()) {
                     if self.quick_completions && menu.can_quick_complete() {
                         match commands.first() {
@@ -2436,5 +2435,99 @@ mod tests {
             Signal::ExternalBreak(buf) => assert_eq!(buf, buffer_content),
             _ => panic!("Expected Signal::ExternalBreak"),
         }
+    }
+
+    fn reedline_with_abbrevs(abbrevs: &[(&str, &str)]) -> Reedline {
+        let map = abbrevs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        Reedline::create().with_abbreviations(map)
+    }
+
+    fn set_buffer_at_end(reedline: &mut Reedline, text: &str) {
+        reedline.run_edit_commands(&[
+            EditCommand::Clear,
+            EditCommand::InsertString(text.to_string()),
+        ]);
+    }
+
+    #[test]
+    fn abbreviation_expands_on_submit() {
+        let mut reedline = reedline_with_abbrevs(&[("gc", "git commit")]);
+        set_buffer_at_end(&mut reedline, "gc");
+        let event = reedline.try_expand_abbreviation_at_cursor(true);
+        assert!(event.is_some(), "expected expansion on submit");
+        reedline.run_edit_commands(&match event.unwrap() {
+            ReedlineEvent::Edit(cmds) => cmds,
+            _ => panic!("expected Edit event"),
+        });
+        assert_eq!(reedline.current_buffer_contents(), "git commit");
+    }
+
+    #[test]
+    fn abbreviation_no_match_returns_none() {
+        let mut reedline = reedline_with_abbrevs(&[("gc", "git commit")]);
+        set_buffer_at_end(&mut reedline, "gx");
+        assert!(reedline.try_expand_abbreviation_at_cursor(true).is_none());
+    }
+
+    #[test]
+    fn abbreviation_empty_buffer_returns_none() {
+        let mut reedline = reedline_with_abbrevs(&[("gc", "git commit")]);
+        assert!(reedline.try_expand_abbreviation_at_cursor(true).is_none());
+    }
+
+    #[test]
+    fn abbreviation_expands_last_word_only() {
+        let mut reedline = reedline_with_abbrevs(&[("gc", "git commit")]);
+        set_buffer_at_end(&mut reedline, "sudo gc");
+        let event = reedline.try_expand_abbreviation_at_cursor(true);
+        assert!(event.is_some());
+        reedline.run_edit_commands(&match event.unwrap() {
+            ReedlineEvent::Edit(cmds) => cmds,
+            _ => panic!("expected Edit event"),
+        });
+        assert_eq!(reedline.current_buffer_contents(), "sudo git commit");
+    }
+
+    #[test]
+    fn abbreviation_no_expansion_inside_double_quoted_string() {
+        let mut reedline = reedline_with_abbrevs(&[("gc", "git commit")]);
+        set_buffer_at_end(&mut reedline, "\"gc");
+        assert!(
+            reedline.try_expand_abbreviation_at_cursor(true).is_none(),
+            "must not expand inside an unclosed double-quoted string"
+        );
+    }
+
+    #[test]
+    fn abbreviation_no_expansion_inside_single_quoted_string() {
+        let mut reedline = reedline_with_abbrevs(&[("gc", "git commit")]);
+        set_buffer_at_end(&mut reedline, "'gc");
+        assert!(
+            reedline.try_expand_abbreviation_at_cursor(true).is_none(),
+            "must not expand inside an unclosed single-quoted string"
+        );
+    }
+
+    #[test]
+    fn abbreviation_non_ascii_key_and_expansion() {
+        let mut reedline = reedline_with_abbrevs(&[("café", "coffee shop")]);
+        set_buffer_at_end(&mut reedline, "café");
+        let event = reedline.try_expand_abbreviation_at_cursor(true);
+        assert!(event.is_some(), "expected expansion for non-ASCII key");
+        reedline.run_edit_commands(&match event.unwrap() {
+            ReedlineEvent::Edit(cmds) => cmds,
+            _ => panic!("expected Edit event"),
+        });
+        assert_eq!(reedline.current_buffer_contents(), "coffee shop");
+    }
+
+    #[test]
+    fn abbreviation_leading_spaces_returns_none() {
+        let mut reedline = reedline_with_abbrevs(&[("gc", "git commit")]);
+        set_buffer_at_end(&mut reedline, "   ");
+        assert!(reedline.try_expand_abbreviation_at_cursor(true).is_none());
     }
 }


### PR DESCRIPTION
Following up on my comment in #556 i figured i would go ahead and get something working. This would be the initial step to getting abbreviations in nushell and would require ~~a parsing implementation~~ abbreviations to be stored in nushell config and then passed to reedline. Open to any comments or opinions as far as implementation goes but this is a feature that i would personally love to have in nushell.

I've essentially added a check during the following events that will check if the word before the cursor is an abbreviation and expand it if true:
- `Submit` and `SubmitOrNewline`
- `Enter` 
- `Edit` if the first command in the event is to insert a space

As for adding this to nushell, here's a simple example of how this might look in the nushell config:

```diff
diff --git a/crates/nu-cli/src/repl.rs b/crates/nu-cli/src/repl.rs
index c1fea4150..239153226 100644
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -414,6 +414,7 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
         )))
         .with_quick_completions(config.completions.quick)
         .with_partial_completions(config.completions.partial)
+        .with_abbreviations(config.abbreviations)
         .with_ansi_colors(config.use_ansi_coloring.get(engine_state))
         .with_cwd(Some(
             engine_state
diff --git a/crates/nu-protocol/src/config/mod.rs b/crates/nu-protocol/src/config/mod.rs
index 37fa177a5..9769160e9 100644
--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -63,6 +63,7 @@ pub struct Config {
     pub hinter: HinterConfig,
     pub history: HistoryConfig,
     pub keybindings: Vec<ParsedKeybinding>,
+    pub abbreviations: HashMap<String, String>,
     pub menus: Vec<ParsedMenu>,
     pub hooks: Hooks,
     pub rm: RmConfig,
@@ -135,6 +136,8 @@ impl Default for Config {

             keybindings: Vec::new(),

+            abbreviations: HashMap::new(),
+
             error_style: ErrorStyle::default(),
             error_lines: 1,
             display_errors: DisplayErrors::default(),
@@ -218,6 +221,10 @@ impl UpdateFromValue for Config {
                     Ok(keybindings) => self.keybindings = keybindings,
                     Err(err) => errors.error(err.into()),
                 },
+                "abbreviations" => match HashMap::from_value(val.clone()) {
+                    Ok(abbreviations) => self.abbreviations = abbreviations,
+                    Err(err) => errors.error(err.into()),
+                },
                 "hooks" => self.hooks.update(val, path, errors),
                 "datetime_format" => self.datetime_format.update(val, path, errors),
                 "error_style" => self.error_style.update(val, path, errors),
```


Note, that the `is_inside_string_literal` function could potentially be used for a bug fix for

- https://github.com/nushell/nushell/issues/6971
- https://github.com/nushell/nushell/issues/13577 

As an aside, here's how im currently getting abbreviations with this hacky solution

```nu
let abbrevs = {
    ga: 'git add'
    gb: 'git branch'
    gc: 'git commit -v'
    gd: 'git diff'
    gdt: 'git difftool -d'
    gm: 'git merge'
    gr: 'git rebase'
    gR: 'git restore'
    gwa: 'git worktree add'
    gwr: 'git worktree remove'
    gwl: 'git worktree list'
    gx: 'git switch'
    la: 'ls -a'
    ll: 'ls -l'
    fg: 'job unfreeze'
    ou: 'overlay use'
    oh: 'overlay hide'
    ol: 'overlay list'
}

$env.config = {
    menus: [
        {
            name: abbr_menu
            only_buffer_difference: false
            marker: none
            type: {
                layout: columnar
                columns: 1
                col_width: 20
                col_padding: 2
            }
            style: {text: green, selected_text: green_reverse, description_text: yellow}
            source: {|buffer, position|
                let match = $abbrevs | columns | where $it == $buffer
                if ($match | is-empty) {
                    {value: $buffer}
                } else {
                    {
                        value: ($abbrevs | get $match.0)
                    }
                }
            }
        }
    ]
}

```