### PR TITLE
fix: apply abbrev expansion before space is inserted

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1344,13 +1344,13 @@ impl Reedline {
                 Ok(EventStatus::Exits(Signal::HostCommand(host_command)))
             }
             ReedlineEvent::Edit(commands) => {
+                self.run_edit_commands(&commands);
                 // Check if a space was just inserted and try to expand abbreviations
                 if let Some(EditCommand::InsertChar(' ')) = commands.first() {
                     if let Some(event) = self.try_expand_abbreviation_at_cursor(false) {
                         return self.handle_editor_event(prompt, event);
                     }
                 }
-                self.run_edit_commands(&commands);
                 if let Some(menu) = self.menus.iter_mut().find(|men| men.is_active()) {
                     if self.quick_completions && menu.can_quick_complete() {
                         match commands.first() {


### PR DESCRIPTION
It seems that one of Copilot's suggestions erroneously made it into #1060 which made it so that you needed to enter two spaces before the abbreviation expanded. this changes that back to the original intended behavior where the abbreviation expands on the initial space.