### PR TITLE
feat(history): add typed inherent methods and JSON filter to SqliteBackedHistory

### DIFF
--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -37,6 +37,25 @@ pub enum SearchDirection {
     Forward,
 }
 
+/// A typed expected value for [`SearchFilter::more_info_json`] filters.
+///
+/// Each variant maps to a JSON scalar type and produces a type-precise SQL comparison
+/// using `json_type()` to avoid collisions between JSON booleans, integers, and strings.
+/// Arrays and objects are intentionally unsupported.
+#[derive(Clone, Debug, PartialEq)]
+pub enum JsonFilterValue {
+    /// Match a JSON `null` at the given path.
+    Null,
+    /// Match a JSON boolean (`true` or `false`) at the given path.
+    Bool(bool),
+    /// Match a JSON integer at the given path. Does not match JSON `true`/`false` or strings.
+    Integer(i64),
+    /// Match a JSON floating-point number at the given path.
+    Real(f64),
+    /// Match a JSON string at the given path. Does not match numbers or booleans.
+    Text(String),
+}
+
 /// Defines additional filters for querying the [`History`]
 pub struct SearchFilter {
     /// Query for the command line content
@@ -53,22 +72,19 @@ pub struct SearchFilter {
     pub exit_successful: Option<bool>,
     /// Filter on the session id
     pub session: Option<HistorySessionId>,
-    /// Filter by JSON path in the `more_info` column using SQLite's `json_extract()`.
+    /// Filter by JSON path in the `more_info` column using SQLite's `json_type()` /
+    /// `json_extract()`.
     ///
-    /// Each entry is `(json_path, expected_value)`, e.g. `("$.meta_command", "true")`.
-    ///
-    /// ## Expected value encoding
-    ///
-    /// - **JSON booleans**: use `"true"` or `"false"` — matched via `json_type()`, which
-    ///   guarantees that integer `1`/`0` and strings `"true"`/`"false"` do *not* collide.
-    /// - **JSON strings**: use the string value directly, e.g. `"$.tag", "mytag"`.
-    /// - **JSON numbers**: use the numeric string, e.g. `"$.count", "42"`.
+    /// Each entry is `(json_path, expected_value)`. The [`JsonFilterValue`] variant
+    /// determines the exact SQL comparison used, preventing collisions between JSON
+    /// booleans, integers, and strings (e.g. `Bool(true)` will not match integer `1`
+    /// or string `"true"`).
     ///
     /// Rows where `more_info` is SQL `NULL` or the JSON path does not exist will not match.
     /// Only evaluated by [`crate::SqliteBackedHistory`] typed search methods
     /// (`search_with_extra`); the non-typed [`History`] trait methods and
     /// [`crate::FileBackedHistory`] ignore this field.
-    pub more_info_json: Option<Vec<(String, String)>>,
+    pub more_info_json: Option<Vec<(String, JsonFilterValue)>>,
 }
 
 impl SearchFilter {

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -55,15 +55,19 @@ pub struct SearchFilter {
     pub session: Option<HistorySessionId>,
     /// Filter by JSON path in the `more_info` column using SQLite's `json_extract()`.
     ///
-    /// Each entry is `(json_path, expected_value)`, e.g. `("$.meta_command", "1")`.
-    /// The expected value is compared against the raw SQLite value returned by `json_extract()`:
-    /// - JSON booleans map to integers: use `"1"` for `true`, `"0"` for `false`
-    /// - JSON strings: use the string value directly, e.g. `"$.tag", "mytag"`
-    /// - JSON numbers: use the numeric string, e.g. `"$.count", "42"`
+    /// Each entry is `(json_path, expected_value)`, e.g. `("$.meta_command", "true")`.
+    ///
+    /// ## Expected value encoding
+    ///
+    /// - **JSON booleans**: use `"true"` or `"false"` — matched via `json_type()`, which
+    ///   guarantees that integer `1`/`0` and strings `"true"`/`"false"` do *not* collide.
+    /// - **JSON strings**: use the string value directly, e.g. `"$.tag", "mytag"`.
+    /// - **JSON numbers**: use the numeric string, e.g. `"$.count", "42"`.
     ///
     /// Rows where `more_info` is SQL `NULL` or the JSON path does not exist will not match.
-    /// Only evaluated by [`crate::SqliteBackedHistory`] typed search methods;
-    /// ignored by [`crate::FileBackedHistory`] and the non-typed [`History`] trait methods.
+    /// Only evaluated by [`crate::SqliteBackedHistory`] typed search methods
+    /// (`search_with_extra`); the non-typed [`History`] trait methods and
+    /// [`crate::FileBackedHistory`] ignore this field.
     pub more_info_json: Option<Vec<(String, String)>>,
 }
 

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -53,6 +53,18 @@ pub struct SearchFilter {
     pub exit_successful: Option<bool>,
     /// Filter on the session id
     pub session: Option<HistorySessionId>,
+    /// Filter by JSON path in the `more_info` column using SQLite's `json_extract()`.
+    ///
+    /// Each entry is `(json_path, expected_value)`, e.g. `("$.meta_command", "1")`.
+    /// The expected value is compared against the raw SQLite value returned by `json_extract()`:
+    /// - JSON booleans map to integers: use `"1"` for `true`, `"0"` for `false`
+    /// - JSON strings: use the string value directly, e.g. `"$.tag", "mytag"`
+    /// - JSON numbers: use the numeric string, e.g. `"$.count", "42"`
+    ///
+    /// Rows where `more_info` is SQL `NULL` or the JSON path does not exist will not match.
+    /// Only evaluated by [`crate::SqliteBackedHistory`] typed search methods;
+    /// ignored by [`crate::FileBackedHistory`] and the non-typed [`History`] trait methods.
+    pub more_info_json: Option<Vec<(String, String)>>,
 }
 
 impl SearchFilter {
@@ -88,6 +100,7 @@ impl SearchFilter {
             cwd_prefix: None,
             exit_successful: None,
             session,
+            more_info_json: None,
         }
     }
 }

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -43,6 +43,7 @@ pub enum SearchDirection {
 /// using `json_type()` to avoid collisions between JSON booleans, integers, and strings.
 /// Arrays and objects are intentionally unsupported.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum JsonFilterValue {
     /// Match a JSON `null` at the given path.
     Null,

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -8,7 +8,8 @@ mod sqlite_backed;
 pub use sqlite_backed::SqliteBackedHistory;
 
 pub use base::{
-    CommandLineSearch, History, HistoryNavigationQuery, SearchDirection, SearchFilter, SearchQuery,
+    CommandLineSearch, History, HistoryNavigationQuery, JsonFilterValue, SearchDirection,
+    SearchFilter, SearchQuery,
 };
 pub use cursor::HistoryCursor;
 pub use item::{

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -814,6 +814,122 @@ mod tests {
         Ok(())
     }
 
+    /// Verify that Real(f) does not collide with Integer values stored at the same path.
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[test]
+    fn json_filter_value_real_vs_integer() -> crate::Result<()> {
+        #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+        struct WithScore {
+            score: f64,
+            count: i64,
+        }
+        impl HistoryItemExtraInfo for WithScore {}
+
+        let mut db = SqliteBackedHistory::in_memory()?;
+        let make = |cmd: &str, score: f64, count: i64| HistoryItem {
+            id: None,
+            start_timestamp: None,
+            command_line: cmd.to_string(),
+            session_id: None,
+            hostname: None,
+            cwd: None,
+            duration: None,
+            exit_status: None,
+            more_info: Some(WithScore { score, count }),
+        };
+        db.save_with_extra(make("cmd_a", 1.5, 1))?;
+        db.save_with_extra(make("cmd_b", 1.0, 2))?;
+
+        let search_score = |val: JsonFilterValue| -> crate::Result<Vec<String>> {
+            let filter = SearchFilter {
+                more_info_json: Some(vec![("$.score".to_string(), val)]),
+                ..SearchFilter::anything(None)
+            };
+            Ok(db
+                .search_with_extra::<WithScore>(SearchQuery {
+                    filter,
+                    ..SearchQuery::everything(SearchDirection::Forward, None)
+                })?
+                .into_iter()
+                .map(|h| h.command_line)
+                .collect())
+        };
+
+        assert_eq!(search_score(JsonFilterValue::Real(1.5))?, vec!["cmd_a"]);
+        assert_eq!(search_score(JsonFilterValue::Real(1.0))?, vec!["cmd_b"]);
+        // Integer(1) must not match JSON real numbers (different json_type)
+        assert_eq!(
+            search_score(JsonFilterValue::Integer(1))?,
+            Vec::<String>::new(),
+            "Integer(1) must not match JSON real numbers"
+        );
+
+        Ok(())
+    }
+
+    /// Verify that Null matches JSON null at a path but not SQL-NULL more_info
+    /// or a path that is simply absent from the JSON object.
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[test]
+    fn json_filter_value_null_vs_missing_path() -> crate::Result<()> {
+        #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+        struct WithOptVal {
+            val: Option<i64>,
+        }
+        impl HistoryItemExtraInfo for WithOptVal {}
+
+        let mut db = SqliteBackedHistory::in_memory()?;
+        let make_opt = |cmd: &str, val: Option<i64>| HistoryItem {
+            id: None,
+            start_timestamp: None,
+            command_line: cmd.to_string(),
+            session_id: None,
+            hostname: None,
+            cwd: None,
+            duration: None,
+            exit_status: None,
+            more_info: Some(WithOptVal { val }),
+        };
+        // Row A: val=null in JSON  (serde serializes None as JSON null)
+        db.save_with_extra(make_opt("null_row", None))?;
+        // Row B: val=42 in JSON
+        db.save_with_extra(make_opt("int_row", Some(42)))?;
+        // Row C: SQL NULL more_info — $.val path is therefore absent
+        db.save_with_extra::<WithOptVal>(HistoryItem {
+            id: None,
+            start_timestamp: None,
+            command_line: "no_extra".to_string(),
+            session_id: None,
+            hostname: None,
+            cwd: None,
+            duration: None,
+            exit_status: None,
+            more_info: None,
+        })?;
+
+        let search_val = |val: JsonFilterValue| -> crate::Result<Vec<String>> {
+            let filter = SearchFilter {
+                more_info_json: Some(vec![("$.val".to_string(), val)]),
+                ..SearchFilter::anything(None)
+            };
+            Ok(db
+                .search_with_extra::<WithOptVal>(SearchQuery {
+                    filter,
+                    ..SearchQuery::everything(SearchDirection::Forward, None)
+                })?
+                .into_iter()
+                .map(|h| h.command_line)
+                .collect())
+        };
+
+        // Null matches row A (json_type = 'null') only; row B and C are excluded
+        assert_eq!(search_val(JsonFilterValue::Null)?, vec!["null_row"]);
+        // Integer(42) matches row B only
+        assert_eq!(search_val(JsonFilterValue::Integer(42))?, vec!["int_row"]);
+
+        Ok(())
+    }
+
     #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
     #[test]
     fn typed_and_untyped_interop() -> crate::Result<()> {

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -1,6 +1,7 @@
 use super::{
     base::{CommandLineSearch, SearchDirection, SearchQuery},
-    History, HistoryItem, HistoryItemId, HistorySessionId,
+    History, HistoryItem, HistoryItemExtraInfo, HistoryItemId, HistorySessionId,
+    IgnoreAllExtraInfo,
 };
 use crate::{
     result::{ReedlineError, ReedlineErrorVariants},
@@ -8,7 +9,7 @@ use crate::{
 };
 use chrono::{TimeZone, Utc};
 use rusqlite::{named_params, params, Connection, ToSql};
-use std::{path::PathBuf, time::Duration};
+use std::{fmt::Write, path::PathBuf, time::Duration};
 const SQLITE_APPLICATION_ID: i32 = 1151497937;
 
 /// A history that stores the values to an SQLite database.
@@ -23,7 +24,9 @@ pub struct SqliteBackedHistory {
     session_timestamp: Option<chrono::DateTime<Utc>>,
 }
 
-fn deserialize_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem> {
+fn deserialize_history_item<E: HistoryItemExtraInfo>(
+    row: &rusqlite::Row,
+) -> rusqlite::Result<HistoryItem<E>> {
     let x: Option<String> = row.get("more_info")?;
     Ok(HistoryItem {
         id: Some(HistoryItemId::new(row.get("id")?)),
@@ -45,7 +48,7 @@ fn deserialize_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem
         exit_status: row.get("exit_status")?,
         more_info: x
             .map(|x| {
-                serde_json::from_str(&x).map_err(|e| {
+                serde_json::from_str::<E>(&x).map_err(|e| {
                     // hack
                     rusqlite::Error::InvalidColumnType(
                         0,
@@ -59,42 +62,8 @@ fn deserialize_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem
 }
 
 impl History for SqliteBackedHistory {
-    fn save(&mut self, mut entry: HistoryItem) -> Result<HistoryItem> {
-        let ret: i64 = self
-            .db
-            .prepare(
-                "insert into history
-                               (id,  start_timestamp,  command_line,  session_id,  hostname,  cwd,  duration_ms,  exit_status,  more_info)
-                        values (:id, :start_timestamp, :command_line, :session_id, :hostname, :cwd, :duration_ms, :exit_status, :more_info)
-                    on conflict (history.id) do update set
-                        start_timestamp = excluded.start_timestamp,
-                        command_line = excluded.command_line,
-                        session_id = excluded.session_id,
-                        hostname = excluded.hostname,
-                        cwd = excluded.cwd,
-                        duration_ms = excluded.duration_ms,
-                        exit_status = excluded.exit_status,
-                        more_info = excluded.more_info
-                    returning id",
-            )
-            .map_err(map_sqlite_err)?
-            .query_row(
-                named_params! {
-                    ":id": entry.id.map(|id| id.0),
-                    ":start_timestamp": entry.start_timestamp.map(|e| e.timestamp_millis()),
-                    ":command_line": entry.command_line,
-                    ":session_id": entry.session_id.map(|e| e.0),
-                    ":hostname": entry.hostname,
-                    ":cwd": entry.cwd,
-                    ":duration_ms": entry.duration.map(|e| e.as_millis() as i64),
-                    ":exit_status": entry.exit_status,
-                    ":more_info": entry.more_info.as_ref().map(|e| serde_json::to_string(e).unwrap())
-                },
-                |row| row.get(0),
-            )
-            .map_err(map_sqlite_err)?;
-        entry.id = Some(HistoryItemId::new(ret));
-        Ok(entry)
+    fn save(&mut self, entry: HistoryItem) -> Result<HistoryItem> {
+        self.save_impl(entry)
     }
 
     fn load(&self, id: HistoryItemId) -> Result<HistoryItem> {
@@ -102,14 +71,18 @@ impl History for SqliteBackedHistory {
             .db
             .prepare("select * from history where id = :id")
             .map_err(map_sqlite_err)?
-            .query_row(named_params! { ":id": id.0 }, deserialize_history_item)
+            .query_row(
+                named_params! { ":id": id.0 },
+                deserialize_history_item::<IgnoreAllExtraInfo>,
+            )
             .map_err(map_sqlite_err)?;
         Ok(entry)
     }
 
     fn count(&self, query: SearchQuery) -> Result<i64> {
         let (query, params) = self.construct_query(&query, "coalesce(count(*), 0)");
-        let params_borrow: Vec<(&str, &dyn ToSql)> = params.iter().map(|e| (e.0, &*e.1)).collect();
+        let params_borrow: Vec<(&str, &dyn ToSql)> =
+            params.iter().map(|e| (e.0.as_str(), &*e.1)).collect();
         let result: i64 = self
             .db
             .prepare(&query)
@@ -121,12 +94,16 @@ impl History for SqliteBackedHistory {
 
     fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>> {
         let (query, params) = self.construct_query(&query, "*");
-        let params_borrow: Vec<(&str, &dyn ToSql)> = params.iter().map(|e| (e.0, &*e.1)).collect();
+        let params_borrow: Vec<(&str, &dyn ToSql)> =
+            params.iter().map(|e| (e.0.as_str(), &*e.1)).collect();
         let results: Vec<HistoryItem> = self
             .db
             .prepare(&query)
             .unwrap()
-            .query_map(&params_borrow[..], deserialize_history_item)
+            .query_map(
+                &params_borrow[..],
+                deserialize_history_item::<IgnoreAllExtraInfo>,
+            )
             .map_err(map_sqlite_err)?
             .collect::<rusqlite::Result<Vec<HistoryItem>>>()
             .map_err(map_sqlite_err)?;
@@ -187,7 +164,13 @@ fn map_sqlite_err(err: rusqlite::Error) -> ReedlineError {
     )))
 }
 
-type BoxedNamedParams<'a> = Vec<(&'static str, Box<dyn ToSql + 'a>)>;
+fn map_json_err(err: serde_json::Error) -> ReedlineError {
+    ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(format!(
+        "could not serialize more_info: {err}"
+    )))
+}
+
+type BoxedNamedParams<'a> = Vec<(String, Box<dyn ToSql + 'a>)>;
 
 impl SqliteBackedHistory {
     /// Creates a new history with an associated history file.
@@ -284,7 +267,7 @@ impl SqliteBackedHistory {
             SearchDirection::Forward => (true, "asc"),
             SearchDirection::Backward => (false, "desc"),
         };
-        let mut wheres = Vec::new();
+        let mut wheres: Vec<&str> = Vec::new();
         let mut params: BoxedNamedParams = Vec::new();
         if let Some(start) = query.start_time {
             wheres.push(if is_asc {
@@ -292,7 +275,10 @@ impl SqliteBackedHistory {
             } else {
                 "timestamp_start < :start_time"
             });
-            params.push((":start_time", Box::new(start.timestamp_millis())));
+            params.push((
+                ":start_time".to_string(),
+                Box::new(start.timestamp_millis()),
+            ));
         }
         if let Some(end) = query.end_time {
             wheres.push(if is_asc {
@@ -300,7 +286,7 @@ impl SqliteBackedHistory {
             } else {
                 ":end_time <= timestamp_start"
             });
-            params.push((":end_time", Box::new(end.timestamp_millis())));
+            params.push((":end_time".to_string(), Box::new(end.timestamp_millis())));
         }
         if let Some(start) = query.start_id {
             wheres.push(if is_asc {
@@ -308,7 +294,7 @@ impl SqliteBackedHistory {
             } else {
                 "id < :start_id"
             });
-            params.push((":start_id", Box::new(start.0)));
+            params.push((":start_id".to_string(), Box::new(start.0)));
         }
         if let Some(end) = query.end_id {
             wheres.push(if is_asc {
@@ -316,11 +302,11 @@ impl SqliteBackedHistory {
             } else {
                 ":end_id <= id"
             });
-            params.push((":end_id", Box::new(end.0)));
+            params.push((":end_id".to_string(), Box::new(end.0)));
         }
         let limit = match query.limit {
             Some(l) => {
-                params.push((":limit", Box::new(l)));
+                params.push((":limit".to_string(), Box::new(l)));
                 "limit :limit"
             }
             None => "",
@@ -329,35 +315,35 @@ impl SqliteBackedHistory {
             match command_line {
                 CommandLineSearch::Exact(e) => {
                     wheres.push("command_line == :command_line");
-                    params.push((":command_line", Box::new(e)));
+                    params.push((":command_line".to_string(), Box::new(e)));
                 }
                 CommandLineSearch::Prefix(prefix) => {
                     wheres.push("instr(command_line, :command_line) == 1");
-                    params.push((":command_line", Box::new(prefix)));
+                    params.push((":command_line".to_string(), Box::new(prefix)));
                 }
                 CommandLineSearch::Substring(cont) => {
                     wheres.push("instr(command_line, :command_line) >= 1");
-                    params.push((":command_line", Box::new(cont)));
+                    params.push((":command_line".to_string(), Box::new(cont)));
                 }
             };
         }
 
         if let Some(str) = &query.filter.not_command_line {
             wheres.push("command_line != :not_cmd");
-            params.push((":not_cmd", Box::new(str)));
+            params.push((":not_cmd".to_string(), Box::new(str)));
         }
         if let Some(hostname) = &query.filter.hostname {
             wheres.push("hostname = :hostname");
-            params.push((":hostname", Box::new(hostname)));
+            params.push((":hostname".to_string(), Box::new(hostname)));
         }
         if let Some(cwd_exact) = &query.filter.cwd_exact {
             wheres.push("cwd = :cwd");
-            params.push((":cwd", Box::new(cwd_exact)));
+            params.push((":cwd".to_string(), Box::new(cwd_exact)));
         }
         if let Some(cwd_prefix) = &query.filter.cwd_prefix {
             wheres.push("cwd like :cwd_like");
             let cwd_like = format!("{cwd_prefix}%");
-            params.push((":cwd_like", Box::new(cwd_like)));
+            params.push((":cwd_like".to_string(), Box::new(cwd_like)));
         }
         if let Some(exit_successful) = query.filter.exit_successful {
             if exit_successful {
@@ -373,23 +359,311 @@ impl SqliteBackedHistory {
             // - that have the same session_id, or
             // - were executed before our session started
             wheres.push("(session_id = :session_id OR start_timestamp < :session_timestamp)");
-            params.push((":session_id", Box::new(session_id)));
+            params.push((":session_id".to_string(), Box::new(session_id)));
             params.push((
-                ":session_timestamp",
+                ":session_timestamp".to_string(),
                 Box::new(session_timestamp.timestamp_millis()),
             ));
         }
-        let mut wheres = wheres.join(" and ");
-        if wheres.is_empty() {
-            wheres = "true".to_string();
+
+        // Build WHERE string, appending dynamic json_extract conditions last
+        let mut where_string = wheres.join(" and ");
+        if let Some(filters) = &query.filter.more_info_json {
+            for (i, (path, value)) in filters.iter().enumerate() {
+                if !where_string.is_empty() {
+                    where_string.push_str(" and ");
+                }
+                // CAST to TEXT so that json_extract's type-dependent output (e.g. integer 1 for
+                // JSON `true`) is consistently comparable to the string expected value.
+                write!(
+                    where_string,
+                    "CAST(json_extract(more_info, :json_path_{i}) AS TEXT) = :json_val_{i}"
+                )
+                .unwrap();
+                params.push((format!(":json_path_{i}"), Box::new(path.clone())));
+                params.push((format!(":json_val_{i}"), Box::new(value.clone())));
+            }
+        }
+        if where_string.is_empty() {
+            where_string = "true".to_string();
         }
         let query = format!(
             "SELECT {select_expression} \
              FROM history \
-             WHERE ({wheres}) \
+             WHERE ({where_string}) \
              ORDER BY id {asc} \
              {limit}"
         );
         (query, params)
+    }
+
+    fn save_impl<E: HistoryItemExtraInfo>(
+        &mut self,
+        mut entry: HistoryItem<E>,
+    ) -> Result<HistoryItem<E>> {
+        let more_info_serialized = entry
+            .more_info
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(map_json_err)?;
+        let ret: i64 = self
+            .db
+            .prepare(
+                "insert into history
+                               (id,  start_timestamp,  command_line,  session_id,  hostname,  cwd,  duration_ms,  exit_status,  more_info)
+                        values (:id, :start_timestamp, :command_line, :session_id, :hostname, :cwd, :duration_ms, :exit_status, :more_info)
+                    on conflict (history.id) do update set
+                        start_timestamp = excluded.start_timestamp,
+                        command_line = excluded.command_line,
+                        session_id = excluded.session_id,
+                        hostname = excluded.hostname,
+                        cwd = excluded.cwd,
+                        duration_ms = excluded.duration_ms,
+                        exit_status = excluded.exit_status,
+                        more_info = excluded.more_info
+                    returning id",
+            )
+            .map_err(map_sqlite_err)?
+            .query_row(
+                named_params! {
+                    ":id": entry.id.map(|id| id.0),
+                    ":start_timestamp": entry.start_timestamp.map(|e| e.timestamp_millis()),
+                    ":command_line": entry.command_line,
+                    ":session_id": entry.session_id.map(|e| e.0),
+                    ":hostname": entry.hostname,
+                    ":cwd": entry.cwd,
+                    ":duration_ms": entry.duration.map(|e| e.as_millis() as i64),
+                    ":exit_status": entry.exit_status,
+                    ":more_info": more_info_serialized,
+                },
+                |row| row.get(0),
+            )
+            .map_err(map_sqlite_err)?;
+        entry.id = Some(HistoryItemId::new(ret));
+        Ok(entry)
+    }
+
+    /// Save a history item with typed `more_info`.
+    ///
+    /// Unlike [`History::save`], this method preserves the full `more_info` type `E`
+    /// by serializing it to JSON and storing it in the `more_info` column.
+    ///
+    /// Note: this method is specific to [`SqliteBackedHistory`]. The [`History`] trait
+    /// methods use [`IgnoreAllExtraInfo`] and do not roundtrip custom `more_info`.
+    pub fn save_with_extra<E: HistoryItemExtraInfo>(
+        &mut self,
+        entry: HistoryItem<E>,
+    ) -> Result<HistoryItem<E>> {
+        self.save_impl(entry)
+    }
+
+    /// Load a history item by ID with typed `more_info`.
+    ///
+    /// Unlike [`History::load`], this method deserializes `more_info` into the concrete
+    /// type `E` instead of discarding it.
+    ///
+    /// Note: this method is specific to [`SqliteBackedHistory`]. The [`History`] trait
+    /// methods use [`IgnoreAllExtraInfo`] and do not roundtrip custom `more_info`.
+    pub fn load_with_extra<E: HistoryItemExtraInfo>(
+        &self,
+        id: HistoryItemId,
+    ) -> Result<HistoryItem<E>> {
+        self.db
+            .prepare("select * from history where id = :id")
+            .map_err(map_sqlite_err)?
+            .query_row(named_params! { ":id": id.0 }, deserialize_history_item::<E>)
+            .map_err(map_sqlite_err)
+    }
+
+    /// Search history items with typed `more_info`.
+    ///
+    /// Unlike [`History::search`], this method deserializes `more_info` into the concrete
+    /// type `E`. It also evaluates [`SearchFilter::more_info_json`] conditions using
+    /// SQLite's `json_extract()`.
+    ///
+    /// Note: this method is specific to [`SqliteBackedHistory`]. The [`History`] trait
+    /// methods use [`IgnoreAllExtraInfo`] and ignore [`SearchFilter::more_info_json`].
+    pub fn search_with_extra<E: HistoryItemExtraInfo>(
+        &self,
+        query: SearchQuery,
+    ) -> Result<Vec<HistoryItem<E>>> {
+        let (sql, params) = self.construct_query(&query, "*");
+        let params_borrow: Vec<(&str, &dyn ToSql)> =
+            params.iter().map(|e| (e.0.as_str(), &*e.1)).collect();
+        self.db
+            .prepare(&sql)
+            .map_err(map_sqlite_err)?
+            .query_map(&params_borrow[..], deserialize_history_item::<E>)
+            .map_err(map_sqlite_err)?
+            .collect::<rusqlite::Result<Vec<HistoryItem<E>>>>()
+            .map_err(map_sqlite_err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::base::{SearchDirection, SearchFilter};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestExtra {
+        meta_command: bool,
+        tag: String,
+    }
+    impl HistoryItemExtraInfo for TestExtra {}
+
+    fn item_with_extra(cmd: &str, extra: TestExtra) -> HistoryItem<TestExtra> {
+        HistoryItem {
+            id: None,
+            start_timestamp: None,
+            command_line: cmd.to_string(),
+            session_id: None,
+            hostname: None,
+            cwd: None,
+            duration: None,
+            exit_status: None,
+            more_info: Some(extra),
+        }
+    }
+
+    fn item_no_extra(cmd: &str) -> HistoryItem<TestExtra> {
+        HistoryItem {
+            id: None,
+            start_timestamp: None,
+            command_line: cmd.to_string(),
+            session_id: None,
+            hostname: None,
+            cwd: None,
+            duration: None,
+            exit_status: None,
+            more_info: None,
+        }
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[test]
+    fn save_and_load_with_extra() -> crate::Result<()> {
+        let mut db = SqliteBackedHistory::in_memory()?;
+        let item = item_with_extra(
+            "ls -la",
+            TestExtra {
+                meta_command: false,
+                tag: "test".into(),
+            },
+        );
+        let saved = db.save_with_extra(item.clone())?;
+        assert!(saved.id.is_some());
+        assert_eq!(saved.more_info, item.more_info);
+
+        let loaded = db.load_with_extra::<TestExtra>(saved.id.unwrap())?;
+        assert_eq!(loaded, saved);
+        Ok(())
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[test]
+    fn save_with_extra_null_more_info_roundtrips() -> crate::Result<()> {
+        let mut db = SqliteBackedHistory::in_memory()?;
+        let item = item_no_extra("pwd");
+        let saved = db.save_with_extra(item)?;
+        assert!(saved.id.is_some());
+
+        let loaded = db.load_with_extra::<TestExtra>(saved.id.unwrap())?;
+        assert_eq!(loaded.more_info, None);
+        Ok(())
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[test]
+    fn search_with_extra_more_info_json_matches() -> crate::Result<()> {
+        let mut db = SqliteBackedHistory::in_memory()?;
+
+        // SQLite's json_extract() returns booleans as integers (1/0), not strings ("true"/"false").
+        // Use "1" to match JSON `true` and "0" to match JSON `false`.
+        let saved_meta = db.save_with_extra(item_with_extra(
+            ":help",
+            TestExtra {
+                meta_command: true,
+                tag: "meta".into(),
+            },
+        ))?;
+        let saved_normal = db.save_with_extra(item_with_extra(
+            "ls",
+            TestExtra {
+                meta_command: false,
+                tag: "normal".into(),
+            },
+        ))?;
+        db.save_with_extra(item_no_extra("pwd"))?;
+
+        // Filter for meta commands (meta_command = true → SQLite integer 1)
+        let filter = SearchFilter {
+            more_info_json: Some(vec![("$.meta_command".to_string(), "1".to_string())]),
+            ..SearchFilter::anything(None)
+        };
+        let results = db.search_with_extra::<TestExtra>(SearchQuery {
+            filter,
+            ..SearchQuery::everything(SearchDirection::Forward, None)
+        })?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, saved_meta.id);
+
+        // Filter for non-meta commands (meta_command = false → SQLite integer 0)
+        let filter2 = SearchFilter {
+            more_info_json: Some(vec![("$.meta_command".to_string(), "0".to_string())]),
+            ..SearchFilter::anything(None)
+        };
+        let results2 = db.search_with_extra::<TestExtra>(SearchQuery {
+            filter: filter2,
+            ..SearchQuery::everything(SearchDirection::Forward, None)
+        })?;
+
+        // Only "ls" matches (meta_command: false = integer 0); "pwd" with NULL more_info does not match
+        assert_eq!(results2.len(), 1);
+        assert_eq!(results2[0].id, saved_normal.id);
+        Ok(())
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[test]
+    fn search_with_extra_null_more_info_not_matched() -> crate::Result<()> {
+        let mut db = SqliteBackedHistory::in_memory()?;
+        db.save_with_extra(item_no_extra("pwd"))?;
+
+        let filter = SearchFilter {
+            more_info_json: Some(vec![("$.meta_command".to_string(), "1".to_string())]),
+            ..SearchFilter::anything(None)
+        };
+        let results = db.search_with_extra::<TestExtra>(SearchQuery {
+            filter,
+            ..SearchQuery::everything(SearchDirection::Forward, None)
+        })?;
+
+        assert_eq!(results, vec![]);
+        Ok(())
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[test]
+    fn typed_and_untyped_interop() -> crate::Result<()> {
+        let mut db = SqliteBackedHistory::in_memory()?;
+        let item = item_with_extra(
+            ":cd /tmp",
+            TestExtra {
+                meta_command: true,
+                tag: String::new(),
+            },
+        );
+        let saved = db.save_with_extra(item)?;
+
+        // Load as untyped (IgnoreAllExtraInfo): more_info column is non-NULL but deserialized
+        // as Some(IgnoreAllExtraInfo) since IgnoreAllExtraInfo accepts any JSON value
+        let untyped = db.load(saved.id.unwrap())?;
+        assert_eq!(untyped.command_line, ":cd /tmp");
+        assert_eq!(untyped.more_info, Some(IgnoreAllExtraInfo));
+        Ok(())
     }
 }

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -79,7 +79,9 @@ impl History for SqliteBackedHistory {
         Ok(entry)
     }
 
-    fn count(&self, query: SearchQuery) -> Result<i64> {
+    fn count(&self, mut query: SearchQuery) -> Result<i64> {
+        // more_info_json is only evaluated by search_with_extra; ignore it here
+        query.filter.more_info_json = None;
         let (query, params) = self.construct_query(&query, "coalesce(count(*), 0)");
         let params_borrow: Vec<(&str, &dyn ToSql)> =
             params.iter().map(|e| (e.0.as_str(), &*e.1)).collect();
@@ -92,7 +94,9 @@ impl History for SqliteBackedHistory {
         Ok(result)
     }
 
-    fn search(&self, query: SearchQuery) -> Result<Vec<HistoryItem>> {
+    fn search(&self, mut query: SearchQuery) -> Result<Vec<HistoryItem>> {
+        // more_info_json is only evaluated by search_with_extra; ignore it here
+        query.filter.more_info_json = None;
         let (query, params) = self.construct_query(&query, "*");
         let params_borrow: Vec<(&str, &dyn ToSql)> =
             params.iter().map(|e| (e.0.as_str(), &*e.1)).collect();
@@ -373,13 +377,23 @@ impl SqliteBackedHistory {
                 if !where_string.is_empty() {
                     where_string.push_str(" and ");
                 }
-                // CAST to TEXT so that json_extract's type-dependent output (e.g. integer 1 for
-                // JSON `true`) is consistently comparable to the string expected value.
-                write!(
-                    where_string,
-                    "CAST(json_extract(more_info, :json_path_{i}) AS TEXT) = :json_val_{i}"
-                )
-                .unwrap();
+                if value == "true" || value == "false" {
+                    // Use json_type() to match JSON booleans exactly.
+                    // CAST-based comparison would collide with integer 1/0 and strings "true"/"false".
+                    // json_type() returns 'true' or 'false' only for JSON boolean values.
+                    write!(
+                        where_string,
+                        "json_type(more_info, :json_path_{i}) = :json_val_{i}"
+                    )
+                    .unwrap();
+                } else {
+                    // For non-boolean values, CAST to TEXT for consistent string comparison.
+                    write!(
+                        where_string,
+                        "CAST(json_extract(more_info, :json_path_{i}) AS TEXT) = :json_val_{i}"
+                    )
+                    .unwrap();
+                }
                 params.push((format!(":json_path_{i}"), Box::new(path.clone())));
                 params.push((format!(":json_val_{i}"), Box::new(value.clone())));
             }
@@ -580,8 +594,6 @@ mod tests {
     fn search_with_extra_more_info_json_matches() -> crate::Result<()> {
         let mut db = SqliteBackedHistory::in_memory()?;
 
-        // SQLite's json_extract() returns booleans as integers (1/0), not strings ("true"/"false").
-        // Use "1" to match JSON `true` and "0" to match JSON `false`.
         let saved_meta = db.save_with_extra(item_with_extra(
             ":help",
             TestExtra {
@@ -598,9 +610,9 @@ mod tests {
         ))?;
         db.save_with_extra(item_no_extra("pwd"))?;
 
-        // Filter for meta commands (meta_command = true → SQLite integer 1)
+        // "true"/"false" use json_type() so they match JSON booleans only, not integer 1/0
         let filter = SearchFilter {
-            more_info_json: Some(vec![("$.meta_command".to_string(), "1".to_string())]),
+            more_info_json: Some(vec![("$.meta_command".to_string(), "true".to_string())]),
             ..SearchFilter::anything(None)
         };
         let results = db.search_with_extra::<TestExtra>(SearchQuery {
@@ -611,9 +623,8 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, saved_meta.id);
 
-        // Filter for non-meta commands (meta_command = false → SQLite integer 0)
         let filter2 = SearchFilter {
-            more_info_json: Some(vec![("$.meta_command".to_string(), "0".to_string())]),
+            more_info_json: Some(vec![("$.meta_command".to_string(), "false".to_string())]),
             ..SearchFilter::anything(None)
         };
         let results2 = db.search_with_extra::<TestExtra>(SearchQuery {
@@ -621,7 +632,7 @@ mod tests {
             ..SearchQuery::everything(SearchDirection::Forward, None)
         })?;
 
-        // Only "ls" matches (meta_command: false = integer 0); "pwd" with NULL more_info does not match
+        // Only "ls" matches (meta_command: false); "pwd" with NULL more_info does not match
         assert_eq!(results2.len(), 1);
         assert_eq!(results2[0].id, saved_normal.id);
         Ok(())
@@ -634,7 +645,7 @@ mod tests {
         db.save_with_extra(item_no_extra("pwd"))?;
 
         let filter = SearchFilter {
-            more_info_json: Some(vec![("$.meta_command".to_string(), "1".to_string())]),
+            more_info_json: Some(vec![("$.meta_command".to_string(), "true".to_string())]),
             ..SearchFilter::anything(None)
         };
         let results = db.search_with_extra::<TestExtra>(SearchQuery {

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -1,5 +1,5 @@
 use super::{
-    base::{CommandLineSearch, SearchDirection, SearchQuery},
+    base::{CommandLineSearch, JsonFilterValue, SearchDirection, SearchQuery},
     History, HistoryItem, HistoryItemExtraInfo, HistoryItemId, HistorySessionId,
     IgnoreAllExtraInfo,
 };
@@ -370,32 +370,60 @@ impl SqliteBackedHistory {
             ));
         }
 
-        // Build WHERE string, appending dynamic json_extract conditions last
+        // Build WHERE string, appending dynamic json_type/json_extract conditions last.
+        // Each JsonFilterValue variant generates type-precise SQL so that JSON booleans,
+        // integers, and strings cannot collide with each other.
         let mut where_string = wheres.join(" and ");
         if let Some(filters) = &query.filter.more_info_json {
             for (i, (path, value)) in filters.iter().enumerate() {
                 if !where_string.is_empty() {
                     where_string.push_str(" and ");
                 }
-                if value == "true" || value == "false" {
-                    // Use json_type() to match JSON booleans exactly.
-                    // CAST-based comparison would collide with integer 1/0 and strings "true"/"false".
-                    // json_type() returns 'true' or 'false' only for JSON boolean values.
-                    write!(
-                        where_string,
-                        "json_type(more_info, :json_path_{i}) = :json_val_{i}"
-                    )
-                    .unwrap();
-                } else {
-                    // For non-boolean values, CAST to TEXT for consistent string comparison.
-                    write!(
-                        where_string,
-                        "CAST(json_extract(more_info, :json_path_{i}) AS TEXT) = :json_val_{i}"
-                    )
-                    .unwrap();
+                match value {
+                    JsonFilterValue::Null => {
+                        write!(
+                            where_string,
+                            "json_type(more_info, :json_path_{i}) = 'null'"
+                        )
+                        .unwrap();
+                    }
+                    JsonFilterValue::Bool(b) => {
+                        let type_str = if *b { "true" } else { "false" };
+                        write!(
+                            where_string,
+                            "json_type(more_info, :json_path_{i}) = '{type_str}'"
+                        )
+                        .unwrap();
+                    }
+                    JsonFilterValue::Integer(n) => {
+                        write!(
+                            where_string,
+                            "json_type(more_info, :json_path_{i}) = 'integer' \
+                             AND json_extract(more_info, :json_path_{i}) = :json_val_{i}"
+                        )
+                        .unwrap();
+                        params.push((format!(":json_val_{i}"), Box::new(*n)));
+                    }
+                    JsonFilterValue::Real(f) => {
+                        write!(
+                            where_string,
+                            "json_type(more_info, :json_path_{i}) = 'real' \
+                             AND json_extract(more_info, :json_path_{i}) = :json_val_{i}"
+                        )
+                        .unwrap();
+                        params.push((format!(":json_val_{i}"), Box::new(*f)));
+                    }
+                    JsonFilterValue::Text(s) => {
+                        write!(
+                            where_string,
+                            "json_type(more_info, :json_path_{i}) = 'text' \
+                             AND json_extract(more_info, :json_path_{i}) = :json_val_{i}"
+                        )
+                        .unwrap();
+                        params.push((format!(":json_val_{i}"), Box::new(s.clone())));
+                    }
                 }
                 params.push((format!(":json_path_{i}"), Box::new(path.clone())));
-                params.push((format!(":json_val_{i}"), Box::new(value.clone())));
             }
         }
         if where_string.is_empty() {
@@ -518,13 +546,14 @@ impl SqliteBackedHistory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::history::base::{SearchDirection, SearchFilter};
+    use crate::history::base::{JsonFilterValue, SearchDirection, SearchFilter};
     use serde::{Deserialize, Serialize};
 
     #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
     struct TestExtra {
         meta_command: bool,
         tag: String,
+        count: i64,
     }
     impl HistoryItemExtraInfo for TestExtra {}
 
@@ -565,6 +594,7 @@ mod tests {
             TestExtra {
                 meta_command: false,
                 tag: "test".into(),
+                ..Default::default()
             },
         );
         let saved = db.save_with_extra(item.clone())?;
@@ -599,6 +629,7 @@ mod tests {
             TestExtra {
                 meta_command: true,
                 tag: "meta".into(),
+                ..Default::default()
             },
         ))?;
         let saved_normal = db.save_with_extra(item_with_extra(
@@ -606,13 +637,16 @@ mod tests {
             TestExtra {
                 meta_command: false,
                 tag: "normal".into(),
+                ..Default::default()
             },
         ))?;
         db.save_with_extra(item_no_extra("pwd"))?;
 
-        // "true"/"false" use json_type() so they match JSON booleans only, not integer 1/0
         let filter = SearchFilter {
-            more_info_json: Some(vec![("$.meta_command".to_string(), "true".to_string())]),
+            more_info_json: Some(vec![(
+                "$.meta_command".to_string(),
+                JsonFilterValue::Bool(true),
+            )]),
             ..SearchFilter::anything(None)
         };
         let results = db.search_with_extra::<TestExtra>(SearchQuery {
@@ -624,7 +658,10 @@ mod tests {
         assert_eq!(results[0].id, saved_meta.id);
 
         let filter2 = SearchFilter {
-            more_info_json: Some(vec![("$.meta_command".to_string(), "false".to_string())]),
+            more_info_json: Some(vec![(
+                "$.meta_command".to_string(),
+                JsonFilterValue::Bool(false),
+            )]),
             ..SearchFilter::anything(None)
         };
         let results2 = db.search_with_extra::<TestExtra>(SearchQuery {
@@ -645,7 +682,10 @@ mod tests {
         db.save_with_extra(item_no_extra("pwd"))?;
 
         let filter = SearchFilter {
-            more_info_json: Some(vec![("$.meta_command".to_string(), "true".to_string())]),
+            more_info_json: Some(vec![(
+                "$.meta_command".to_string(),
+                JsonFilterValue::Bool(true),
+            )]),
             ..SearchFilter::anything(None)
         };
         let results = db.search_with_extra::<TestExtra>(SearchQuery {
@@ -657,6 +697,123 @@ mod tests {
         Ok(())
     }
 
+    /// Verify that Bool, Integer, and Text filters do not collide with each other
+    /// even when the raw JSON bytes look similar (e.g. `true` vs `1` vs `"1"`).
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[test]
+    fn json_filter_value_no_type_collisions() -> crate::Result<()> {
+        let mut db = SqliteBackedHistory::in_memory()?;
+
+        // Row A: meta_command=true (JSON boolean), count=1 (JSON integer), tag="1" (JSON string)
+        db.save_with_extra(item_with_extra(
+            "cmd_a",
+            TestExtra {
+                meta_command: true,
+                tag: "1".into(),
+                count: 1,
+            },
+        ))?;
+        // Row B: meta_command=false, count=0, tag="true"
+        db.save_with_extra(item_with_extra(
+            "cmd_b",
+            TestExtra {
+                meta_command: false,
+                tag: "true".into(),
+                count: 0,
+            },
+        ))?;
+
+        let search = |val: JsonFilterValue| -> crate::Result<usize> {
+            let filter = SearchFilter {
+                more_info_json: Some(vec![("$.meta_command".to_string(), val)]),
+                ..SearchFilter::anything(None)
+            };
+            Ok(db
+                .search_with_extra::<TestExtra>(SearchQuery {
+                    filter,
+                    ..SearchQuery::everything(SearchDirection::Forward, None)
+                })?
+                .len())
+        };
+
+        // Bool(true) must match only row A (meta_command: true), not integer 1 or string "1"
+        assert_eq!(search(JsonFilterValue::Bool(true))?, 1);
+        // Bool(false) must match only row B (meta_command: false)
+        assert_eq!(search(JsonFilterValue::Bool(false))?, 1);
+        // Integer(1) must not match the boolean true in meta_command
+        assert_eq!(
+            search(JsonFilterValue::Integer(1))?,
+            0,
+            "Integer(1) must not match JSON boolean true"
+        );
+        // Text("true") must not match the boolean true in meta_command
+        assert_eq!(
+            search(JsonFilterValue::Text("true".into()))?,
+            0,
+            r#"Text("true") must not match JSON boolean true"#
+        );
+
+        let search_count = |val: JsonFilterValue| -> crate::Result<usize> {
+            let filter = SearchFilter {
+                more_info_json: Some(vec![("$.count".to_string(), val)]),
+                ..SearchFilter::anything(None)
+            };
+            Ok(db
+                .search_with_extra::<TestExtra>(SearchQuery {
+                    filter,
+                    ..SearchQuery::everything(SearchDirection::Forward, None)
+                })?
+                .len())
+        };
+
+        // Integer(1) must match row A (count: 1) but not row B (count: 0)
+        assert_eq!(search_count(JsonFilterValue::Integer(1))?, 1);
+        // Bool(true) must not match integer 1 in count
+        assert_eq!(
+            search_count(JsonFilterValue::Bool(true))?,
+            0,
+            "Bool(true) must not match JSON integer 1"
+        );
+        // Text("1") must not match JSON integer 1
+        assert_eq!(
+            search_count(JsonFilterValue::Text("1".into()))?,
+            0,
+            r#"Text("1") must not match JSON integer 1"#
+        );
+
+        let search_tag = |val: JsonFilterValue| -> crate::Result<usize> {
+            let filter = SearchFilter {
+                more_info_json: Some(vec![("$.tag".to_string(), val)]),
+                ..SearchFilter::anything(None)
+            };
+            Ok(db
+                .search_with_extra::<TestExtra>(SearchQuery {
+                    filter,
+                    ..SearchQuery::everything(SearchDirection::Forward, None)
+                })?
+                .len())
+        };
+
+        // Text("1") must match row A (tag: "1") but not row B (tag: "true")
+        assert_eq!(search_tag(JsonFilterValue::Text("1".into()))?, 1);
+        // Text("true") must match row B (tag: "true") but not row A
+        assert_eq!(search_tag(JsonFilterValue::Text("true".into()))?, 1);
+        // Bool(true) must not match the string "true" in tag
+        assert_eq!(
+            search_tag(JsonFilterValue::Bool(true))?,
+            0,
+            r#"Bool(true) must not match JSON string "true""#
+        );
+        // Integer(1) must not match the string "1" in tag
+        assert_eq!(
+            search_tag(JsonFilterValue::Integer(1))?,
+            0,
+            r#"Integer(1) must not match JSON string "1""#
+        );
+
+        Ok(())
+    }
+
     #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
     #[test]
     fn typed_and_untyped_interop() -> crate::Result<()> {
@@ -665,7 +822,7 @@ mod tests {
             ":cd /tmp",
             TestExtra {
                 meta_command: true,
-                tag: String::new(),
+                ..Default::default()
             },
         );
         let saved = db.save_with_extra(item)?;

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -174,7 +174,8 @@ fn map_json_err(err: serde_json::Error) -> ReedlineError {
     )))
 }
 
-type BoxedNamedParams<'a> = Vec<(String, Box<dyn ToSql + 'a>)>;
+type BoxedNamedParams<'a> = Vec<(&'static str, Box<dyn ToSql + 'a>)>;
+type OwnedNamedParams<'a> = Vec<(String, Box<dyn ToSql + 'a>)>;
 
 impl SqliteBackedHistory {
     /// Creates a new history with an associated history file.
@@ -265,13 +266,13 @@ impl SqliteBackedHistory {
         &self,
         query: &'a SearchQuery,
         select_expression: &str,
-    ) -> (String, BoxedNamedParams<'a>) {
+    ) -> (String, OwnedNamedParams<'a>) {
         // TODO: this whole function could be done with less allocs
         let (is_asc, asc) = match query.direction {
             SearchDirection::Forward => (true, "asc"),
             SearchDirection::Backward => (false, "desc"),
         };
-        let mut wheres: Vec<&str> = Vec::new();
+        let mut wheres = Vec::new();
         let mut params: BoxedNamedParams = Vec::new();
         if let Some(start) = query.start_time {
             wheres.push(if is_asc {
@@ -279,10 +280,7 @@ impl SqliteBackedHistory {
             } else {
                 "timestamp_start < :start_time"
             });
-            params.push((
-                ":start_time".to_string(),
-                Box::new(start.timestamp_millis()),
-            ));
+            params.push((":start_time", Box::new(start.timestamp_millis())));
         }
         if let Some(end) = query.end_time {
             wheres.push(if is_asc {
@@ -290,7 +288,7 @@ impl SqliteBackedHistory {
             } else {
                 ":end_time <= timestamp_start"
             });
-            params.push((":end_time".to_string(), Box::new(end.timestamp_millis())));
+            params.push((":end_time", Box::new(end.timestamp_millis())));
         }
         if let Some(start) = query.start_id {
             wheres.push(if is_asc {
@@ -298,7 +296,7 @@ impl SqliteBackedHistory {
             } else {
                 "id < :start_id"
             });
-            params.push((":start_id".to_string(), Box::new(start.0)));
+            params.push((":start_id", Box::new(start.0)));
         }
         if let Some(end) = query.end_id {
             wheres.push(if is_asc {
@@ -306,11 +304,11 @@ impl SqliteBackedHistory {
             } else {
                 ":end_id <= id"
             });
-            params.push((":end_id".to_string(), Box::new(end.0)));
+            params.push((":end_id", Box::new(end.0)));
         }
         let limit = match query.limit {
             Some(l) => {
-                params.push((":limit".to_string(), Box::new(l)));
+                params.push((":limit", Box::new(l)));
                 "limit :limit"
             }
             None => "",
@@ -319,35 +317,35 @@ impl SqliteBackedHistory {
             match command_line {
                 CommandLineSearch::Exact(e) => {
                     wheres.push("command_line == :command_line");
-                    params.push((":command_line".to_string(), Box::new(e)));
+                    params.push((":command_line", Box::new(e)));
                 }
                 CommandLineSearch::Prefix(prefix) => {
                     wheres.push("instr(command_line, :command_line) == 1");
-                    params.push((":command_line".to_string(), Box::new(prefix)));
+                    params.push((":command_line", Box::new(prefix)));
                 }
                 CommandLineSearch::Substring(cont) => {
                     wheres.push("instr(command_line, :command_line) >= 1");
-                    params.push((":command_line".to_string(), Box::new(cont)));
+                    params.push((":command_line", Box::new(cont)));
                 }
             };
         }
 
         if let Some(str) = &query.filter.not_command_line {
             wheres.push("command_line != :not_cmd");
-            params.push((":not_cmd".to_string(), Box::new(str)));
+            params.push((":not_cmd", Box::new(str)));
         }
         if let Some(hostname) = &query.filter.hostname {
             wheres.push("hostname = :hostname");
-            params.push((":hostname".to_string(), Box::new(hostname)));
+            params.push((":hostname", Box::new(hostname)));
         }
         if let Some(cwd_exact) = &query.filter.cwd_exact {
             wheres.push("cwd = :cwd");
-            params.push((":cwd".to_string(), Box::new(cwd_exact)));
+            params.push((":cwd", Box::new(cwd_exact)));
         }
         if let Some(cwd_prefix) = &query.filter.cwd_prefix {
             wheres.push("cwd like :cwd_like");
             let cwd_like = format!("{cwd_prefix}%");
-            params.push((":cwd_like".to_string(), Box::new(cwd_like)));
+            params.push((":cwd_like", Box::new(cwd_like)));
         }
         if let Some(exit_successful) = query.filter.exit_successful {
             if exit_successful {
@@ -363,9 +361,9 @@ impl SqliteBackedHistory {
             // - that have the same session_id, or
             // - were executed before our session started
             wheres.push("(session_id = :session_id OR start_timestamp < :session_timestamp)");
-            params.push((":session_id".to_string(), Box::new(session_id)));
+            params.push((":session_id", Box::new(session_id)));
             params.push((
-                ":session_timestamp".to_string(),
+                ":session_timestamp",
                 Box::new(session_timestamp.timestamp_millis()),
             ));
         }
@@ -373,7 +371,10 @@ impl SqliteBackedHistory {
         // Build WHERE string, appending dynamic json_type/json_extract conditions last.
         // Each JsonFilterValue variant generates type-precise SQL so that JSON booleans,
         // integers, and strings cannot collide with each other.
+        // Dynamic parameter names (":json_path_N", ":json_val_N") are stored separately
+        // since they cannot be &'static str.
         let mut where_string = wheres.join(" and ");
+        let mut json_params: Vec<(String, Box<dyn ToSql + 'a>)> = Vec::new();
         if let Some(filters) = &query.filter.more_info_json {
             for (i, (path, value)) in filters.iter().enumerate() {
                 if !where_string.is_empty() {
@@ -402,7 +403,7 @@ impl SqliteBackedHistory {
                              AND json_extract(more_info, :json_path_{i}) = :json_val_{i}"
                         )
                         .unwrap();
-                        params.push((format!(":json_val_{i}"), Box::new(*n)));
+                        json_params.push((format!(":json_val_{i}"), Box::new(*n)));
                     }
                     JsonFilterValue::Real(f) => {
                         write!(
@@ -411,7 +412,7 @@ impl SqliteBackedHistory {
                              AND json_extract(more_info, :json_path_{i}) = :json_val_{i}"
                         )
                         .unwrap();
-                        params.push((format!(":json_val_{i}"), Box::new(*f)));
+                        json_params.push((format!(":json_val_{i}"), Box::new(*f)));
                     }
                     JsonFilterValue::Text(s) => {
                         write!(
@@ -420,10 +421,10 @@ impl SqliteBackedHistory {
                              AND json_extract(more_info, :json_path_{i}) = :json_val_{i}"
                         )
                         .unwrap();
-                        params.push((format!(":json_val_{i}"), Box::new(s.clone())));
+                        json_params.push((format!(":json_val_{i}"), Box::new(s.clone())));
                     }
                 }
-                params.push((format!(":json_path_{i}"), Box::new(path.clone())));
+                json_params.push((format!(":json_path_{i}"), Box::new(path.clone())));
             }
         }
         if where_string.is_empty() {
@@ -436,7 +437,12 @@ impl SqliteBackedHistory {
              ORDER BY id {asc} \
              {limit}"
         );
-        (query, params)
+        let mut all_params: OwnedNamedParams = params
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect();
+        all_params.extend(json_params);
+        (query, all_params)
     }
 
     fn save_impl<E: HistoryItemExtraInfo>(

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -946,9 +946,7 @@ mod tests {
             cwd: None,
             duration: None,
             exit_status: None,
-            more_info: Some(WithoutVal {
-                other: "x".into(),
-            }),
+            more_info: Some(WithoutVal { other: "x".into() }),
         })?;
 
         let search_val = |val: JsonFilterValue| -> crate::Result<Vec<String>> {

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -63,7 +63,7 @@ fn deserialize_history_item<E: HistoryItemExtraInfo>(
 
 impl History for SqliteBackedHistory {
     fn save(&mut self, entry: HistoryItem) -> Result<HistoryItem> {
-        self.save_impl(entry)
+        self.save_with_extra(entry)
     }
 
     fn load(&self, id: HistoryItemId) -> Result<HistoryItem> {
@@ -445,7 +445,14 @@ impl SqliteBackedHistory {
         (query, all_params)
     }
 
-    fn save_impl<E: HistoryItemExtraInfo>(
+    /// Save a history item with typed `more_info`.
+    ///
+    /// Unlike [`History::save`], this method preserves the full `more_info` type `E`
+    /// by serializing it to JSON and storing it in the `more_info` column.
+    ///
+    /// Note: this method is specific to [`SqliteBackedHistory`]. The [`History`] trait
+    /// methods use [`IgnoreAllExtraInfo`] and do not roundtrip custom `more_info`.
+    pub fn save_with_extra<E: HistoryItemExtraInfo>(
         &mut self,
         mut entry: HistoryItem<E>,
     ) -> Result<HistoryItem<E>> {
@@ -490,20 +497,6 @@ impl SqliteBackedHistory {
             .map_err(map_sqlite_err)?;
         entry.id = Some(HistoryItemId::new(ret));
         Ok(entry)
-    }
-
-    /// Save a history item with typed `more_info`.
-    ///
-    /// Unlike [`History::save`], this method preserves the full `more_info` type `E`
-    /// by serializing it to JSON and storing it in the `more_info` column.
-    ///
-    /// Note: this method is specific to [`SqliteBackedHistory`]. The [`History`] trait
-    /// methods use [`IgnoreAllExtraInfo`] and do not roundtrip custom `more_info`.
-    pub fn save_with_extra<E: HistoryItemExtraInfo>(
-        &mut self,
-        entry: HistoryItem<E>,
-    ) -> Result<HistoryItem<E>> {
-        self.save_impl(entry)
     }
 
     /// Load a history item by ID with typed `more_info`.

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -818,15 +818,21 @@ mod tests {
     #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
     #[test]
     fn json_filter_value_real_vs_integer() -> crate::Result<()> {
+        // Two structs so we can store the same path ($.score) as either real or integer.
         #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-        struct WithScore {
+        struct WithRealScore {
             score: f64,
-            count: i64,
         }
-        impl HistoryItemExtraInfo for WithScore {}
+        impl HistoryItemExtraInfo for WithRealScore {}
+
+        #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+        struct WithIntScore {
+            score: i64,
+        }
+        impl HistoryItemExtraInfo for WithIntScore {}
 
         let mut db = SqliteBackedHistory::in_memory()?;
-        let make = |cmd: &str, score: f64, count: i64| HistoryItem {
+        let make_real = |cmd: &str, score: f64| HistoryItem {
             id: None,
             start_timestamp: None,
             command_line: cmd.to_string(),
@@ -835,10 +841,25 @@ mod tests {
             cwd: None,
             duration: None,
             exit_status: None,
-            more_info: Some(WithScore { score, count }),
+            more_info: Some(WithRealScore { score }),
         };
-        db.save_with_extra(make("cmd_a", 1.5, 1))?;
-        db.save_with_extra(make("cmd_b", 1.0, 2))?;
+        let make_int = |cmd: &str, score: i64| HistoryItem {
+            id: None,
+            start_timestamp: None,
+            command_line: cmd.to_string(),
+            session_id: None,
+            hostname: None,
+            cwd: None,
+            duration: None,
+            exit_status: None,
+            more_info: Some(WithIntScore { score }),
+        };
+        // Row A: $.score = 1.5 (JSON real)
+        db.save_with_extra(make_real("real_a", 1.5))?;
+        // Row B: $.score = 1.0 (JSON real — serde_json always emits decimal point for f64)
+        db.save_with_extra(make_real("real_b", 1.0))?;
+        // Row C: $.score = 1 (JSON integer — stored via i64 struct)
+        db.save_with_extra(make_int("int_c", 1))?;
 
         let search_score = |val: JsonFilterValue| -> crate::Result<Vec<String>> {
             let filter = SearchFilter {
@@ -846,7 +867,7 @@ mod tests {
                 ..SearchFilter::anything(None)
             };
             Ok(db
-                .search_with_extra::<WithScore>(SearchQuery {
+                .search_with_extra::<WithRealScore>(SearchQuery {
                     filter,
                     ..SearchQuery::everything(SearchDirection::Forward, None)
                 })?
@@ -855,13 +876,15 @@ mod tests {
                 .collect())
         };
 
-        assert_eq!(search_score(JsonFilterValue::Real(1.5))?, vec!["cmd_a"]);
-        assert_eq!(search_score(JsonFilterValue::Real(1.0))?, vec!["cmd_b"]);
-        // Integer(1) must not match JSON real numbers (different json_type)
+        // Real(1.5) matches only real_a
+        assert_eq!(search_score(JsonFilterValue::Real(1.5))?, vec!["real_a"]);
+        // Real(1.0) matches real_b but NOT int_c (json_type for int_c is 'integer', not 'real')
+        assert_eq!(search_score(JsonFilterValue::Real(1.0))?, vec!["real_b"]);
+        // Integer(1) matches int_c but NOT real_a or real_b
         assert_eq!(
             search_score(JsonFilterValue::Integer(1))?,
-            Vec::<String>::new(),
-            "Integer(1) must not match JSON real numbers"
+            vec!["int_c"],
+            "Integer(1) must match JSON integer 1 but not JSON reals"
         );
 
         Ok(())
@@ -877,6 +900,13 @@ mod tests {
             val: Option<i64>,
         }
         impl HistoryItemExtraInfo for WithOptVal {}
+
+        // A separate struct without a `val` field to produce JSON that omits $.val entirely.
+        #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+        struct WithoutVal {
+            other: String,
+        }
+        impl HistoryItemExtraInfo for WithoutVal {}
 
         let mut db = SqliteBackedHistory::in_memory()?;
         let make_opt = |cmd: &str, val: Option<i64>| HistoryItem {
@@ -894,17 +924,31 @@ mod tests {
         db.save_with_extra(make_opt("null_row", None))?;
         // Row B: val=42 in JSON
         db.save_with_extra(make_opt("int_row", Some(42)))?;
-        // Row C: SQL NULL more_info — $.val path is therefore absent
+        // Row C: SQL NULL more_info — $.val is absent because more_info IS NULL
         db.save_with_extra::<WithOptVal>(HistoryItem {
             id: None,
             start_timestamp: None,
-            command_line: "no_extra".to_string(),
+            command_line: "sql_null_row".to_string(),
             session_id: None,
             hostname: None,
             cwd: None,
             duration: None,
             exit_status: None,
             more_info: None,
+        })?;
+        // Row D: non-null JSON that simply has no `val` key — $.val path is missing
+        db.save_with_extra(HistoryItem {
+            id: None,
+            start_timestamp: None,
+            command_line: "missing_path_row".to_string(),
+            session_id: None,
+            hostname: None,
+            cwd: None,
+            duration: None,
+            exit_status: None,
+            more_info: Some(WithoutVal {
+                other: "x".into(),
+            }),
         })?;
 
         let search_val = |val: JsonFilterValue| -> crate::Result<Vec<String>> {
@@ -922,7 +966,7 @@ mod tests {
                 .collect())
         };
 
-        // Null matches row A (json_type = 'null') only; row B and C are excluded
+        // Null matches row A (json_type = 'null') only; rows B, C, and D are excluded
         assert_eq!(search_val(JsonFilterValue::Null)?, vec!["null_row"]);
         // Integer(42) matches row B only
         assert_eq!(search_val(JsonFilterValue::Integer(42))?, vec!["int_row"]);

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -8,7 +8,7 @@ use crate::{
     Result,
 };
 use chrono::{TimeZone, Utc};
-use rusqlite::{named_params, params, Connection, ToSql};
+use rusqlite::{named_params, params, Connection, ToSql, TransactionBehavior};
 use std::{fmt::Write, path::PathBuf, time::Duration};
 const SQLITE_APPLICATION_ID: i32 = 1151497937;
 
@@ -59,6 +59,68 @@ fn deserialize_history_item<E: HistoryItemExtraInfo>(
             })
             .transpose()?,
     })
+}
+
+/// Shared implementation of [`SqliteBackedHistory::load_with_extra`], generic over
+/// anything that derefs to a [`Connection`] so it can run against either the history's
+/// own connection or an in-flight [`rusqlite::Transaction`].
+fn load_with_extra_conn<E: HistoryItemExtraInfo>(
+    conn: &Connection,
+    id: HistoryItemId,
+) -> Result<HistoryItem<E>> {
+    conn.prepare("select * from history where id = :id")
+        .map_err(map_sqlite_err)?
+        .query_row(named_params! { ":id": id.0 }, deserialize_history_item::<E>)
+        .map_err(map_sqlite_err)
+}
+
+/// Shared implementation of [`SqliteBackedHistory::save_with_extra`], generic over
+/// anything that derefs to a [`Connection`] so it can run against either the history's
+/// own connection or an in-flight [`rusqlite::Transaction`].
+fn save_with_extra_conn<E: HistoryItemExtraInfo>(
+    conn: &Connection,
+    mut entry: HistoryItem<E>,
+) -> Result<HistoryItem<E>> {
+    let more_info_serialized = entry
+        .more_info
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(map_json_err)?;
+    let ret: i64 = conn
+        .prepare(
+            "insert into history
+                           (id,  start_timestamp,  command_line,  session_id,  hostname,  cwd,  duration_ms,  exit_status,  more_info)
+                    values (:id, :start_timestamp, :command_line, :session_id, :hostname, :cwd, :duration_ms, :exit_status, :more_info)
+                on conflict (history.id) do update set
+                    start_timestamp = excluded.start_timestamp,
+                    command_line = excluded.command_line,
+                    session_id = excluded.session_id,
+                    hostname = excluded.hostname,
+                    cwd = excluded.cwd,
+                    duration_ms = excluded.duration_ms,
+                    exit_status = excluded.exit_status,
+                    more_info = excluded.more_info
+                returning id",
+        )
+        .map_err(map_sqlite_err)?
+        .query_row(
+            named_params! {
+                ":id": entry.id.map(|id| id.0),
+                ":start_timestamp": entry.start_timestamp.map(|e| e.timestamp_millis()),
+                ":command_line": entry.command_line,
+                ":session_id": entry.session_id.map(|e| e.0),
+                ":hostname": entry.hostname,
+                ":cwd": entry.cwd,
+                ":duration_ms": entry.duration.map(|e| e.as_millis() as i64),
+                ":exit_status": entry.exit_status,
+                ":more_info": more_info_serialized,
+            },
+            |row| row.get(0),
+        )
+        .map_err(map_sqlite_err)?;
+    entry.id = Some(HistoryItemId::new(ret));
+    Ok(entry)
 }
 
 impl History for SqliteBackedHistory {
@@ -459,49 +521,9 @@ impl SqliteBackedHistory {
     /// methods use [`IgnoreAllExtraInfo`] and do not roundtrip custom `more_info`.
     pub fn save_with_extra<E: HistoryItemExtraInfo>(
         &mut self,
-        mut entry: HistoryItem<E>,
+        entry: HistoryItem<E>,
     ) -> Result<HistoryItem<E>> {
-        let more_info_serialized = entry
-            .more_info
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()
-            .map_err(map_json_err)?;
-        let ret: i64 = self
-            .db
-            .prepare(
-                "insert into history
-                               (id,  start_timestamp,  command_line,  session_id,  hostname,  cwd,  duration_ms,  exit_status,  more_info)
-                        values (:id, :start_timestamp, :command_line, :session_id, :hostname, :cwd, :duration_ms, :exit_status, :more_info)
-                    on conflict (history.id) do update set
-                        start_timestamp = excluded.start_timestamp,
-                        command_line = excluded.command_line,
-                        session_id = excluded.session_id,
-                        hostname = excluded.hostname,
-                        cwd = excluded.cwd,
-                        duration_ms = excluded.duration_ms,
-                        exit_status = excluded.exit_status,
-                        more_info = excluded.more_info
-                    returning id",
-            )
-            .map_err(map_sqlite_err)?
-            .query_row(
-                named_params! {
-                    ":id": entry.id.map(|id| id.0),
-                    ":start_timestamp": entry.start_timestamp.map(|e| e.timestamp_millis()),
-                    ":command_line": entry.command_line,
-                    ":session_id": entry.session_id.map(|e| e.0),
-                    ":hostname": entry.hostname,
-                    ":cwd": entry.cwd,
-                    ":duration_ms": entry.duration.map(|e| e.as_millis() as i64),
-                    ":exit_status": entry.exit_status,
-                    ":more_info": more_info_serialized,
-                },
-                |row| row.get(0),
-            )
-            .map_err(map_sqlite_err)?;
-        entry.id = Some(HistoryItemId::new(ret));
-        Ok(entry)
+        save_with_extra_conn(&self.db, entry)
     }
 
     /// Load a history item by ID with typed `more_info`.
@@ -515,11 +537,7 @@ impl SqliteBackedHistory {
         &self,
         id: HistoryItemId,
     ) -> Result<HistoryItem<E>> {
-        self.db
-            .prepare("select * from history where id = :id")
-            .map_err(map_sqlite_err)?
-            .query_row(named_params! { ":id": id.0 }, deserialize_history_item::<E>)
-            .map_err(map_sqlite_err)
+        load_with_extra_conn(&self.db, id)
     }
 
     /// Update every column of an existing row except `more_info`, leaving it as-is.
@@ -573,9 +591,15 @@ impl SqliteBackedHistory {
         id: HistoryItemId,
         updater: &dyn Fn(HistoryItem<E>) -> HistoryItem<E>,
     ) -> Result<()> {
-        // in theory this should run in a transaction
-        let item = self.load_with_extra::<E>(id)?;
-        self.save_with_extra(updater(item))?;
+        // `Immediate` acquires the write lock up front, so no other connection can
+        // interleave a write between the load and the save below.
+        let tx = self
+            .db
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(map_sqlite_err)?;
+        let item = load_with_extra_conn::<E>(&tx, id)?;
+        save_with_extra_conn(&tx, updater(item))?;
+        tx.commit().map_err(map_sqlite_err)?;
         Ok(())
     }
 

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -1153,4 +1153,73 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn update_with_extra_blocks_concurrent_writer() -> crate::Result<()> {
+        use std::cell::{Cell, RefCell};
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let histfile = tmp.path().join("history.sqlite3");
+
+        let mut writer = SqliteBackedHistory::with_file(histfile.clone(), None, None)?;
+        let saved = writer.save_with_extra(item_with_extra(
+            "cmd",
+            TestExtra {
+                meta_command: false,
+                tag: "before".into(),
+                count: 1,
+            },
+        ))?;
+        let id = saved.id.unwrap();
+
+        // A second connection to the same file. Its busy timeout is set to 0 so a
+        // lock conflict surfaces immediately as an error instead of blocking for
+        // rusqlite's default 5-second busy handler, keeping this test fast.
+        let other = SqliteBackedHistory::with_file(histfile, None, None)?;
+        other
+            .db
+            .busy_timeout(Duration::from_millis(0))
+            .map_err(map_sqlite_err)?;
+        let other = RefCell::new(other);
+
+        let concurrent_write_blocked = Cell::new(false);
+        writer.update_with_extra::<TestExtra>(id, &|mut e| {
+            // Runs while `writer`'s immediate transaction still holds the write
+            // lock. Without it, this competing write would succeed.
+            let result = other.borrow_mut().save_with_extra(item_with_extra(
+                "competing",
+                TestExtra {
+                    meta_command: false,
+                    tag: "concurrent".into(),
+                    count: 0,
+                },
+            ));
+            let is_locked_error =
+                matches!(&result, Err(e) if e.to_string().contains("database is locked"));
+            concurrent_write_blocked.set(is_locked_error);
+
+            if let Some(extra) = e.more_info.as_mut() {
+                extra.tag = "after".into();
+                extra.count += 1;
+            }
+            e
+        })?;
+
+        assert!(
+            concurrent_write_blocked.get(),
+            "expected the competing writer to fail with a database-locked error while update_with_extra's immediate transaction was held"
+        );
+
+        let reloaded = writer.load_with_extra::<TestExtra>(id)?;
+        assert_eq!(
+            reloaded.more_info,
+            Some(TestExtra {
+                meta_command: false,
+                tag: "after".into(),
+                count: 2,
+            })
+        );
+        Ok(())
+    }
 }

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -121,8 +121,13 @@ impl History for SqliteBackedHistory {
     ) -> Result<()> {
         // in theory this should run in a transaction
         let item = self.load(id)?;
-        self.save(updater(item))?;
-        Ok(())
+        // `HistoryItem` here is always `HistoryItem<IgnoreAllExtraInfo>`, which cannot
+        // carry a meaningful `more_info` value (it serializes to `null` regardless of
+        // what was loaded). So this type-erased path updates every column except
+        // `more_info`, leaving whatever a typed caller wrote via `save_with_extra`
+        // intact. Callers that need to read/modify typed `more_info` should use
+        // [`Self::update_with_extra`] instead.
+        self.update_preserving_more_info(updater(item))
     }
 
     fn clear(&mut self) -> Result<()> {
@@ -515,6 +520,63 @@ impl SqliteBackedHistory {
             .map_err(map_sqlite_err)?
             .query_row(named_params! { ":id": id.0 }, deserialize_history_item::<E>)
             .map_err(map_sqlite_err)
+    }
+
+    /// Update every column of an existing row except `more_info`, leaving it as-is.
+    ///
+    /// Used by the type-erased [`History::update`], which cannot express a meaningful
+    /// change to `more_info` (see its implementation for why).
+    fn update_preserving_more_info(&mut self, entry: HistoryItem) -> Result<()> {
+        let changed = self
+            .db
+            .prepare(
+                "update history set
+                    start_timestamp = :start_timestamp,
+                    command_line = :command_line,
+                    session_id = :session_id,
+                    hostname = :hostname,
+                    cwd = :cwd,
+                    duration_ms = :duration_ms,
+                    exit_status = :exit_status
+                 where id = :id",
+            )
+            .map_err(map_sqlite_err)?
+            .execute(named_params! {
+                ":id": entry.id.map(|id| id.0),
+                ":start_timestamp": entry.start_timestamp.map(|e| e.timestamp_millis()),
+                ":command_line": entry.command_line,
+                ":session_id": entry.session_id.map(|e| e.0),
+                ":hostname": entry.hostname,
+                ":cwd": entry.cwd,
+                ":duration_ms": entry.duration.map(|e| e.as_millis() as i64),
+                ":exit_status": entry.exit_status,
+            })
+            .map_err(map_sqlite_err)?;
+        if changed == 0 {
+            return Err(ReedlineError(ReedlineErrorVariants::HistoryDatabaseError(
+                "Could not find item".to_string(),
+            )));
+        }
+        Ok(())
+    }
+
+    /// Update a history item atomically while preserving typed `more_info`.
+    ///
+    /// Unlike [`History::update`], this loads and saves through [`Self::load_with_extra`]
+    /// and [`Self::save_with_extra`], so `updater` can read and change the typed
+    /// `more_info` and have the change persisted.
+    ///
+    /// Note: this method is specific to [`SqliteBackedHistory`]. It is not part of the
+    /// [`History`] trait and so is unavailable through `&dyn History`.
+    pub fn update_with_extra<E: HistoryItemExtraInfo>(
+        &mut self,
+        id: HistoryItemId,
+        updater: &dyn Fn(HistoryItem<E>) -> HistoryItem<E>,
+    ) -> Result<()> {
+        // in theory this should run in a transaction
+        let item = self.load_with_extra::<E>(id)?;
+        self.save_with_extra(updater(item))?;
+        Ok(())
     }
 
     /// Search history items with typed `more_info`.
@@ -989,6 +1051,82 @@ mod tests {
         let untyped = db.load(saved.id.unwrap())?;
         assert_eq!(untyped.command_line, ":cd /tmp");
         assert_eq!(untyped.more_info, Some(IgnoreAllExtraInfo));
+        Ok(())
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[test]
+    fn trait_update_preserves_typed_more_info() -> crate::Result<()> {
+        let mut db = SqliteBackedHistory::in_memory()?;
+        let saved = db.save_with_extra(item_with_extra(
+            "cmd",
+            TestExtra {
+                meta_command: true,
+                tag: "keep-me".into(),
+                count: 7,
+            },
+        ))?;
+        let id = saved.id.unwrap();
+
+        // Go through the type-erased `History::update`, e.g. as
+        // `Reedline::update_last_command_context` does for post-command bookkeeping.
+        History::update(&mut db, id, &|mut e| {
+            e.exit_status = Some(0);
+            e
+        })?;
+
+        let reloaded = db.load_with_extra::<TestExtra>(id)?;
+        assert_eq!(reloaded.exit_status, Some(0));
+        assert_eq!(
+            reloaded.more_info,
+            Some(TestExtra {
+                meta_command: true,
+                tag: "keep-me".into(),
+                count: 7,
+            })
+        );
+        Ok(())
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[test]
+    fn trait_update_missing_id_errors() {
+        let mut db = SqliteBackedHistory::in_memory().unwrap();
+        let result = History::update(&mut db, HistoryItemId::new(999), &|e| e);
+        assert!(result.is_err());
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[test]
+    fn update_with_extra_modifies_typed_more_info() -> crate::Result<()> {
+        let mut db = SqliteBackedHistory::in_memory()?;
+        let saved = db.save_with_extra(item_with_extra(
+            "cmd",
+            TestExtra {
+                meta_command: false,
+                tag: "before".into(),
+                count: 1,
+            },
+        ))?;
+        let id = saved.id.unwrap();
+
+        db.update_with_extra::<TestExtra>(id, &|mut e| {
+            if let Some(extra) = e.more_info.as_mut() {
+                extra.tag = "after".into();
+                extra.count += 1;
+            }
+            e
+        })?;
+
+        let reloaded = db.load_with_extra::<TestExtra>(id)?;
+        assert_eq!(
+            reloaded.more_info,
+            Some(TestExtra {
+                meta_command: false,
+                tag: "after".into(),
+                count: 2,
+            })
+        );
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,8 +252,8 @@ mod history;
 pub use history::SqliteBackedHistory;
 pub use history::{
     CommandLineSearch, FileBackedHistory, History, HistoryItem, HistoryItemExtraInfo,
-    HistoryItemId, HistoryNavigationQuery, HistorySessionId, IgnoreAllExtraInfo, SearchDirection,
-    SearchFilter, SearchQuery, HISTORY_SIZE,
+    HistoryItemId, HistoryNavigationQuery, HistorySessionId, IgnoreAllExtraInfo, JsonFilterValue,
+    SearchDirection, SearchFilter, SearchQuery, HISTORY_SIZE,
 };
 
 mod prompt;


### PR DESCRIPTION
## Summary

Three typed inherent methods are added to `SqliteBackedHistory` (`save_with_extra`, `load_with_extra`, `search_with_extra`) for round-tripping `more_info` without type erasure. `History::save` now delegates to `save_with_extra`, so both paths share the same implementation. A new `JsonFilterValue` enum and `SearchFilter::more_info_json` field enable type-precise filtering by JSON path at the SQL level. The `History` trait is unchanged.

## Motivation

#1011 made `HistoryItem` generic over `ExtraInfo` and exposed `HistoryItemExtraInfo` publicly. However, the `History` trait still uses the type-erased `HistoryItem<IgnoreAllExtraInfo>`, so any `more_info` written through the trait is silently discarded on the next read. The generics are in place, but there is no usable end-to-end path to preserve custom metadata.

Downstream crates that want to persist typed metadata in `more_info` necessarily hold `SqliteBackedHistory` directly, since `FileBackedHistory` has no `more_info` support at all. Typed inherent methods on `SqliteBackedHistory` model this capability boundary precisely, without changing the `History` trait.