### PR TITLE
remove old JT links that are no longer live or available

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,12 +219,6 @@
 //!
 //! For more ideas check out the [feature discussion](https://github.com/nushell/reedline/issues/63) or hop on the `#reedline` channel of the [nushell discord](https://discordapp.com/invite/NtAbbGn).
 //!
-//! ### Development history
-//!
-//! If you want to follow along with the history how reedline got started, you can watch the [recordings](https://youtube.com/playlist?list=PLP2yfE2-FXdQw0I6O4YdIX_mzBeF5TDdv) of [JT](https://github.com/jntrnr)'s [live-coding streams](https://www.twitch.tv/jntrnr).
-//!
-//! [Playlist: Creating a line editor in Rust](https://youtube.com/playlist?list=PLP2yfE2-FXdQw0I6O4YdIX_mzBeF5TDdv)
-//!
 //! ### Alternatives
 //!
 //! For currently more mature Rust line editing check out:


### PR DESCRIPTION
Unfortunately the JT links are no longer available that were made to help a new developer understand Reedline better.

It makes sense to delete these links because the YouTube content has been deleted.

Too bad they are gone !
