### PR TITLE
fix: re-use prompt rows after a quiet buffer editor

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1985,6 +1985,12 @@ impl Reedline {
                     let mut file = File::create(temp_file)?;
                     write!(file, "{}", self.editor.get_buffer())?;
                 }
+                // Capture the prompt's screen range so that an editor
+                // which leaves the cursor untouched (e.g. a GUI editor,
+                // or one that wrote nothing to the tty) re-uses the
+                // existing prompt rows instead of starting a new prompt
+                // a row below the old one.
+                let suspended_state = self.painter.state_before_suspension();
                 {
                     let mut child = command.spawn()?;
                     // The child owns the tty now; invalidate eagerly so
@@ -1995,12 +2001,15 @@ impl Reedline {
                 }
 
                 // On the success path, re-initialize position and size
-                // from scratch (covers a resize-during-editor with no
-                // SIGWINCH). On query failure, the eager invalidate
-                // above is our floor — losing the size refresh is
-                // acceptable; losing the user's edited buffer below
-                // is not.
-                let _ = self.painter.initialize_prompt_position(None);
+                // (covers a resize-during-editor with no SIGWINCH). If
+                // the editor moved the cursor out of the prompt's rows
+                // (it printed output), a fresh prompt starts below that
+                // output. On query failure, the eager invalidate above
+                // is our floor — losing the size refresh is acceptable;
+                // losing the user's edited buffer below is not.
+                let _ = self
+                    .painter
+                    .initialize_prompt_position(Some(&suspended_state));
 
                 let res = std::fs::read_to_string(temp_file)?;
                 let res = res.trim_end().to_string();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1986,10 +1986,10 @@ impl Reedline {
                     write!(file, "{}", self.editor.get_buffer())?;
                 }
                 // Capture the prompt's screen range so that an editor
-                // which leaves the cursor untouched (e.g. a GUI editor,
-                // or one that wrote nothing to the tty) re-uses the
-                // existing prompt rows instead of starting a new prompt
-                // a row below the old one.
+                // that leaves the cursor untouched (e.g. an editor that
+                // uses the alternate screen only) re-uses the existing
+                // prompt rows instead of starting a new prompt a row
+                // below the old one.
                 let suspended_state = self.painter.state_before_suspension();
                 {
                     let mut child = command.spawn()?;


### PR DESCRIPTION
The buffer-editor success path re-initialized the prompt position from scratch; with the cursor still sitting after the old buffer text, `select_prompt_row` would start a new prompt one row down, leaving the original input line above.

This change captures the painter's state before spawning the editor and restore with it; if the editor wrote nothing to the tty (or did so on the alternate screen only) this allows reusing the original prompt row. An editor that printed output should get a fresh row.

Closes #1106