### PR TITLE
refactor(completer)!: don't require Send on the Completer trait

### DIFF
--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -29,7 +29,7 @@ impl Span {
 
 /// A trait that defines how to convert some text and a position to a list of potential completions in that position.
 /// The text could be a part of the whole line, and the position is the index of the end of the text in the original line.
-pub trait Completer: Send {
+pub trait Completer {
     /// the action that will take the line and position and convert it to a vector of completions, which include the
     /// span to replace and the contents of that replacement
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion>;

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -11,10 +11,6 @@ const SELECTION_CHAR: char = '!';
 // It pulls data from the object that contains access to the History
 pub(crate) struct HistoryCompleter<'menu>(&'menu dyn History);
 
-// Safe to implement Send since the HistoryCompleter should only be used when
-// updating the menu and that must happen in the same thread
-unsafe impl Send for HistoryCompleter<'_> {}
-
 fn search_unique(
     completer: &HistoryCompleter,
     line: &str,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -160,7 +160,7 @@ pub struct Reedline {
     edit_mode: Box<dyn EditMode>,
 
     // Provides the tab completions
-    completer: Box<dyn Completer>,
+    completer: Box<dyn Completer + Send>,
     quick_completions: bool,
     partial_completions: bool,
 
@@ -401,7 +401,7 @@ impl Reedline {
     /// let mut line_editor = Reedline::create().with_completer(completer);
     /// ```
     #[must_use]
-    pub fn with_completer(mut self, completer: Box<dyn Completer>) -> Self {
+    pub fn with_completer(mut self, completer: Box<dyn Completer + Send>) -> Self {
         self.completer = completer;
         self
     }
@@ -2268,6 +2268,16 @@ mod tests {
     use crate::terminal_extensions::semantic_prompt::PromptKind;
     use crate::DefaultPrompt;
     use rstest::rstest;
+
+    #[test]
+    fn reedline_is_send() {
+        // `Reedline` must stay `Send` so it can be moved across threads.
+        // The `Send` bound lives on the stored `Box<dyn Completer + Send>`
+        // (engine + `ReedlineMenu`), not on the `Completer`/`Menu` traits
+        // themselves, so this guards against that bound being dropped.
+        fn assert_send<T: Send>() {}
+        assert_send::<Reedline>();
+    }
 
     #[test]
     fn test_cursor_position_after_multiline_history_navigation() {

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -360,7 +360,7 @@ pub enum ReedlineMenu {
         /// Base menu
         menu: Box<dyn Menu>,
         /// External completer defined outside Reedline
-        completer: Box<dyn Completer>,
+        completer: Box<dyn Completer + Send>,
     },
 }
 


### PR DESCRIPTION
The `unsafe impl Send` on `HistoryCompleter` was actually sound: it's a `pub(crate)` type only ever created as a stack local and borrowed into menus, never sent across threads.
But it pointed at a trait that's too tight, since `Completer: Send` forces *every* completer to be `Send`.

So instead of asserting `Send` where it isn't required, this drops it from the `Completer` trait and requires it only on the completers that are actually owned and stored, thus in `Reedline` and `ReedlineMenu::WithCompleter`, now `Box<dyn Completer + Send>`.
The `unsafe` falls away naturally, with **no** new bound on `History`, so `SqliteBackedHistory` (whose `rusqlite::Connection` is `!Sync`) is untouched.

This is an alternative to #869, which tightened `History: Sync` to fix the same `unsafe` but broke the sqlite backend as a result.

Added `reedline_is_send` as a compile-time guard on the relocated bound.

**API note:** `with_completer` and `ReedlineMenu::WithCompleter` now take `Box<dyn Completer + Send>`. Source-compatible (the old `Completer: Send` already required it), but visible in signatures.
