### PR TITLE
perf: minimize cursor::position queries

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -824,6 +824,10 @@ impl Reedline {
             #[cfg(feature = "idle_callback")]
             if let Some(ref mut callback) = self.idle_callback {
                 callback();
+                // The callback owns stdout while it runs and may have
+                // written or moved the cursor. Re-verify the anchor on
+                // the next paint.
+                self.painter.invalidate_prompt_start_row();
             }
 
             if let Some(ref signal) = self.break_signal {
@@ -1979,13 +1983,20 @@ impl Reedline {
                 }
                 {
                     let mut child = command.spawn()?;
+                    // The child owns the tty now; invalidate eagerly so
+                    // any `?` early-return below still leaves the
+                    // painter in a safe state.
+                    self.painter.invalidate_prompt_start_row();
                     child.wait()?;
                 }
 
-                // The spawned editor inherited our tty and may have left the
-                // cursor anywhere; ensure the next repaint will re-query the
-                // cursor position and accordingly update the prompt location.
-                self.painter.invalidate_prompt_start_row();
+                // On the success path, re-initialize position and size
+                // from scratch (covers a resize-during-editor with no
+                // SIGWINCH). On query failure, the eager invalidate
+                // above is our floor — losing the size refresh is
+                // acceptable; losing the user's edited buffer below
+                // is not.
+                let _ = self.painter.initialize_prompt_position(None);
 
                 let res = std::fs::read_to_string(temp_file)?;
                 let res = res.trim_end().to_string();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1982,6 +1982,11 @@ impl Reedline {
                     child.wait()?;
                 }
 
+                // The spawned editor inherited our tty and may have left the
+                // cursor anywhere; ensure the next repaint will re-query the
+                // cursor position and accordingly update the prompt location.
+                self.painter.invalidate_prompt_start_row();
+
                 let res = std::fs::read_to_string(temp_file)?;
                 let res = res.trim_end().to_string();
 

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -165,7 +165,15 @@ pub(crate) struct PromptLayout {
 pub struct Painter {
     // Stdout
     stdout: W,
+    /// Row where the prompt starts on screen. `_stale = false` means
+    /// the cached value is consistent with the terminal as of the
+    /// last successful query or paint; `true` means something may
+    /// have moved the cursor or written content we don't model, so
+    /// the next `repaint_buffer` must re-query. Call
+    /// `invalidate_prompt_start_row` from any new code path that
+    /// violates this invariant.
     prompt_start_row: u16,
+    prompt_start_row_stale: bool,
     // The number of lines that the prompt takes up
     prompt_height: u16,
     terminal_size: (u16, u16),
@@ -184,6 +192,9 @@ impl Painter {
         Painter {
             stdout,
             prompt_start_row: 0,
+            // `true` so `repaint_buffer` cannot trust an uninitialised
+            // row; `initialize_prompt_position` clears it.
+            prompt_start_row_stale: true,
             prompt_height: 0,
             terminal_size: (0, 0),
             last_required_lines: 0,
@@ -373,7 +384,18 @@ impl Painter {
                 }
             }
         };
+        // `prompt_start_row` matches the cursor row we just measured;
+        // mark fresh so subsequent paints can skip the drift-detection DSR.
+        self.prompt_start_row_stale = false;
         Ok(())
+    }
+
+    /// Mark `prompt_start_row` as possibly out of sync — the next
+    /// `repaint_buffer` will re-query the terminal. Call from any path
+    /// that lets something other than reedline's rendering move the
+    /// cursor (e.g. `$EDITOR`).
+    pub(crate) fn invalidate_prompt_start_row(&mut self) {
+        self.prompt_start_row_stale = true;
     }
 
     /// Main painter for the prompt and buffer
@@ -414,6 +436,9 @@ impl Painter {
                 .prompt_start_row
                 .saturating_sub(lines_before_cursor - 1);
             self.just_resized = false;
+            // Re-anchor complete; cache is back in sync with the
+            // prompt's post-resize screen origin.
+            self.prompt_start_row_stale = false;
         }
 
         // Lines and distance parameters
@@ -423,21 +448,36 @@ impl Painter {
         // Marking the painter state as larger buffer to avoid animations
         self.large_buffer = required_lines >= screen_height;
 
-        // This might not be terribly performant. Testing it out
-        let is_reset = || match cursor::position() {
-            // when output something without newline, the cursor position is at current line.
-            // but the prompt_start_row is next line.
-            // in this case we don't want to reset, need to `add 1` to handle for such case.
-            Ok(position) => position.1 + 1 < self.prompt_start_row,
-            Err(_) => false,
+        // True if the prompt has scrolled above the cached
+        // `prompt_start_row` and the caller must re-anchor at row 0.
+        // When stale, query the terminal; clear the stale flag if the
+        // query confirms no drift, so later paints can skip the query.
+        let should_reset_anchor = if self.prompt_start_row_stale {
+            match cursor::position() {
+                // The `+1` handles the case where the previous output
+                // ended without a newline, leaving the cursor on the
+                // same row as the next prompt.
+                Ok(position) => {
+                    let drifted = position.1 + 1 < self.prompt_start_row;
+                    if !drifted {
+                        self.prompt_start_row_stale = false;
+                    }
+                    drifted
+                }
+                Err(_) => false,
+            }
+        } else {
+            false
         };
 
         // Moving the start position of the cursor based on the size of the required lines
-        if self.large_buffer || is_reset() {
+        if self.large_buffer || should_reset_anchor {
             for _ in 0..screen_height.saturating_sub(lines_before_cursor) {
                 self.stdout.queue(Print(&coerce_crlf("\n")))?;
             }
             self.prompt_start_row = 0;
+            // The reset puts the prompt at row 0; cache is back in sync.
+            self.prompt_start_row_stale = false;
         } else if required_lines >= remaining_lines {
             let extra = required_lines.saturating_sub(remaining_lines);
             self.queue_universal_scroll(extra)?;
@@ -883,17 +923,17 @@ impl Painter {
     pub(crate) fn handle_resize(&mut self, width: u16, height: u16) {
         self.terminal_size = (width, height);
 
-        // `cursor::position() is blocking and can timeout.
-        // The question is whether we can afford it. If not, perhaps we should use it in some scenarios but not others
-        // The problem is trying to calculate this internally doesn't seem to be reliable because terminals might
-        // have additional text in their buffer that messes with the offset on scroll.
-        // It seems like it _should_ be ok because it only happens on resize.
+        // `prompt_start_row` is the cursor row here, not the prompt's
+        // screen origin; the `just_resized` branch in `repaint_buffer`
+        // will re-anchor and mark fresh.
+        self.invalidate_prompt_start_row();
 
-        // Known bug: on iterm2 and kitty, clearing the screen via CMD-K doesn't reset
-        // the position. Might need to special-case this.
+        // `cursor::position()` is blocking and can time out, but a
+        // resize happens infrequently enough that we accept the cost.
         //
-        // I assume this is a bug with the position() call but haven't figured that
-        // out yet.
+        // Known bug: on iterm2 and kitty, clearing the screen via CMD-K
+        // doesn't reset the cursor position — possibly a `position()`
+        // bug; not addressed here.
         #[cfg(not(test))]
         {
             if let Ok(position) = cursor::position() {
@@ -903,11 +943,15 @@ impl Painter {
         }
     }
 
-    /// Writes `line` to the terminal with a following carriage return and newline
+    /// Writes `line` to the terminal followed by `\r\n`. Invalidates
+    /// `prompt_start_row` defensively — current callers
+    /// (`print_history*`) only run between `read_line` cycles, but the
+    /// painter shouldn't trust a cache after content it didn't track.
     pub(crate) fn paint_line(&mut self, line: &str) -> Result<()> {
         self.stdout.queue(Print(line))?.queue(Print("\r\n"))?;
-
-        self.stdout.flush()
+        self.stdout.flush()?;
+        self.invalidate_prompt_start_row();
+        Ok(())
     }
 
     /// Goes to the beginning of the next line
@@ -998,6 +1042,12 @@ impl Painter {
                 self.prompt_start_row = new_start;
             }
         }
+        // External messages can contain ANSI escapes, ambiguous-width
+        // chars, embedded `\r`, etc. — modelling their on-screen extent
+        // precisely from the string is fragile. Invalidate instead; the
+        // next paint's DSR resynchronises. Cost: one DSR per
+        // external-printer batch.
+        self.invalidate_prompt_start_row();
         Ok(())
     }
 

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -161,19 +161,53 @@ pub(crate) struct PromptLayout {
     first_buffer_col: u16,
 }
 
+/// Cached row where the prompt starts on screen, together with its
+/// freshness.
+///
+/// Call [`PromptStartRow::invalidate`] from any new code path that
+/// yields the tty or writes content the painter doesn't track.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PromptStartRow {
+    /// No row known yet (pre-`initialize_prompt_position`).
+    Unverified,
+    /// Last-known row, but something may have moved the cursor or written
+    /// content the painter doesn't model since. The next `repaint_buffer`
+    /// must re-query before trusting it.
+    Stale(u16),
+    /// Row matches the terminal as of the last successful query or paint.
+    Verified(u16),
+}
+
+impl PromptStartRow {
+    /// Painter's best understanding of the prompt's screen row,
+    /// regardless of freshness. Defaults to `0` when never initialized,
+    /// which should only happen before `initialize_prompt_position` runs;
+    /// we don't expect that to happen in normal flow.
+    pub(crate) fn last_known_row(self) -> u16 {
+        match self {
+            PromptStartRow::Verified(r) | PromptStartRow::Stale(r) => r,
+            PromptStartRow::Unverified => 0,
+        }
+    }
+
+    /// Record `row` as freshly verified.
+    pub(crate) fn mark_verified(&mut self, row: u16) {
+        *self = PromptStartRow::Verified(row);
+    }
+
+    /// Demote to stale, preserving the last-known row if any. Idempotent.
+    pub(crate) fn invalidate(&mut self) {
+        if let PromptStartRow::Verified(r) = *self {
+            *self = PromptStartRow::Stale(r);
+        }
+    }
+}
+
 /// Implementation of the output to the terminal
 pub struct Painter {
     // Stdout
     stdout: W,
-    /// Row where the prompt starts on screen. `_stale = false` means
-    /// the cached value is consistent with the terminal as of the
-    /// last successful query or paint; `true` means something may
-    /// have moved the cursor or written content we don't model, so
-    /// the next `repaint_buffer` must re-query. Call
-    /// `invalidate_prompt_start_row` from any new code path that
-    /// violates this invariant.
-    prompt_start_row: u16,
-    prompt_start_row_stale: bool,
+    prompt_start_row: PromptStartRow,
     // The number of lines that the prompt takes up
     prompt_height: u16,
     terminal_size: (u16, u16),
@@ -191,10 +225,7 @@ impl Painter {
     pub(crate) fn new(stdout: W) -> Self {
         Painter {
             stdout,
-            prompt_start_row: 0,
-            // `true` so `repaint_buffer` cannot trust an uninitialised
-            // row; `initialize_prompt_position` clears it.
-            prompt_start_row_stale: true,
+            prompt_start_row: PromptStartRow::Unverified,
             prompt_height: 0,
             terminal_size: (0, 0),
             last_required_lines: 0,
@@ -228,7 +259,7 @@ impl Painter {
     /// Returns the empty lines from the prompt down.
     pub fn remaining_lines_real(&self) -> u16 {
         self.screen_height()
-            .saturating_sub(self.prompt_start_row)
+            .saturating_sub(self.prompt_start_row.last_known_row())
             .saturating_sub(self.prompt_height)
     }
 
@@ -238,7 +269,8 @@ impl Painter {
     /// If you want the number of empty lines below the prompt,
     /// use [`Painter::remaining_lines_real`] instead.
     pub fn remaining_lines(&self) -> u16 {
-        self.screen_height().saturating_sub(self.prompt_start_row)
+        self.screen_height()
+            .saturating_sub(self.prompt_start_row.last_known_row())
     }
 
     /// Computes layout values shared between rendering and snapshot creation.
@@ -289,7 +321,7 @@ impl Painter {
                 let input_width = lines.estimate_right_prompt_line_width(screen_width);
 
                 if input_width <= start_position {
-                    let mut row = self.prompt_start_row;
+                    let mut row = self.prompt_start_row.last_known_row();
                     if lines.right_prompt_on_last_line {
                         row += lines.prompt_lines_with_wrap(screen_width);
                     }
@@ -309,7 +341,7 @@ impl Painter {
             if cursor_distance >= screen_height.saturating_sub(1) {
                 screen_height.saturating_sub(menu.min_rows())
             } else {
-                self.prompt_start_row + cursor_distance + 1
+                self.prompt_start_row.last_known_row() + cursor_distance + 1
             }
         });
 
@@ -341,7 +373,7 @@ impl Painter {
     ///
     /// This state will be used to re-initialize the painter to re-use last prompt if possible.
     pub fn state_before_suspension(&self) -> PainterSuspendedState {
-        let start_row = self.prompt_start_row;
+        let start_row = self.prompt_start_row.last_known_row();
         let final_row = start_row + self.last_required_lines;
         PainterSuspendedState {
             previous_prompt_rows_range: start_row..=final_row,
@@ -369,7 +401,7 @@ impl Painter {
             }
         };
         let prompt_selector = select_prompt_row(suspended_state, cursor::position()?);
-        self.prompt_start_row = match prompt_selector {
+        let new_row = match prompt_selector {
             PromptRowSelector::UseExistingPrompt { start_row } => start_row,
             PromptRowSelector::MakeNewPrompt { new_row } => {
                 // If we are on the last line and would move beyond the last line, we need to make
@@ -384,9 +416,10 @@ impl Painter {
                 }
             }
         };
-        // `prompt_start_row` matches the cursor row we just measured;
-        // mark fresh so subsequent paints can skip the drift-detection DSR.
-        self.prompt_start_row_stale = false;
+        // Matches the cursor row we just measured; mark verified so
+        // subsequent paints can skip the possibly-expensive
+        // drift-detection call to cursor::position().
+        self.prompt_start_row.mark_verified(new_row);
         Ok(())
     }
 
@@ -395,7 +428,7 @@ impl Painter {
     /// that lets something other than reedline's rendering move the
     /// cursor (e.g. `$EDITOR`).
     pub(crate) fn invalidate_prompt_start_row(&mut self) {
-        self.prompt_start_row_stale = true;
+        self.prompt_start_row.invalidate();
     }
 
     /// Main painter for the prompt and buffer
@@ -432,13 +465,16 @@ impl Painter {
 
         // Calibrate prompt start position for multi-line prompt/content before cursor. Check issue #841/#848/#930
         if self.just_resized {
-            self.prompt_start_row = self
+            let resized_row = self
                 .prompt_start_row
+                .last_known_row()
                 .saturating_sub(lines_before_cursor - 1);
+            // Leave as `Stale` so the drift check below still runs this
+            // paint and self-heals if the arithmetic landed wrong.
+            // Resize is infrequent; one extra call to cursor::position()
+            // per resize is fine.
+            self.prompt_start_row = PromptStartRow::Stale(resized_row);
             self.just_resized = false;
-            // Re-anchor complete; cache is back in sync with the
-            // prompt's post-resize screen origin.
-            self.prompt_start_row_stale = false;
         }
 
         // Lines and distance parameters
@@ -450,24 +486,35 @@ impl Painter {
 
         // True if the prompt has scrolled above the cached
         // `prompt_start_row` and the caller must re-anchor at row 0.
-        // When stale, query the terminal; clear the stale flag if the
-        // query confirms no drift, so later paints can skip the query.
-        let should_reset_anchor = if self.prompt_start_row_stale {
-            match cursor::position() {
+        // When not verified, query the terminal; promote to verified if
+        // the query confirms no drift, so later paints can skip it.
+        let should_reset_anchor = match self.prompt_start_row {
+            PromptStartRow::Verified(_) => false,
+            PromptStartRow::Stale(row) => match cursor::position() {
                 // The `+1` handles the case where the previous output
                 // ended without a newline, leaving the cursor on the
                 // same row as the next prompt.
                 Ok(position) => {
-                    let drifted = position.1 + 1 < self.prompt_start_row;
+                    let drifted = position.1 + 1 < row;
                     if !drifted {
-                        self.prompt_start_row_stale = false;
+                        self.prompt_start_row.mark_verified(row);
                     }
                     drifted
                 }
                 Err(_) => false,
+            },
+            // `initialize_prompt_position` runs before any
+            // `repaint_buffer`, so this branch is unreachable in normal
+            // flow. Panic loudly in debug builds; in release, force a
+            // re-anchor since the alternative is drawing over screen
+            // content at row 0 with no scroll.
+            PromptStartRow::Unverified => {
+                debug_assert!(
+                    false,
+                    "repaint_buffer reached before initialize_prompt_position"
+                );
+                true
             }
-        } else {
-            false
         };
 
         // Moving the start position of the cursor based on the size of the required lines
@@ -475,19 +522,20 @@ impl Painter {
             for _ in 0..screen_height.saturating_sub(lines_before_cursor) {
                 self.stdout.queue(Print(&coerce_crlf("\n")))?;
             }
-            self.prompt_start_row = 0;
             // The reset puts the prompt at row 0; cache is back in sync.
-            self.prompt_start_row_stale = false;
+            self.prompt_start_row.mark_verified(0);
         } else if required_lines >= remaining_lines {
             let extra = required_lines.saturating_sub(remaining_lines);
             self.queue_universal_scroll(extra)?;
-            self.prompt_start_row = self.prompt_start_row.saturating_sub(extra);
+            let scrolled_row = self.prompt_start_row.last_known_row().saturating_sub(extra);
+            self.prompt_start_row.mark_verified(scrolled_row);
         }
 
         // Moving the cursor to the start of the prompt
         // from this position everything will be printed
+        let anchor_row = self.prompt_start_row.last_known_row();
         self.stdout
-            .queue(cursor::MoveTo(0, self.prompt_start_row))?
+            .queue(cursor::MoveTo(0, anchor_row))?
             .queue(Clear(ClearType::FromCursorDown))?;
 
         let layout = self.compute_layout(lines, menu);
@@ -549,7 +597,7 @@ impl Painter {
         RenderSnapshot {
             screen_width: self.screen_width(),
             screen_height: self.screen_height(),
-            prompt_start_row: self.prompt_start_row,
+            prompt_start_row: self.prompt_start_row.last_known_row(),
             prompt_height: self.prompt_height,
             large_buffer: self.large_buffer,
             prompt_str_left: lines.prompt_str_left.to_string(),
@@ -923,35 +971,35 @@ impl Painter {
     pub(crate) fn handle_resize(&mut self, width: u16, height: u16) {
         self.terminal_size = (width, height);
 
-        // `prompt_start_row` is the cursor row here, not the prompt's
-        // screen origin; the `just_resized` branch in `repaint_buffer`
-        // will re-anchor and mark fresh.
         self.invalidate_prompt_start_row();
 
         // `cursor::position()` is blocking and can time out, but a
         // resize happens infrequently enough that we accept the cost.
+        // The row stored below is the *cursor* row, not the prompt's
+        // screen origin; `just_resized` in `repaint_buffer` re-anchors
+        // it on the next paint.
         //
         // Known bug: on iterm2 and kitty, clearing the screen via CMD-K
         // doesn't reset the cursor position — possibly a `position()`
-        // bug; not addressed here.
+        // bug.
         #[cfg(not(test))]
         {
             if let Ok(position) = cursor::position() {
-                self.prompt_start_row = position.1;
+                self.prompt_start_row = PromptStartRow::Stale(position.1);
                 self.just_resized = true;
             }
         }
     }
 
-    /// Writes `line` to the terminal followed by `\r\n`. Invalidates
-    /// `prompt_start_row` defensively — current callers
-    /// (`print_history*`) only run between `read_line` cycles, but the
-    /// painter shouldn't trust a cache after content it didn't track.
+    /// Writes `line` to the terminal followed by `\r\n` and
+    /// invalidates the cached prompt anchor since the line scrolls the
+    /// terminal independently of the painter.
     pub(crate) fn paint_line(&mut self, line: &str) -> Result<()> {
-        self.stdout.queue(Print(line))?.queue(Print("\r\n"))?;
-        self.stdout.flush()?;
+        // Invalidate up front: a partial write below can still leave
+        // bytes in the kernel/tty buffer and displace the cursor.
         self.invalidate_prompt_start_row();
-        Ok(())
+        self.stdout.queue(Print(line))?.queue(Print("\r\n"))?;
+        self.stdout.flush()
     }
 
     /// Goes to the beginning of the next line
@@ -1027,6 +1075,12 @@ impl Painter {
             self.stdout.queue(MoveUp(buffer_num_lines - 1))?;
         }
         let erase_line = format!("\r{}\r", " ".repeat(self.screen_width().into()));
+        let max_row = self.screen_height().saturating_sub(1);
+        let starting_row = self.prompt_start_row.last_known_row();
+        // Invalidate up front: a `?` early-return below can leave
+        // bytes in the buffer with the cache still claiming `Verified`.
+        self.invalidate_prompt_start_row();
+        let mut row = starting_row;
         for line in messages {
             self.stdout.queue(Print(&erase_line))?;
             // Note: we don't use `print_line` here because we don't want to
@@ -1034,20 +1088,14 @@ impl Painter {
             // immediate flush anyways. And if we flush here, every external
             // print causes visible flicker.
             self.stdout.queue(Print(line))?.queue(Print("\r\n"))?;
-            let new_start = self.prompt_start_row.saturating_add(1);
-            let height = self.screen_height();
-            if new_start >= height {
-                self.prompt_start_row = height - 1;
-            } else {
-                self.prompt_start_row = new_start;
-            }
+            row = row.saturating_add(1).min(max_row);
         }
-        // External messages can contain ANSI escapes, ambiguous-width
-        // chars, embedded `\r`, etc. — modelling their on-screen extent
-        // precisely from the string is fragile. Invalidate instead; the
-        // next paint's DSR resynchronises. Cost: one DSR per
-        // external-printer batch.
-        self.invalidate_prompt_start_row();
+        // Track the row by counting `\r\n`s — matches reedline's
+        // historical behavior. The drift check is one-sided so a
+        // message that secretly scrolls more rows than we counted
+        // (embedded `\n`, certain CSI sequences) can still incorrectly
+        // anchor.
+        self.prompt_start_row = PromptStartRow::Stale(row);
         Ok(())
     }
 
@@ -1317,7 +1365,7 @@ mod tests {
     fn make_painter(width: u16, height: u16, large_buffer: bool) -> Painter {
         let mut p = Painter::new(W::new(std::io::stderr()));
         p.terminal_size = (width, height);
-        p.prompt_start_row = 0;
+        p.prompt_start_row.mark_verified(0);
         p.prompt_height = 1;
         p.large_buffer = large_buffer;
         p
@@ -1440,7 +1488,7 @@ mod tests {
 
         let mut painter = Painter::new(W::new(std::io::stderr()));
         painter.terminal_size = (20, 10);
-        painter.prompt_start_row = 0;
+        painter.prompt_start_row.mark_verified(0);
         painter.prompt_height = 1;
         painter.set_semantic_markers(Some(Box::new(markers)));
 


### PR DESCRIPTION
# Skip redundant cursor::position queries in the repaint hot path

Reedline issues a CSI 6n / DSR (`cursor::position()`) on every paint to check whether `prompt_start_row` has drifted from the terminal's real cursor row. That's a synchronous round-trip; over high-latency transports like SSH it dominates prompt-redraw latency.

Within a `read_line` cycle reedline is the sole writer to the terminal and updates `prompt_start_row` itself as its rendering scrolls — so the drift check is unnecessary in the steady state.

A new `prompt_start_row_stale: bool` on `Painter` tracks freshness:

- Cleared after the cursor query in `initialize_prompt_position`.
- Set by paths that yield the tty or write content the painter doesn't  model (`handle_resize`, `print_external_message`, `paint_line`,  `open_editor`).
- Re-cleared on the next paint by a confirmed-no-drift query.

The hot-path drift check skips the DSR when the cache is fresh. The change is wholly inside reedline, so the improvement carries to any consumer (e.g., Nushell, brush, custom REPLs) without changes on their side.

## Notes

I know that this is an area that may be challenging to test/validate. I'm open to any suggestions/feedback on how to ensure that this change does not regress existing functionality, while still improving the performance.

**_Full disclosure:_** as you can probably tell, I used Claude to identify and develop changes -- but I was heavily steering, and ultimately rewrote the code several times to address concerns that I had myself over maintainability challenges. I'm also placing this in draft first, with the hope to get early feedback on the approach and the maintainers' openness to considering this change. Any and all feedback is very much welcome, please :smile:

## Tradeoffs

- Each invalidating event trades the unconditional per-paint DSR for one DSR on the next paint; that's strictly better than the current per-paint cost, but not free on workloads heavy in external-printer batches or resizes.
- Terminals where `cursor::position()` fails see the same behavior as before: the drift check still runs and fails, with no optimization gain (and no regression).

## Measurements

Nushell 0.113.0 (HEAD) built against this branch's reedline vs against reedline `main`. PTY harness (portable-pty), 80×24, scripted 80 ms input pacing, 5 Enter presses per run, `--no-config-file --no-history`. Three samples per condition; the harness is deterministic and produced identical DSR counts across samples within each condition.

DSR counts:

| reedline | total DSRs (5 Enters) | per Enter |
| --- | --- | --- |
| `main` | 19 | 3.80 |
| this branch | 6 | 1.20 |

Same harness with `--simulated-rtt-ms 125` (each CSI 6n reply delayed 125 ms — comparable to a typical cross-region SSH round trip):

| reedline | total wall-clock (5 Enters) | per Enter |
| --- | --- | --- |
| `main` | ~2150 ms | ~430 ms |
| this branch | ~640 ms | ~127 ms |

The remaining ~1 DSR/cycle on this branch is the unavoidable one in `initialize_prompt_position`; reedline genuinely doesn't know where the host left the cursor before `read_line` is called.

[brush](https://github.com/reubeno/brush), a smaller `reedline`-based shell, shows the same shape (3.0 → 1.0 DSRs/cycle) — confirming the win is at the reedline layer, not shell-specific.

closes #968 

related #1010 
related #870