### PR TITLE
fix(vi): enter visual mode through command

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -138,6 +138,7 @@ impl Editor {
                 self.move_left_until_char(*c, true, true, *select)
             }
             EditCommand::SelectAll => self.select_all(),
+            EditCommand::SelectChar => self.select_char(),
             EditCommand::CutSelection => self.cut_selection_to_cut_buffer(),
             EditCommand::CopySelection => self.copy_selection_to_cut_buffer(),
             EditCommand::Paste => self.paste_cut_buffer(),
@@ -640,6 +641,16 @@ impl Editor {
     fn select_all(&mut self) {
         self.selection_anchor = Some(0);
         self.line_buffer.move_to_end();
+    }
+
+    fn select_char(&mut self) {
+        self.update_selection_anchor(true);
+
+        // Normal vi mode already has inclusive selection via `get_selection`.
+        if !matches!(self.edit_mode, PromptEditMode::Vi(PromptViMode::Normal)) {
+            self.line_buffer
+                .set_insertion_point(self.line_buffer.grapheme_right_index());
+        }
     }
 
     #[cfg(feature = "system_clipboard")]
@@ -2167,5 +2178,47 @@ mod test {
 
         assert_eq!(bracket_result, expected_bracket);
         assert_eq!(quote_result, expected_quote);
+    }
+
+    #[rstest]
+    #[case("foo", 0, (0, 1))]
+    #[case("oof", 2, (2, 3))]
+    #[case("🇫oo", 0, (0, "🇫".len()))]
+    #[case("oo🇫", 2, (2, "oo🇫".len()))]
+    fn test_select_char(
+        #[case] input: &str,
+        #[case] cursor_pos: usize,
+        #[case] expected_selection: (usize, usize),
+    ) {
+        let mut editor = editor_with(input);
+        editor.move_to_position(cursor_pos, false);
+        editor.select_char();
+
+        let selection = editor.get_selection();
+        assert_eq!(selection, Some(expected_selection));
+    }
+
+    #[rstest]
+    #[case("foo", 0, "oo")]
+    #[case("oof", 2, "oo")]
+    #[case("hello world", 6, "hello orld")]
+    #[case("🇫oo", 0, "oo")]
+    #[case("oo🇫", 2, "oo")]
+    fn test_vi_visual_mode_vd_deletes_char_under_cursor(
+        #[case] input: &str,
+        #[case] cursor_pos: usize,
+        #[case] expected: &str,
+    ) {
+        let mut editor = editor_with(input);
+        editor.set_edit_mode(PromptEditMode::Vi(PromptViMode::Normal));
+        editor.move_to_position(cursor_pos, false);
+
+        // `v` in normal mode -> select char under cursor
+        editor.run_edit_command(&EditCommand::SelectChar);
+        // `d` in visual mode -> cut the selection
+        editor.run_edit_command(&EditCommand::CutSelection);
+
+        assert_eq!(editor.get_buffer(), expected);
+        assert_eq!(editor.insertion_point(), cursor_pos);
     }
 }

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -78,6 +78,13 @@ where
             let _ = input.next();
             Some(Command::EnterViAppend)
         }
+        Some('v') => {
+            let _ = input.next();
+            match mode {
+                ViMode::Normal => Some(Command::EnterViVisual),
+                _ => None,
+            }
+        }
         Some('u') => {
             let _ = input.next();
             Some(Command::Undo)
@@ -185,6 +192,7 @@ pub enum Command {
     PasteBefore,
     EnterViAppend,
     EnterViInsert,
+    EnterViVisual,
     Undo,
     ChangeToLineEnd,
     DeleteToEnd,
@@ -228,6 +236,10 @@ impl Command {
             Self::EnterViAppend => vec![ReedlineOption::Edit(EditCommand::MoveRight {
                 select: false,
             })],
+            Self::EnterViVisual => vec![
+                ReedlineOption::Event(ReedlineEvent::Esc),
+                ReedlineOption::Edit(EditCommand::SelectChar),
+            ],
             Self::NewlineAbove => vec![ReedlineOption::Edit(EditCommand::InsertNewlineAbove)],
             Self::NewlineBelow => vec![ReedlineOption::Edit(EditCommand::InsertNewlineBelow)],
             Self::PasteAfter => vec![ReedlineOption::Edit(EditCommand::PasteCutBufferAfter)],

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -78,11 +78,6 @@ impl EditMode for Vi {
             Event::Key(KeyEvent {
                 code, modifiers, ..
             }) => match (self.mode, modifiers, code) {
-                (ViMode::Normal, KeyModifiers::NONE, KeyCode::Char('v')) => {
-                    self.cache.clear();
-                    self.mode = ViMode::Visual;
-                    ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint])
-                }
                 (ViMode::Normal | ViMode::Visual, modifier, KeyCode::Char(c)) => {
                     let c = c.to_ascii_lowercase();
 
@@ -341,5 +336,32 @@ mod test {
         let result = vi.parse_event(esc);
 
         assert_eq!(result, ReedlineEvent::None);
+    }
+
+    #[test]
+    fn v_selects_char_under_cursor_test() {
+        let mut vi = Vi {
+            insert_keybindings: default_vi_insert_keybindings(),
+            normal_keybindings: default_vi_normal_keybindings(),
+            mode: ViMode::Normal,
+            ..Default::default()
+        };
+
+        let v = ReedlineRawEvent::try_from(Event::Key(KeyEvent::new(
+            KeyCode::Char('v'),
+            KeyModifiers::NONE,
+        )))
+        .unwrap();
+        let result = vi.parse_event(v);
+
+        // Should also select the grapheme, not just change mode
+        assert_eq!(vi.mode, ViMode::Visual);
+        assert_eq!(
+            result,
+            ReedlineEvent::Multiple(vec![
+                ReedlineEvent::Esc,
+                ReedlineEvent::Edit(vec![EditCommand::SelectChar])
+            ])
+        );
     }
 }

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -115,6 +115,9 @@ impl ParsedViSequence {
             (Some(Command::Delete), ParseResult::Incomplete) if mode == ViMode::Visual => {
                 Some(ViMode::Normal)
             }
+            (Some(Command::EnterViVisual), ParseResult::Incomplete) if mode == ViMode::Normal => {
+                Some(ViMode::Visual)
+            }
             (Some(Command::ChangeInsidePair { .. }), _) => Some(ViMode::Insert),
             (Some(Command::ChangeTextObject { .. }), _) => Some(ViMode::Insert),
             (Some(Command::Delete), ParseResult::Incomplete)

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -384,6 +384,9 @@ pub enum EditCommand {
     /// Select whole input buffer
     SelectAll,
 
+    /// Select grapheme under cursor
+    SelectChar,
+
     /// Cut selection to local buffer
     CutSelection,
 
@@ -536,9 +539,10 @@ impl EditCommand {
             | EditCommand::MoveLeftBefore { select, .. } => {
                 EditType::MoveCursor { select: *select }
             }
-            EditCommand::SwapCursorAndAnchor => EditType::MoveCursor { select: true },
-
-            EditCommand::SelectAll => EditType::MoveCursor { select: true },
+            // Selection
+            EditCommand::SwapCursorAndAnchor | EditCommand::SelectAll | EditCommand::SelectChar => {
+                EditType::MoveCursor { select: true }
+            }
             // Text edits
             EditCommand::InsertChar(_)
             | EditCommand::Backspace


### PR DESCRIPTION
### Problem:
Entering visual mode does not actually select char/grapheme under cursor. Thus you have to do something like `vlh` to actually move selection to cursor. This happens because the parser eats the `v` input and sets mode manually instead of it going through the usual `Command` -> `EditCommand` pipeline.

### Solution:
- Add `EditCommand::SelectChar` that sets selection anchor to current cursor position
- Add `Command::EnterViVisual` that maps to `EditCommand::SelectChar`

Mode change still happens in parser, but now through the return value of `changes_mode`.