### PR TITLE
Reverts the changes in #1051 and #1058

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1256,13 +1256,9 @@ impl Reedline {
             }
             ReedlineEvent::CtrlC => {
                 self.deactivate_menus();
+                self.run_edit_commands(&[EditCommand::Clear]);
                 self.editor.reset_undo_stack();
-                if self.editor.is_empty() {
-                    Ok(EventStatus::Exits(Signal::CtrlC))
-                } else {
-                    self.run_edit_commands(&[EditCommand::Clear]);
-                    Ok(EventStatus::Handled)
-                }
+                Ok(EventStatus::Exits(Signal::CtrlC))
             }
             ReedlineEvent::ClearScreen => {
                 self.deactivate_menus();


### PR DESCRIPTION
The changes in #1051 created a regression in Nushell where <kbd>Ctrl</kbd>+<kbd>C</kbd> erased the current commandline.  This reverts the change and restores the ability to view the prior commandline after a <kbd>Ctrl</kbd>+<kbd>C</kbd>.