### PR TITLE
feat(history): rank history menu by existing prompt

### DIFF
--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 const SELECTION_CHAR: char = '!';
+const MAX_SEARCH_PROMPT_BYTES: usize = 512;
 
 // The HistoryCompleter is created just before updating the menu
 // It pulls data from the object that contains access to the History
@@ -80,8 +81,14 @@ impl<'menu> HistoryCompleter<'menu> {
         }
     }
 
+    /// Use the editor buffer to rank history results by the existing left-hand prompt.
+    ///
+    /// LHS ranking is intended for single-line command prefixes. Multiline or large
+    /// buffers fall back to regular history ordering.
     pub fn with_buffer(mut self, buffer: &str) -> Self {
-        self.buffer = Some(buffer.to_string());
+        if buffer.len() <= MAX_SEARCH_PROMPT_BYTES && !buffer.contains('\n') {
+            self.buffer = Some(buffer.to_string());
+        }
         self
     }
 

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -162,7 +162,10 @@ mod tests {
 
     fn apply_suggestion(buffer: &str, suggestion: &Suggestion) -> String {
         let mut buffer = buffer.to_string();
-        buffer.replace_range(suggestion.span.start..suggestion.span.end, &suggestion.value);
+        buffer.replace_range(
+            suggestion.span.start..suggestion.span.end,
+            &suggestion.value,
+        );
         buffer
     }
 
@@ -276,10 +279,16 @@ mod tests {
             .map(|suggestion| suggestion.value.as_str())
             .collect();
 
-        assert_eq!(actual_values, ["git log --oneline", "hg log", "docker logs"]);
+        assert_eq!(
+            actual_values,
+            ["git log --oneline", "hg log", "docker logs"]
+        );
         assert_eq!(actual[0].span, Span::new(0, buffer.len()));
         assert_eq!(apply_suggestion(buffer, &actual[0]), "git log --oneline");
-        assert_eq!(actual[1].span, Span::new(buffer.len() - line.len(), buffer.len()));
+        assert_eq!(
+            actual[1].span,
+            Span::new(buffer.len() - line.len(), buffer.len())
+        );
         assert_eq!(apply_suggestion(buffer, &actual[1]), "git hg log");
         Ok(())
     }

--- a/src/completion/history.rs
+++ b/src/completion/history.rs
@@ -9,53 +9,116 @@ const SELECTION_CHAR: char = '!';
 
 // The HistoryCompleter is created just before updating the menu
 // It pulls data from the object that contains access to the History
-pub(crate) struct HistoryCompleter<'menu>(&'menu dyn History);
+pub(crate) struct HistoryCompleter<'menu> {
+    history: &'menu dyn History,
+    buffer: Option<String>,
+}
 
-fn search_unique(
+struct SearchPrompt {
+    text: String,
+    replace_span: Span,
+}
+
+fn search_ranked(
     completer: &HistoryCompleter,
     line: &str,
-) -> Result<impl Iterator<Item = HistoryItem>> {
+    pos: usize,
+) -> Result<(Vec<HistoryItem>, Option<SearchPrompt>)> {
     let parsed = parse_selection_char(line, SELECTION_CHAR);
-    let values = completer.0.search(SearchQuery::all_that_contain_rev(
+    let values = completer.history.search(SearchQuery::all_that_contain_rev(
         parsed.remainder.to_string(),
     ))?;
-
+    let prompt = completer.search_prompt(line, pos);
     let mut seen_matching_command_lines = HashSet::new();
-    Ok(values
+
+    let values = values
         .into_iter()
-        .filter(move |value| seen_matching_command_lines.insert(value.command_line.clone())))
+        .filter(|value| seen_matching_command_lines.insert(value.command_line.clone()));
+
+    let Some(prompt) = prompt else {
+        return Ok((values.collect(), None));
+    };
+
+    let (mut matches, other_matches): (Vec<_>, Vec<_>) =
+        values.partition(|value| value.command_line.contains(&prompt.text));
+
+    if matches.is_empty() {
+        Ok((other_matches, None))
+    } else {
+        matches.extend(other_matches);
+        Ok((matches, Some(prompt)))
+    }
 }
 
 impl Completer for HistoryCompleter<'_> {
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
-        match search_unique(self, line) {
+        match search_ranked(self, line, pos) {
             Err(_) => vec![],
-            Ok(search_results) => search_results
-                .map(|value| self.create_suggestion(line, pos, value.command_line.deref()))
+            Ok((values, prompt)) => values
+                .into_iter()
+                .map(|value| {
+                    self.create_suggestion(line, pos, value.command_line.deref(), prompt.as_ref())
+                })
                 .collect(),
         }
     }
 
     // TODO: Implement `fn partial_complete()`
 
-    fn total_completions(&mut self, line: &str, _pos: usize) -> usize {
-        search_unique(self, line).map(|i| i.count()).unwrap_or(0)
+    fn total_completions(&mut self, line: &str, pos: usize) -> usize {
+        search_ranked(self, line, pos)
+            .map(|(values, _)| values.len())
+            .unwrap_or(0)
     }
 }
 
 impl<'menu> HistoryCompleter<'menu> {
     pub fn new(history: &'menu dyn History) -> Self {
-        Self(history)
+        Self {
+            history,
+            buffer: None,
+        }
+    }
+
+    pub fn with_buffer(mut self, buffer: &str) -> Self {
+        self.buffer = Some(buffer.to_string());
+        self
+    }
+
+    fn search_prompt(&self, line: &str, pos: usize) -> Option<SearchPrompt> {
+        let buffer = self.buffer.as_deref()?;
+        let start = pos.checked_sub(line.len())?;
+        if buffer.get(start..pos)? != line {
+            return None;
+        }
+
+        let before_search = &buffer[..start];
+        let prompt = before_search.trim();
+        let leading_whitespace = before_search.len() - before_search.trim_start().len();
+
+        (!prompt.is_empty()).then(|| SearchPrompt {
+            text: prompt.to_string(),
+            replace_span: Span::new(leading_whitespace, pos),
+        })
     }
 
     /// Assumes `line.len() <= pos` (i.e. `line` is the cursor-prefix slice).
     /// Update this span calculation before HistoryMenu opts into `InputMode::FullBuffer`,
     /// where `line` would be the entire buffer and `pos - line.len()` would underflow.
-    fn create_suggestion(&self, line: &str, pos: usize, value: &str) -> Suggestion {
-        let span = Span {
-            start: pos - line.len(),
-            end: pos,
-        };
+    fn create_suggestion(
+        &self,
+        line: &str,
+        pos: usize,
+        value: &str,
+        prompt: Option<&SearchPrompt>,
+    ) -> Suggestion {
+        let span = prompt
+            .filter(|prompt| value.contains(&prompt.text))
+            .map(|prompt| prompt.replace_span)
+            .unwrap_or(Span {
+                start: pos - line.len(),
+                end: pos,
+            });
 
         Suggestion {
             value: value.to_string(),
@@ -88,6 +151,12 @@ mod tests {
             exit_status: None,
             more_info: None,
         }
+    }
+
+    fn apply_suggestion(buffer: &str, suggestion: &Suggestion) -> String {
+        let mut buffer = buffer.to_string();
+        buffer.replace_range(suggestion.span.start..suggestion.span.end, &suggestion.value);
+        buffer
     }
 
     #[test]
@@ -153,6 +222,78 @@ mod tests {
             .map(|suggestion| suggestion.value)
             .collect();
         assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn diff_history_prioritizes_existing_prompt() -> Result<()> {
+        let mut history = FileBackedHistory::new(5)?;
+        for history_item in [
+            "git status",
+            "git stash",
+            "docker logs",
+            "git log --oneline",
+            "hg log",
+        ] {
+            history.save(new_history_item(history_item))?;
+        }
+
+        let buffer = "git st";
+        let mut sut = HistoryCompleter::new(&history).with_buffer(buffer);
+        let actual = sut.complete("", buffer.len());
+        let actual_values: Vec<_> = actual
+            .iter()
+            .map(|suggestion| suggestion.value.as_str())
+            .collect();
+
+        assert_eq!(
+            actual_values,
+            [
+                "git stash",
+                "git status",
+                "hg log",
+                "git log --oneline",
+                "docker logs"
+            ]
+        );
+        assert_eq!(actual[0].span, Span::new(0, buffer.len()));
+        assert_eq!(apply_suggestion(buffer, &actual[0]), "git stash");
+        assert_eq!(sut.total_completions("", buffer.len()), 5);
+
+        let buffer = "git log";
+        let line = "log";
+        let mut sut = HistoryCompleter::new(&history).with_buffer(buffer);
+        let actual = sut.complete(line, buffer.len());
+        let actual_values: Vec<_> = actual
+            .iter()
+            .map(|suggestion| suggestion.value.as_str())
+            .collect();
+
+        assert_eq!(actual_values, ["git log --oneline", "hg log", "docker logs"]);
+        assert_eq!(actual[0].span, Span::new(0, buffer.len()));
+        assert_eq!(apply_suggestion(buffer, &actual[0]), "git log --oneline");
+        assert_eq!(actual[1].span, Span::new(buffer.len() - line.len(), buffer.len()));
+        assert_eq!(apply_suggestion(buffer, &actual[1]), "git hg log");
+        Ok(())
+    }
+
+    #[test]
+    fn diff_history_falls_back_when_existing_prompt_does_not_match() -> Result<()> {
+        let mut history = FileBackedHistory::new(3)?;
+        for history_item in ["cargo test", "ls", "docker logs"] {
+            history.save(new_history_item(history_item))?;
+        }
+
+        let buffer = "zzlog";
+        let line = "log";
+        let mut sut = HistoryCompleter::new(&history).with_buffer(buffer);
+        let actual_values: Vec<_> = sut
+            .complete(line, buffer.len())
+            .into_iter()
+            .map(|suggestion| suggestion.value)
+            .collect();
+
+        assert_eq!(actual_values, ["docker logs"]);
         Ok(())
     }
 }

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -394,7 +394,8 @@ impl ReedlineMenu {
                 menu.can_partially_complete(values_updated, editor, completer)
             }
             Self::HistoryMenu(menu) => {
-                let mut history_completer = HistoryCompleter::new(history);
+                let mut history_completer =
+                    HistoryCompleter::new(history).with_buffer(editor.get_buffer());
                 menu.can_partially_complete(values_updated, editor, &mut history_completer)
             }
             Self::WithCompleter {
@@ -413,7 +414,8 @@ impl ReedlineMenu {
         match self {
             Self::EngineCompleter(menu) => menu.update_values(editor, completer),
             Self::HistoryMenu(menu) => {
-                let mut history_completer = HistoryCompleter::new(history);
+                let mut history_completer =
+                    HistoryCompleter::new(history).with_buffer(editor.get_buffer());
                 menu.update_values(editor, &mut history_completer);
             }
             Self::WithCompleter {
@@ -437,7 +439,8 @@ impl ReedlineMenu {
                 menu.update_working_details(editor, completer, painter);
             }
             Self::HistoryMenu(menu) => {
-                let mut history_completer = HistoryCompleter::new(history);
+                let mut history_completer =
+                    HistoryCompleter::new(history).with_buffer(editor.get_buffer());
                 menu.update_working_details(editor, &mut history_completer, painter);
             }
             Self::WithCompleter {


### PR DESCRIPTION
History menu completion now considers text already present before the active search input when ordering results.

I use the history search menu a lot in nushell, and this specific behavior has always irked me. So I'm proposing this solution, which in my opinion, is a big usability win for a likely common case where the user has partially entered a command into the line buffer, (with no history menu open), then hits Ctrl+R *after*, and expects the menu to complete their command based on their previous history of using that command.

Originally, the results yielded would not consider the existing prefix at all. After this PR change, we give high priority to results that match against the prefix. If a prefix-matching result gets selected, the existing line gets replaced by the overlapping result instead of appended, to match expected behavior for line completion. If there's no match for the existing prefix, or the current buffer is excessively long/multilined, we fallback to the original results and append selections to the line as we did before.