### PR TITLE
fix(vi): stop dot-repeat recording itself

### DIFF
--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -728,13 +728,8 @@ mod test {
     }
 
     #[test]
-    fn repeated_dot_accumulates_nesting_in_previous() {
-        // Each `.` press wraps `previous` in an outer Multiple AND
-        // assigns the wrapped result back to `previous`. So every
-        // press deepens the nesting by one. Observationally fine
-        // (engine flattens via recursion), but `previous` grows
-        // unboundedly over a session. Worse with multipliers — `2.`
-        // doubles the inner Vec each call.
+    fn repeated_dot_doesnt_accumulates_nesting_in_previous() {
+        // `.` replays the last change; it must not record itself
         fn depth(ev: &ReedlineEvent) -> usize {
             match ev {
                 ReedlineEvent::Multiple(v) if v.len() == 1 => 1 + depth(&v[0]),
@@ -750,13 +745,13 @@ mod test {
         assert_eq!(depth(vi.previous.as_ref().unwrap()), 1);
 
         let _ = vi.parse_event(key(KeyCode::Char('.'), KeyModifiers::NONE));
-        assert_eq!(depth(vi.previous.as_ref().unwrap()), 2);
+        assert_eq!(depth(vi.previous.as_ref().unwrap()), 1);
 
         let _ = vi.parse_event(key(KeyCode::Char('.'), KeyModifiers::NONE));
-        assert_eq!(depth(vi.previous.as_ref().unwrap()), 3);
+        assert_eq!(depth(vi.previous.as_ref().unwrap()), 1);
 
         let _ = vi.parse_event(key(KeyCode::Char('.'), KeyModifiers::NONE));
-        assert_eq!(depth(vi.previous.as_ref().unwrap()), 4);
+        assert_eq!(depth(vi.previous.as_ref().unwrap()), 1);
     }
 
     #[test]

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -131,25 +131,31 @@ impl ParsedViSequence {
         }
     }
 
+    /// Record `events` as the repeatable previous action, unless there is
+    /// nothing to record or the command is itself a repeat: `.` replays the
+    /// last change and must never record itself, otherwise `previous` would
+    /// nest without bound. `RepeatLastAction` only reaches the no-motion arm,
+    /// but guarding here keeps the recording policy correct for either caller.
+    fn record_previous(vi_state: &mut Vi, command: &Command, events: &ReedlineEvent) {
+        match events {
+            ReedlineEvent::None => {}
+            _ if matches!(command, Command::RepeatLastAction) => {}
+            event => vi_state.previous = Some(event.clone()),
+        }
+    }
+
     pub fn to_reedline_event(&self, vi_state: &mut Vi) -> ReedlineEvent {
         match (&self.multiplier, &self.command, &self.count, &self.motion) {
             (_, Some(command), None, ParseResult::Incomplete) => {
                 let events = self.apply_multiplier(Some(command.to_reedline(vi_state)));
-                match &events {
-                    ReedlineEvent::None => {}
-                    _ if matches!(command, Command::RepeatLastAction) => {}
-                    event => vi_state.previous = Some(event.clone()),
-                }
+                Self::record_previous(vi_state, command, &events);
                 events
             }
             // This case handles all combinations of commands and motions that could exist
             (_, Some(command), _, ParseResult::Valid(motion)) => {
                 let events =
                     self.apply_multiplier(command.to_reedline_with_motion(motion, vi_state));
-                match &events {
-                    ReedlineEvent::None => {}
-                    event => vi_state.previous = Some(event.clone()),
-                }
+                Self::record_previous(vi_state, command, &events);
                 events
             }
             (_, None, _, ParseResult::Valid(motion)) => {

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -137,6 +137,7 @@ impl ParsedViSequence {
                 let events = self.apply_multiplier(Some(command.to_reedline(vi_state)));
                 match &events {
                     ReedlineEvent::None => {}
+                    _ if matches!(command, Command::RepeatLastAction) => {}
                     event => vi_state.previous = Some(event.clone()),
                 }
                 events


### PR DESCRIPTION
. should replay the last change, but it was recording its own replay back into previous.
Each press re-wrapped previous in another Multiple, so the nesting grew by one per . (and 2. doubled the inner vec).
Observationally fine, since the engine flattens on replay, but previous grew without bound over a session.

Fix: skip recording when the command is RepeatLastAction.
. is not itself a change, so it must not update the repeat register.

The recording policy was duplicated across two arms of to_reedline_event, so this also folds it into a single record_previous helper.

The existing repeated_dot_accumulates_nesting_in_previous test pinned the buggy behavior, which got renamed and flipped to assert depth stays flat across repeated ..