### PR TITLE
Fix abbreviation expansion inserting a double trailing space

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1825,7 +1825,10 @@ impl Reedline {
                     select: false,
                 },
                 EditCommand::MoveToPosition {
-                    position: word_end,
+                    // Select through the cursor, not just the end of the word, so
+                    // the triggering space (already inserted on a <space> expansion)
+                    // is replaced rather than left beside the inserted suffix.
+                    position: cursor_position_in_buffer,
                     select: true,
                 },
                 EditCommand::InsertString(format!("{}{}", expansion, suffix)),
@@ -2544,6 +2547,24 @@ mod tests {
             _ => panic!("expected Edit event"),
         });
         assert_eq!(reedline.current_buffer_contents(), "git commit");
+    }
+
+    #[test]
+    fn abbreviation_expands_on_space_without_double_space() {
+        let mut reedline =
+            reedline_with_abbrevs_and_default_string_lit_check(&[("gc", "git commit")]);
+        // When expansion is triggered by <space>, the triggering space has
+        // already been inserted into the buffer before the expansion runs.
+        set_buffer_at_end(&mut reedline, "gc ");
+        let event = reedline.try_expand_abbreviation_at_cursor(false);
+        assert!(event.is_some(), "expected expansion on space");
+        reedline.run_edit_commands(&match event.unwrap() {
+            ReedlineEvent::Edit(cmds) => cmds,
+            _ => panic!("expected Edit event"),
+        });
+        // Exactly one trailing space: the triggering space must be replaced,
+        // not left in place alongside the inserted suffix space.
+        assert_eq!(reedline.current_buffer_contents(), "git commit ");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Expanding an abbreviation by pressing `<space>` inserted **two** trailing
spaces instead of one — one before the cursor and one after. This breaks
history-based completion: e.g. `git switch  ` (two spaces) is not a prefix of
`git switch main`, so the ghost-text completion disappears until the extra
space is deleted manually. Fixes #1108.

## Fix

On a `<space>` expansion the triggering space has already been inserted into
the buffer before `try_expand_abbreviation_at_cursor` runs. The replacement
selected only the abbreviation word (`word_start..word_end`), leaving that
space in place, and then inserted the expansion followed by its own suffix
space — yielding two trailing spaces.

The selection now extends through `cursor_position_in_buffer` instead of the
end of the word, so the already-inserted triggering space is replaced by the
expansion's suffix. The submit (`<enter>`) path is unaffected: there the cursor
sits at the end of the word, so the selected range is unchanged.

## Test

Adds `abbreviation_expands_on_space_without_double_space`, which exercises the
`<space>` expansion path (`submitted = false`) — previously untested; all
existing abbreviation tests only covered the submit path. It asserts that
expanding `gc` → `git commit` after the triggering space yields exactly
`git commit ` (one trailing space), and fails against the old behaviour
(`git commit  `).

## Reference

Reported in #1108. The issue pinpointed `src/engine.rs` abbreviation handling
as the cause.
