### PR TITLE
Additive `InputMode` / `OutputMode` enums for menu settings

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -16,7 +16,7 @@ use {
 
 #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
 use reedline::FileBackedHistory;
-use reedline::{CursorConfig, MenuBuilder};
+use reedline::{CursorConfig, MenuBuilder, OutputMode};
 
 fn main() -> reedline::Result<()> {
     println!("Ctrl-D to quit");
@@ -102,7 +102,9 @@ fn main() -> reedline::Result<()> {
             ColumnarMenu::default().with_name("completion_menu"),
         )))
         .with_menu(ReedlineMenu::HistoryMenu(Box::new(
-            ListMenu::default().with_name("history_menu"),
+            ListMenu::default()
+                .with_name("history_menu")
+                .with_output_mode(OutputMode::FullBuffer),
         )));
 
     let edit_mode: Box<dyn EditMode> = if vi_mode {

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -52,6 +52,9 @@ impl<'menu> HistoryCompleter<'menu> {
         Self(history)
     }
 
+    /// Assumes `line.len() <= pos` (i.e. `line` is the cursor-prefix slice).
+    /// Update this span calculation before HistoryMenu opts into `InputMode::FullBuffer`,
+    /// where `line` would be the entire buffer and `pos - line.len()` would underflow.
     fn create_suggestion(&self, line: &str, pos: usize, value: &str) -> Suggestion {
         let span = Span {
             start: pos - line.len(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,8 +291,9 @@ pub use validator::{DefaultValidator, ValidationResult, Validator};
 
 mod menu;
 pub use menu::{
-    menu_functions, ColumnarMenu, DescriptionMenu, DescriptionMode, IdeMenu, ListMenu, Menu,
-    MenuBuilder, MenuEvent, MenuSettings, MenuTextStyle, ReedlineMenu, TraversalDirection,
+    menu_functions, ColumnarMenu, DescriptionMenu, DescriptionMode, IdeMenu, InputMode, ListMenu,
+    Menu, MenuBuilder, MenuEvent, MenuSettings, MenuTextStyle, OutputMode, ReedlineMenu,
+    TraversalDirection,
 };
 
 mod terminal_extensions;

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -682,7 +682,7 @@ impl Menu for ColumnarMenu {
 
     /// The buffer gets replaced in the Span location
     fn replace_in_buffer(&self, editor: &mut Editor) {
-        replace_in_buffer(self.get_value(), editor);
+        replace_in_buffer(self.get_value(), editor, self.settings.output_mode);
     }
 
     /// Minimum rows that should be displayed by the menu

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -1,6 +1,7 @@
 use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
+    menu::InputMode,
     menu_functions::{
         can_partially_complete, completer_input, floor_char_boundary, get_match_indices,
         replace_in_buffer, style_suggestion, truncate_with_ansi,
@@ -551,7 +552,7 @@ impl Menu for ColumnarMenu {
 
     /// Updates menu values
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
-        if self.settings.only_buffer_difference && self.input.is_none() {
+        if self.settings.effective_input_mode() == InputMode::Diff && self.input.is_none() {
             self.input = Some(editor.get_buffer().to_string());
         }
 
@@ -559,7 +560,7 @@ impl Menu for ColumnarMenu {
             editor.get_buffer(),
             editor.insertion_point(),
             self.input.as_deref(),
-            self.settings.only_buffer_difference,
+            self.settings.effective_input_mode(),
         );
 
         let (values, base_ranges) = completer.complete_with_base_ranges(&input, pos);

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -1,10 +1,9 @@
 use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
-    menu::InputMode,
     menu_functions::{
-        can_partially_complete, completer_input, floor_char_boundary, get_match_indices,
-        replace_in_buffer, style_suggestion, truncate_with_ansi,
+        can_partially_complete, floor_char_boundary, get_match_indices, replace_in_buffer,
+        resolve_completer_input, style_suggestion, truncate_with_ansi,
     },
     painting::Painter,
     Completer, Suggestion,
@@ -552,16 +551,7 @@ impl Menu for ColumnarMenu {
 
     /// Updates menu values
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
-        if self.settings.effective_input_mode() == InputMode::Diff && self.input.is_none() {
-            self.input = Some(editor.get_buffer().to_string());
-        }
-
-        let (input, pos) = completer_input(
-            editor.get_buffer(),
-            editor.insertion_point(),
-            self.input.as_deref(),
-            self.settings.effective_input_mode(),
-        );
+        let (input, pos) = resolve_completer_input(editor, &mut self.input, &self.settings);
 
         let (values, base_ranges) = completer.complete_with_base_ranges(&input, pos);
 

--- a/src/menu/description_menu.rs
+++ b/src/menu/description_menu.rs
@@ -1,8 +1,7 @@
 use {
     super::MenuSettings,
     crate::{
-        menu::InputMode,
-        menu_functions::{completer_input, replace_in_buffer},
+        menu_functions::{replace_in_buffer, resolve_completer_input},
         Completer, Editor, Menu, MenuBuilder, MenuEvent, Painter, Suggestion,
     },
     nu_ansi_term::ansi::RESET,
@@ -444,16 +443,7 @@ impl Menu for DescriptionMenu {
 
     /// Updates menu values
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
-        if self.settings.effective_input_mode() == InputMode::Diff && self.input.is_none() {
-            self.input = Some(editor.get_buffer().to_string());
-        }
-
-        let (input, pos) = completer_input(
-            editor.get_buffer(),
-            editor.insertion_point(),
-            self.input.as_deref(),
-            self.settings.effective_input_mode(),
-        );
+        let (input, pos) = resolve_completer_input(editor, &mut self.input, &self.settings);
         self.values = completer.complete(&input, pos);
 
         self.reset_position();

--- a/src/menu/description_menu.rs
+++ b/src/menu/description_menu.rs
@@ -594,7 +594,7 @@ impl Menu for DescriptionMenu {
                     .expect("the example index is always checked");
                 suggestion.value.clone_from(example);
             }
-            replace_in_buffer(Some(suggestion), editor);
+            replace_in_buffer(Some(suggestion), editor, self.settings.output_mode);
         }
     }
 

--- a/src/menu/description_menu.rs
+++ b/src/menu/description_menu.rs
@@ -1,6 +1,7 @@
 use {
     super::MenuSettings,
     crate::{
+        menu::InputMode,
         menu_functions::{completer_input, replace_in_buffer},
         Completer, Editor, Menu, MenuBuilder, MenuEvent, Painter, Suggestion,
     },
@@ -443,7 +444,7 @@ impl Menu for DescriptionMenu {
 
     /// Updates menu values
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
-        if self.settings.only_buffer_difference && self.input.is_none() {
+        if self.settings.effective_input_mode() == InputMode::Diff && self.input.is_none() {
             self.input = Some(editor.get_buffer().to_string());
         }
 
@@ -451,7 +452,7 @@ impl Menu for DescriptionMenu {
             editor.get_buffer(),
             editor.insertion_point(),
             self.input.as_deref(),
-            self.settings.only_buffer_difference,
+            self.settings.effective_input_mode(),
         );
         self.values = completer.complete(&input, pos);
 

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -1,10 +1,9 @@
 use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
-    menu::InputMode,
     menu_functions::{
-        can_partially_complete, completer_input, floor_char_boundary, get_match_indices,
-        replace_in_buffer, style_suggestion, truncate_with_ansi,
+        can_partially_complete, floor_char_boundary, get_match_indices, replace_in_buffer,
+        resolve_completer_input, style_suggestion, truncate_with_ansi,
     },
     painting::Painter,
     Completer, Suggestion,
@@ -621,16 +620,7 @@ impl Menu for IdeMenu {
 
     /// Update menu values
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
-        if self.settings.effective_input_mode() == InputMode::Diff && self.input.is_none() {
-            self.input = Some(editor.get_buffer().to_string());
-        }
-
-        let (input, pos) = completer_input(
-            editor.get_buffer(),
-            editor.insertion_point(),
-            self.input.as_deref(),
-            self.settings.effective_input_mode(),
-        );
+        let (input, pos) = resolve_completer_input(editor, &mut self.input, &self.settings);
         let (values, base_ranges) = completer.complete_with_base_ranges(&input, pos);
 
         self.values = values;

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -818,7 +818,7 @@ impl Menu for IdeMenu {
 
     /// The buffer gets replaced in the Span location
     fn replace_in_buffer(&self, editor: &mut Editor) {
-        replace_in_buffer(self.get_value(), editor);
+        replace_in_buffer(self.get_value(), editor, self.settings.output_mode);
     }
 
     /// Minimum rows that should be displayed by the menu

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -1,6 +1,7 @@
 use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
+    menu::InputMode,
     menu_functions::{
         can_partially_complete, completer_input, floor_char_boundary, get_match_indices,
         replace_in_buffer, style_suggestion, truncate_with_ansi,
@@ -620,7 +621,7 @@ impl Menu for IdeMenu {
 
     /// Update menu values
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
-        if self.settings.only_buffer_difference && self.input.is_none() {
+        if self.settings.effective_input_mode() == InputMode::Diff && self.input.is_none() {
             self.input = Some(editor.get_buffer().to_string());
         }
 
@@ -628,7 +629,7 @@ impl Menu for IdeMenu {
             editor.get_buffer(),
             editor.insertion_point(),
             self.input.as_deref(),
-            self.settings.only_buffer_difference,
+            self.settings.effective_input_mode(),
         );
         let (values, base_ranges) = completer.complete_with_base_ranges(&input, pos);
 

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -2,6 +2,7 @@ use {
     super::{menu_functions::parse_selection_char, Menu, MenuBuilder, MenuEvent, MenuSettings},
     crate::{
         core_editor::Editor,
+        menu::InputMode,
         menu_functions::{completer_input, replace_in_buffer},
         painting::{estimate_single_line_wraps, Painter},
         Completer, Suggestion,
@@ -346,7 +347,7 @@ impl Menu for ListMenu {
 
     /// Collecting the value from the completer to be shown in the menu
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
-        if self.settings.only_buffer_difference && self.input.is_none() {
+        if self.settings.effective_input_mode() == InputMode::Diff && self.input.is_none() {
             self.input = Some(editor.get_buffer().to_string());
         }
 
@@ -354,7 +355,7 @@ impl Menu for ListMenu {
             editor.get_buffer(),
             editor.insertion_point(),
             self.input.as_deref(),
-            self.settings.only_buffer_difference,
+            self.settings.effective_input_mode(),
         );
 
         let parsed = parse_selection_char(&input, SELECTION_CHAR);

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -2,8 +2,7 @@ use {
     super::{menu_functions::parse_selection_char, Menu, MenuBuilder, MenuEvent, MenuSettings},
     crate::{
         core_editor::Editor,
-        menu::InputMode,
-        menu_functions::{completer_input, replace_in_buffer},
+        menu_functions::{replace_in_buffer, resolve_completer_input},
         painting::{estimate_single_line_wraps, Painter},
         Completer, Suggestion,
     },
@@ -347,16 +346,7 @@ impl Menu for ListMenu {
 
     /// Collecting the value from the completer to be shown in the menu
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
-        if self.settings.effective_input_mode() == InputMode::Diff && self.input.is_none() {
-            self.input = Some(editor.get_buffer().to_string());
-        }
-
-        let (input, pos) = completer_input(
-            editor.get_buffer(),
-            editor.insertion_point(),
-            self.input.as_deref(),
-            self.settings.effective_input_mode(),
-        );
+        let (input, pos) = resolve_completer_input(editor, &mut self.input, &self.settings);
 
         let parsed = parse_selection_char(&input, SELECTION_CHAR);
         self.update_row_pos(parsed.index);

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -413,7 +413,7 @@ impl Menu for ListMenu {
 
     /// The buffer gets cleared with the actual value
     fn replace_in_buffer(&self, editor: &mut Editor) {
-        replace_in_buffer(self.get_value(), editor);
+        replace_in_buffer(self.get_value(), editor, self.settings.output_mode);
     }
 
     fn update_working_details(

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -10,7 +10,7 @@ use nu_ansi_term::{ansi::RESET, Style};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-use crate::{Editor, Suggestion, UndoBehavior};
+use crate::{menu::InputMode, Editor, Suggestion, UndoBehavior};
 
 /// Index result obtained from parsing a string with an index marker
 /// For example, the next string:
@@ -272,28 +272,32 @@ pub fn string_difference<'a>(new_string: &'a str, old_string: &str) -> (usize, &
 /// Get the part of the line that should be given as input to the completer, as well
 /// as the index of the end of that piece of text
 ///
-/// `prev_input` is the text in the buffer when the menu was activated. Needed if only_buffer_difference is true
+/// `prev_input` is the text in the buffer when the menu was activated. Needed for `InputMode::Diff`.
 pub fn completer_input(
     buffer: &str,
     insertion_point: usize,
     prev_input: Option<&str>,
-    only_buffer_difference: bool,
+    input_mode: InputMode,
 ) -> (String, usize) {
-    if only_buffer_difference {
-        if let Some(old_string) = prev_input {
-            let (start, input) = string_difference(buffer, old_string);
-            if !input.is_empty() {
-                (input.to_owned(), start + input.len())
+    match input_mode {
+        InputMode::FullBuffer => (buffer.to_owned(), insertion_point),
+        InputMode::CursorPrefix => {
+            // TODO previously, all but the list menu replaced newlines with spaces here
+            // The completers should be adapted to account for this, and tests need to be added
+            (buffer[..insertion_point].to_owned(), insertion_point)
+        }
+        InputMode::Diff => {
+            if let Some(old_string) = prev_input {
+                let (start, input) = string_difference(buffer, old_string);
+                if !input.is_empty() {
+                    (input.to_owned(), start + input.len())
+                } else {
+                    (String::new(), insertion_point)
+                }
             } else {
                 (String::new(), insertion_point)
             }
-        } else {
-            (String::new(), insertion_point)
         }
-    } else {
-        // TODO previously, all but the list menu replaced newlines with spaces here
-        // The completers should be adapted to account for this, and tests need to be added
-        (buffer[..insertion_point].to_owned(), insertion_point)
     }
 }
 
@@ -948,24 +952,24 @@ mod tests {
     }
 
     #[rstest]
-    #[case("foobar", 6, None, false, "foobar", 6)]
-    #[case("foo\r\nbar", 5, None, false, "foo\r\n", 5)]
-    #[case("foo\nbar", 4, None, false, "foo\n", 4)]
-    #[case("foobar", 6, None, true, "", 6)]
-    #[case("foobar", 3, Some("foobar"), true, "", 3)]
-    #[case("foobar", 6, Some("foo"), true, "bar", 6)]
-    #[case("foobar", 6, Some("for"), true, "oba", 5)]
+    #[case("foobar", 6, None, InputMode::CursorPrefix, "foobar", 6)]
+    #[case("foo\r\nbar", 5, None, InputMode::CursorPrefix, "foo\r\n", 5)]
+    #[case("foo\nbar", 4, None, InputMode::CursorPrefix, "foo\n", 4)]
+    #[case("foobar", 6, None, InputMode::Diff, "", 6)]
+    #[case("foobar", 3, Some("foobar"), InputMode::Diff, "", 3)]
+    #[case("foobar", 6, Some("foo"), InputMode::Diff, "bar", 6)]
+    #[case("foobar", 6, Some("for"), InputMode::Diff, "oba", 5)]
     fn test_completer_input(
         #[case] buffer: String,
         #[case] insertion_point: usize,
         #[case] prev_input: Option<&str>,
-        #[case] only_buffer_difference: bool,
+        #[case] input_mode: InputMode,
         #[case] output: String,
         #[case] pos: usize,
     ) {
         assert_eq!(
             (output, pos),
-            completer_input(&buffer, insertion_point, prev_input, only_buffer_difference)
+            completer_input(&buffer, insertion_point, prev_input, input_mode)
         )
     }
 

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -11,7 +11,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
-    menu::{InputMode, OutputMode},
+    menu::{InputMode, MenuSettings, OutputMode},
     Editor, Suggestion, UndoBehavior,
 };
 
@@ -302,6 +302,27 @@ pub fn completer_input(
             }
         }
     }
+}
+
+/// Stashes the buffer on first call when in `InputMode::Diff` (so later calls can diff
+/// against the original), then resolves the completer input via [`completer_input`].
+///
+/// Centralises the input-resolution boilerplate shared by all menu `update_values` impls.
+pub fn resolve_completer_input(
+    editor: &Editor,
+    saved_input: &mut Option<String>,
+    settings: &MenuSettings,
+) -> (String, usize) {
+    let mode = settings.effective_input_mode();
+    if mode == InputMode::Diff && saved_input.is_none() {
+        *saved_input = Some(editor.get_buffer().to_string());
+    }
+    completer_input(
+        editor.get_buffer(),
+        editor.insertion_point(),
+        saved_input.as_deref(),
+        mode,
+    )
 }
 
 /// Find the closest index less than or equal to the current index that's a

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -10,7 +10,10 @@ use nu_ansi_term::{ansi::RESET, Style};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-use crate::{menu::InputMode, Editor, Suggestion, UndoBehavior};
+use crate::{
+    menu::{InputMode, OutputMode},
+    Editor, Suggestion, UndoBehavior,
+};
 
 /// Index result obtained from parsing a string with an index marker
 /// For example, the next string:
@@ -318,7 +321,11 @@ pub fn floor_char_boundary(s: &str, index: usize) -> usize {
 }
 
 /// Helper to accept a completion suggestion and edit the buffer
-pub fn replace_in_buffer(value: Option<Suggestion>, editor: &mut Editor) {
+pub fn replace_in_buffer(
+    value: Option<Suggestion>,
+    editor: &mut Editor,
+    output_mode: Option<OutputMode>,
+) {
     if let Some(Suggestion {
         mut value,
         span,
@@ -326,8 +333,14 @@ pub fn replace_in_buffer(value: Option<Suggestion>, editor: &mut Editor) {
         ..
     }) = value
     {
-        let end = floor_char_boundary(editor.get_buffer(), span.end);
-        let start = floor_char_boundary(editor.get_buffer(), span.start).min(end);
+        let buffer_len = editor.get_buffer().len();
+        let (raw_start, raw_end) = match output_mode {
+            Some(OutputMode::FullBuffer) => (0, buffer_len),
+            Some(OutputMode::ExtendToEnd) => (span.start, buffer_len),
+            Some(OutputMode::SuggestedSpan) | None => (span.start, span.end),
+        };
+        let end = floor_char_boundary(editor.get_buffer(), raw_end);
+        let start = floor_char_boundary(editor.get_buffer(), raw_start).min(end);
         if append_whitespace {
             value.push(' ');
         }
@@ -959,6 +972,7 @@ mod tests {
     #[case("foobar", 3, Some("foobar"), InputMode::Diff, "", 3)]
     #[case("foobar", 6, Some("foo"), InputMode::Diff, "bar", 6)]
     #[case("foobar", 6, Some("for"), InputMode::Diff, "oba", 5)]
+    #[case("foobar baz", 3, None, InputMode::FullBuffer, "foobar baz", 3)]
     fn test_completer_input(
         #[case] buffer: String,
         #[case] insertion_point: usize,
@@ -998,6 +1012,57 @@ mod tests {
                 ..Default::default()
             }),
             &mut editor,
+            None,
+        );
+        assert_eq!(new_buffer, editor.get_buffer());
+        assert_eq!(new_insertion_point, editor.insertion_point());
+
+        editor.run_edit_command(&EditCommand::Undo);
+        assert_eq!(orig_buffer, editor.get_buffer());
+        assert_eq!(orig_insertion_point, editor.insertion_point());
+    }
+
+    #[rstest]
+    #[case::full_buffer(
+        "old content",
+        11,
+        "new",
+        3,
+        "new",
+        Span::new(0, 0),
+        OutputMode::FullBuffer
+    )]
+    #[case::extend_to_end(
+        "hello world",
+        11,
+        "hello rust",
+        10,
+        "rust",
+        Span::new(6, 8),
+        OutputMode::ExtendToEnd
+    )]
+    fn test_replace_in_buffer_with_output_mode(
+        #[case] orig_buffer: &str,
+        #[case] orig_insertion_point: usize,
+        #[case] new_buffer: &str,
+        #[case] new_insertion_point: usize,
+        #[case] value: String,
+        #[case] span: Span,
+        #[case] output_mode: OutputMode,
+    ) {
+        let mut editor = Editor::default();
+        let mut line_buffer = LineBuffer::new();
+        line_buffer.set_buffer(orig_buffer.to_owned());
+        line_buffer.set_insertion_point(orig_insertion_point);
+        editor.set_line_buffer(line_buffer, UndoBehavior::CreateUndoPoint);
+        replace_in_buffer(
+            Some(Suggestion {
+                value,
+                span,
+                ..Default::default()
+            }),
+            &mut editor,
+            Some(output_mode),
         );
         assert_eq!(new_buffer, editor.get_buffer());
         assert_eq!(new_insertion_point, editor.insertion_point());

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -159,8 +159,8 @@ pub struct MenuSettings {
     color: MenuTextStyle,
     /// Menu marker when active
     marker: String,
-    /// Calls the completer using only the line buffer difference difference
-    /// after the menu was activated
+    /// Calls the completer using only the line buffer difference
+    /// after the menu was activated. Ignored if `input_mode` is set.
     only_buffer_difference: bool,
     /// Optional override for completer input handling.
     /// If `Some`, takes precedence over `only_buffer_difference`.
@@ -205,20 +205,24 @@ impl MenuSettings {
         self
     }
 
-    /// MenuSettings builder with only_buffer_difference
+    /// MenuSettings builder with only_buffer_difference.
+    /// Consider `with_input_mode` for finer control; the bool is ignored when
+    /// `input_mode` is set.
     #[must_use]
     pub fn with_only_buffer_difference(mut self, only_buffer_difference: bool) -> Self {
         self.only_buffer_difference = only_buffer_difference;
         self
     }
 
-    /// set the input mode. If set, this overrides `only_buffer_difference`.
+    /// Set the input mode. If set, this overrides `only_buffer_difference`.
+    #[must_use]
     pub fn with_input_mode(mut self, mode: InputMode) -> Self {
         self.input_mode = Some(mode);
         self
     }
 
-    /// set the output mode. If unset, the menu uses `Suggestion::span` as-is.
+    /// Set the output mode. If unset, the menu uses `Suggestion::span` as-is.
+    #[must_use]
     pub fn with_output_mode(mut self, mode: OutputMode) -> Self {
         self.output_mode = Some(mode);
         self
@@ -251,11 +255,11 @@ pub enum InputMode {
     /// Equivalent to `only_buffer_difference: false`.
     CursorPrefix,
     /// Completer receives the entire buffer including text after the cursor.
-    /// No bool equivalent
+    /// No bool equivalent.
     FullBuffer,
 }
 
-/// Controls what range og the buffer the menu replaces when a suggestion is selected.
+/// Controls what range of the buffer the menu replaces when a suggestion is selected.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputMode {
@@ -326,7 +330,8 @@ pub trait MenuBuilder: Menu + Sized {
         self
     }
 
-    /// Menu builder with new value for only_buffer_difference
+    /// Menu builder with new value for only_buffer_difference.
+    /// Ignored when `input_mode` is set; consider `with_input_mode` for finer control.
     #[must_use]
     fn with_only_buffer_difference(mut self, only_buffer_difference: bool) -> Self {
         self.settings_mut().only_buffer_difference = only_buffer_difference;

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -231,16 +231,11 @@ impl MenuSettings {
     /// Resolves input_mode and only_buffer_difference into concrete InputMode.
     /// `input_mode` wins if set; otherwise falls back to the bool.
     pub fn effective_input_mode(&self) -> InputMode {
-        match self.input_mode {
-            Some(mode) => mode,
-            None => {
-                if self.only_buffer_difference {
-                    InputMode::Diff
-                } else {
-                    InputMode::CursorPrefix
-                }
-            }
-        }
+        self.input_mode.unwrap_or(if self.only_buffer_difference {
+            InputMode::Diff
+        } else {
+            InputMode::CursorPrefix
+        })
     }
 }
 
@@ -263,7 +258,8 @@ pub enum InputMode {
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputMode {
-    /// Replace the range specified by `Suggestion::span`. Default behaviour
+    /// Replace the range specified by `Suggestion::span`.
+    /// Equivalent to leaving `output_mode` unset.
     SuggestedSpan,
     /// Replace the entire buffer (`0..buffer.len()`), ignoring `Suggestion::span`.
     FullBuffer,

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -162,6 +162,12 @@ pub struct MenuSettings {
     /// Calls the completer using only the line buffer difference difference
     /// after the menu was activated
     only_buffer_difference: bool,
+    /// Optional override for completer input handling.
+    /// If `Some`, takes precedence over `only_buffer_difference`.
+    input_mode: Option<InputMode>,
+    /// Optional override for the buffer range replaced on selection.
+    /// If `None`, the menu uses `Suggestion::span` as-is.
+    output_mode: Option<OutputMode>,
 }
 
 impl Default for MenuSettings {
@@ -171,6 +177,8 @@ impl Default for MenuSettings {
             color: MenuTextStyle::default(),
             marker: "| ".to_string(),
             only_buffer_difference: false,
+            input_mode: None,
+            output_mode: None,
         }
     }
 }
@@ -203,6 +211,60 @@ impl MenuSettings {
         self.only_buffer_difference = only_buffer_difference;
         self
     }
+
+    /// set the input mode. If set, this overrides `only_buffer_difference`.
+    pub fn with_input_mode(mut self, mode: InputMode) -> Self {
+        self.input_mode = Some(mode);
+        self
+    }
+
+    /// set the output mode. If unset, the menu uses `Suggestion::span` as-is.
+    pub fn with_output_mode(mut self, mode: OutputMode) -> Self {
+        self.output_mode = Some(mode);
+        self
+    }
+
+    /// Resolves input_mode and only_buffer_difference into concrete InputMode.
+    /// `input_mode` wins if set; otherwise falls back to the bool.
+    pub fn effective_input_mode(&self) -> InputMode {
+        match self.input_mode {
+            Some(mode) => mode,
+            None => {
+                if self.only_buffer_difference {
+                    InputMode::Diff
+                } else {
+                    InputMode::CursorPrefix
+                }
+            }
+        }
+    }
+}
+
+/// Controls what the menu hands to its completer.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputMode {
+    /// Completer receives only the text typed after menu activation.
+    /// Equivalent to `only_buffer_difference: true`.
+    Diff,
+    /// Completer receives the buffer up to the cursor (`buffer[..cursor]`).
+    /// Equivalent to `only_buffer_difference: false`.
+    CursorPrefix,
+    /// Completer receives the entire buffer including text after the cursor.
+    /// No bool equivalent
+    FullBuffer,
+}
+
+/// Controls what range og the buffer the menu replaces when a suggestion is selected.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputMode {
+    /// Replace the range specified by `Suggestion::span`. Default behaviour
+    SuggestedSpan,
+    /// Replace the entire buffer (`0..buffer.len()`), ignoring `Suggestion::span`.
+    FullBuffer,
+    /// Keep `Suggestion::span.start`, force `end = buffer.len()`.
+    ExtentToEnd,
 }
 
 /// Common builder for all menus

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -264,7 +264,7 @@ pub enum OutputMode {
     /// Replace the entire buffer (`0..buffer.len()`), ignoring `Suggestion::span`.
     FullBuffer,
     /// Keep `Suggestion::span.start`, force `end = buffer.len()`.
-    ExtentToEnd,
+    ExtendToEnd,
 }
 
 /// Common builder for all menus
@@ -330,6 +330,20 @@ pub trait MenuBuilder: Menu + Sized {
     #[must_use]
     fn with_only_buffer_difference(mut self, only_buffer_difference: bool) -> Self {
         self.settings_mut().only_buffer_difference = only_buffer_difference;
+        self
+    }
+
+    /// Menu builder with new value for input_mode. Overrides `only_buffer_difference` when set.
+    #[must_use]
+    fn with_input_mode(mut self, mode: InputMode) -> Self {
+        self.settings_mut().input_mode = Some(mode);
+        self
+    }
+
+    /// Menu builder with new value for output_mode. Defaults to `OutputMode::SuggestedSpan` when unset.
+    #[must_use]
+    fn with_output_mode(mut self, mode: OutputMode) -> Self {
+        self.settings_mut().output_mode = Some(mode);
         self
     }
 }
@@ -532,5 +546,30 @@ impl Menu for ReedlineMenu {
 
     fn set_cursor_pos(&mut self, pos: (u16, u16)) {
         self.as_mut().set_cursor_pos(pos);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::bool_only_false(false, None, InputMode::CursorPrefix)]
+    #[case::bool_only_true(true, None, InputMode::Diff)]
+    #[case::enum_overrides_false_bool(false, Some(InputMode::Diff), InputMode::Diff)]
+    #[case::enum_overrides_true_bool(true, Some(InputMode::CursorPrefix), InputMode::CursorPrefix)]
+    #[case::full_buffer(true, Some(InputMode::FullBuffer), InputMode::FullBuffer)]
+    fn test_effective_input_mode(
+        #[case] only_buffer_difference: bool,
+        #[case] input_mode: Option<InputMode>,
+        #[case] expected: InputMode,
+    ) {
+        let mut settings =
+            MenuSettings::default().with_only_buffer_difference(only_buffer_difference);
+        if let Some(mode) = input_mode {
+            settings = settings.with_input_mode(mode);
+        }
+        assert_eq!(settings.effective_input_mode(), expected);
     }
 }


### PR DESCRIPTION
Adds `InputMode` and `OutputMode` enums to `MenuSettings` with their own builder methods.
When set, they override `only_buffer_difference` (kept for back-compat) and when unset, the bool path is preserved unchanged.
Decouples menu input (what the completer receives) from output (what range of the buffer gets replaced on selection) if needed, which is the structural coupling behind #1006.

```rust
#[non_exhaustive]
pub enum InputMode {
    Diff,            // ≡ only_buffer_difference: true
    CursorPrefix,    // ≡ only_buffer_difference: false
    FullBuffer,      // NEW — exposes post-cursor content to the completer
}

#[non_exhaustive]
pub enum OutputMode {
    SuggestedSpan,   // ≡ Suggestion::span as-is (default)
    FullBuffer,      // overwrite 0..buffer.len()
    ExtendToEnd,     // keep span.start, force end = buffer.len()
}
```

`MenuSettings::effective_input_mode()` resolves enum-over-bool precedence in one place and all four menu impls (`Columnar`/`Description`/`Ide`/`ListMenu`) go through it.
`replace_in_buffer` takes `Option<OutputMode>`, also `None` and `Some(SuggestedSpan)` are equivalent.

`examples/demo.rs` opts the history menu into `OutputMode::FullBuffer`, demonstrating the pattern that fixes #1006 once nushell exposes the corresponding config field.

**Out of scope:**
- nushell config integration
- migration of other built-in menus
- `HistoryCompleter::create_suggestion` span update needed before HistoryMenu can use `InputMode::FullBuffer` (doc-comment warning added).

**Tests:** precedence table for `effective_input_mode`, `FullBuffer` case for `completer_input`, two cases for `replace_in_buffer` with explicit `OutputMode` variants.
Full suite passes (843 + 28 doctests).

Manually verified via `cargo run --example demo`: opened history menu mid-buffer, filtered, selected and the whole line replaced.