### PR TITLE
fix: expand and submit abbr on enter

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1289,7 +1289,7 @@ impl Reedline {
                     return self.handle_editor_event(prompt, event);
                 }
                 if let Some(event) = self.try_expand_abbreviation_at_cursor(true) {
-                    return self.handle_editor_event(prompt, event);
+                    self.handle_editor_event(prompt, event)?;
                 }
 
                 let buffer = self.editor.get_buffer().to_string();
@@ -1308,7 +1308,7 @@ impl Reedline {
                     return self.handle_editor_event(prompt, event);
                 }
                 if let Some(event) = self.try_expand_abbreviation_at_cursor(true) {
-                    return self.handle_editor_event(prompt, event);
+                    self.handle_editor_event(prompt, event)?;
                 }
 
                 Ok(self.submit_buffer(prompt)?)
@@ -1319,7 +1319,7 @@ impl Reedline {
                     return self.handle_editor_event(prompt, event);
                 }
                 if let Some(event) = self.try_expand_abbreviation_at_cursor(true) {
-                    return self.handle_editor_event(prompt, event);
+                    self.handle_editor_event(prompt, event)?;
                 }
 
                 let cursor_position_in_buffer = self.editor.insertion_point();


### PR DESCRIPTION
changes the behavior of abbreviations to expand *and* submit on `enter` instead of previously requiring `enter` twice

@fdncred 