### PR TITLE
docs: fix cargo doc warning

### DIFF
--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -407,7 +407,7 @@ impl LineBuffer {
     /// insertion point.
     ///
     /// Only LF is inserted regardless of platform. The painting layer
-    /// ([`coerce_crlf`]) is responsible for converting LF to CRLF when
+    /// (`coerce_crlf`) is responsible for converting LF to CRLF when
     /// writing to the terminal in raw mode.
     pub fn insert_newline(&mut self) {
         self.insert_char('\n');

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -436,7 +436,7 @@ impl Reedline {
     /// emits OSC 133 markers. Use [`MouseClickMode::EnabledWithOsc133`] to have
     /// Reedline emit OSC 133 markers with `click_events=1` so supporting terminals
     /// can send click events.
-    /// See: https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers
+    /// See: <https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers>
     #[must_use]
     pub fn with_mouse_click(mut self, mode: MouseClickMode) -> Self {
         self.mouse_click_mode = mode;

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -65,7 +65,7 @@ pub enum TextObjectType {
     Word,
     /// WORD (delimited only by whitespace)
     BigWord,
-    /// (, ), [, ], {, }
+    /// (, ), \[, ], {, }
     Brackets,
     /// ", ', `
     Quote,


### PR DESCRIPTION
Running `cargo doc --all-features` generated some warnings. This PR is to address them.