### PR TITLE
Asyncronous prompt updates

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -52,7 +52,10 @@ use {
         io::Result,
         io::Write,
         process::Command,
-        sync::{atomic::AtomicBool, Arc},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
         time::Duration,
         time::SystemTime,
     },
@@ -208,6 +211,10 @@ pub struct Reedline {
     // `Signal::ExternalBreak` with the current buffer contents.
     break_signal: Option<Arc<AtomicBool>>,
 
+    // External repaint signal: when triggered, the prompt is re-evaluated
+    // and repainted in place while `read_line()` is running.
+    repaint_signal: Option<RepaintSignal>,
+
     // Maximum time to block on input before yielding control for features that
     // require periodic processing (external printer, idle callback).
     // Only used when external_printer or idle_callback is configured.
@@ -225,6 +232,26 @@ pub struct Reedline {
 struct BufferEditor {
     command: Command,
     temp_file: PathBuf,
+}
+
+/// Call [`request_repaint`](RepaintSignal::request_repaint) once
+/// new prompt data is ready! The next iteration of the input loop re-evaluates
+/// the [`Prompt`] and redraws it without interrupting the current line edit.
+#[derive(Clone, Debug, Default)]
+pub struct RepaintSignal {
+    flag: Arc<AtomicBool>,
+}
+
+impl RepaintSignal {
+    /// Request that the prompt is re-evaluated and repainted in place.
+    pub fn request_repaint(&self) {
+        self.flag.store(true, Ordering::Relaxed);
+    }
+
+    /// Consume a pending repaint request.
+    fn take(&self) -> bool {
+        self.flag.swap(false, Ordering::Relaxed)
+    }
 }
 
 impl Drop for Reedline {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -326,6 +326,7 @@ impl Reedline {
             kitty_protocol: KittyProtocolGuard::default(),
             immediately_accept: false,
             break_signal: None,
+            repaint_signal: None,
             poll_interval: DEFAULT_POLL_INTERVAL,
             #[cfg(feature = "external_printer")]
             external_printer: None,
@@ -712,6 +713,16 @@ impl Reedline {
         self
     }
 
+    /// Get a [`RepaintSignal`] handle that can trigger an in-place repaint of
+    /// the prompt from another thread while [`Reedline::read_line()`] is
+    /// running, avoiding interfering with current line edit.
+    pub fn repaint_signal(&mut self) -> RepaintSignal {
+        // The handle is created lazily on the first call; subsequent calls return clones
+        self.repaint_signal
+            .get_or_insert_with(RepaintSignal::default)
+            .clone()
+    }
+
     /// Returns the corresponding expected prompt style for the given edit mode
     pub fn prompt_edit_mode(&self) -> PromptEditMode {
         self.edit_mode.edit_mode()
@@ -852,6 +863,29 @@ impl Reedline {
         Ok(())
     }
 
+    /// Consume a pending external repaint request, returning whether one was
+    /// pending. Any number of requests since the last check collapse into one.
+    fn take_repaint_request(&self) -> bool {
+        self.repaint_signal
+            .as_ref()
+            .map_or(false, RepaintSignal::take)
+    }
+
+    /// Whether the input loop must poll with a timeout instead of blocking
+    /// indefinitely, so external triggers (break signal, repaint signal,
+    /// external printer, idle callback) are noticed while waiting for input.
+    fn input_needs_polling(&self) -> bool {
+        let poll = self.break_signal.is_some() || self.repaint_signal.is_some();
+
+        #[cfg(feature = "external_printer")]
+        let poll = poll || self.external_printer.is_some();
+
+        #[cfg(feature = "idle_callback")]
+        let poll = poll || self.idle_callback.is_some();
+
+        poll
+    }
+
     /// Helper implementing the logic for [`Reedline::read_line()`] to be wrapped
     /// in a `raw_mode` context.
     fn read_line_helper(&mut self, prompt: &dyn Prompt) -> Result<Signal> {
@@ -863,6 +897,10 @@ impl Reedline {
             self.suspended_state = None;
         }
         self.hide_hints = false;
+
+        // Repaint requests raised while no read_line was active are stale:
+        // the fresh prompt painted below already reflects the latest state.
+        self.take_repaint_request();
 
         self.repaint(prompt)?;
 
@@ -886,6 +924,10 @@ impl Reedline {
                     self.editor.reset_undo_stack();
                     return Ok(Signal::ExternalBreak(buffer));
                 }
+            }
+
+            if self.take_repaint_request() {
+                self.repaint(prompt)?;
             }
 
             #[cfg(feature = "external_printer")]
@@ -941,22 +983,7 @@ impl Reedline {
             let mut events: Vec<Event> = vec![];
 
             if !self.immediately_accept {
-                let needs_polling = {
-                    #[allow(unused_mut)]
-                    let mut result = self.break_signal.is_some();
-                    result |= completer_pending;
-                    #[cfg(feature = "external_printer")]
-                    if self.external_printer.is_some() {
-                        result = true;
-                    }
-                    #[cfg(feature = "idle_callback")]
-                    if self.idle_callback.is_some() {
-                        result = true;
-                    }
-                    result
-                };
-
-                if needs_polling {
+                if self.input_needs_polling() || completer_pending {
                     if event::poll(self.poll_interval)? {
                         events.push(crossterm::event::read()?);
                     }
@@ -2702,6 +2729,62 @@ mod tests {
         fn f<S: Send>(_: S) {}
         let signal = Arc::new(AtomicBool::new(false));
         f(Reedline::create().with_break_signal(signal));
+    }
+
+    #[test]
+    fn take_repaint_request_is_false_without_a_handle() {
+        let reedline = Reedline::create();
+        assert!(!reedline.take_repaint_request());
+        assert!(!reedline.take_repaint_request());
+    }
+
+    #[test]
+    fn take_repaint_request_consumes_the_request() {
+        let mut reedline = Reedline::create();
+        let signal = reedline.repaint_signal();
+
+        signal.request_repaint();
+        assert!(reedline.take_repaint_request());
+        // Consumed: no repaint left pending
+        assert!(!reedline.take_repaint_request());
+
+        // A new request is honored again
+        signal.request_repaint();
+        assert!(reedline.take_repaint_request());
+        assert!(!reedline.take_repaint_request());
+    }
+
+    #[test]
+    fn repaint_signal_switches_input_loop_to_polling() {
+        let mut reedline = Reedline::create();
+        assert!(
+            !reedline.input_needs_polling(),
+            "without external triggers the loop should block on input"
+        );
+
+        let _signal = reedline.repaint_signal();
+        assert!(
+            reedline.input_needs_polling(),
+            "a repaint handle must switch the loop to polling so requests are noticed"
+        );
+    }
+
+    #[test]
+    fn repaint_request_during_active_read_survives_while_stale_ones_are_dropped() {
+        // Emulates the loop's consumption pattern: read_line_helper drains any
+        // stale pre-read_line request before painting the initial prompt, so
+        // only requests raised afterwards trigger an extra repaint.
+        let mut reedline = Reedline::create();
+        let signal = reedline.repaint_signal();
+
+        // Raised while no read_line is active -> dropped by the initial drain
+        signal.request_repaint();
+        reedline.take_repaint_request();
+        assert!(!reedline.take_repaint_request());
+
+        // Raised "mid-edit" -> observed by the next loop iteration
+        signal.request_repaint();
+        assert!(reedline.take_repaint_request());
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -875,13 +875,22 @@ impl Reedline {
     /// indefinitely, so external triggers (break signal, repaint signal,
     /// external printer, idle callback) are noticed while waiting for input.
     fn input_needs_polling(&self) -> bool {
-        let poll = self.break_signal.is_some() || self.repaint_signal.is_some();
+        #[allow(unused_mut)] // Dependent on feature flags
+        let mut poll = self.break_signal.is_some()
+            || self
+                .repaint_signal
+                .as_ref()
+                .map_or(false, |sig| Arc::strong_count(&sig.flag) > 1);
 
         #[cfg(feature = "external_printer")]
-        let poll = poll || self.external_printer.is_some();
+        {
+            poll |= self.external_printer.is_some();
+        }
 
         #[cfg(feature = "idle_callback")]
-        let poll = poll || self.idle_callback.is_some();
+        {
+            poll |= self.idle_callback.is_some();
+        }
 
         poll
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2788,6 +2788,95 @@ mod tests {
     }
 
     #[test]
+    fn repaint_signal_handles_share_one_flag() {
+        // Every handle returned by `repaint_signal()` (and its clones) must
+        // observe the same underlying flag, so a request from any of them is
+        // seen exactly once by the loop.
+        let mut reedline = Reedline::create();
+        let a = reedline.repaint_signal();
+        let b = reedline.repaint_signal();
+        let c = a.clone();
+
+        b.request_repaint();
+        assert!(reedline.take_repaint_request());
+        assert!(!reedline.take_repaint_request());
+
+        // A request made through the clone is also observed.
+        c.request_repaint();
+        assert!(reedline.take_repaint_request());
+    }
+
+    #[test]
+    fn repaint_signal_survives_behind_an_arc() {
+        // This is what a shell would be using...
+        // handed to a worker that knows nothing about `Reedline`.
+        use std::sync::Arc;
+        let mut reedline = Reedline::create();
+        let shared: Arc<RepaintSignal> = Arc::new(reedline.repaint_signal());
+
+        let worker = shared.clone();
+        std::thread::spawn(move || worker.request_repaint())
+            .join()
+            .expect("worker thread panicked");
+
+        assert!(reedline.take_repaint_request());
+    }
+
+    #[test]
+    fn repaint_request_collapses_rapid_fire() {
+        // Many requests arriving between two loop iterations must collapse into
+        // a single repaint, not N. `take` is a swap(false), so only one take
+        // should observe the request regardless of how many were raised.
+        let mut reedline = Reedline::create();
+        let signal = reedline.repaint_signal();
+
+        for _ in 0..1_000 {
+            signal.request_repaint();
+        }
+        assert!(reedline.take_repaint_request());
+        assert!(!reedline.take_repaint_request());
+    }
+
+    #[test]
+    fn repaint_signal_is_independent_of_break_signal() {
+        // The two out-of-band triggers must not interfere: arming a repaint
+        // request must not be mistaken for a break, and vice versa.
+        use std::sync::atomic::AtomicBool;
+        use std::sync::Arc;
+
+        let mut reedline = Reedline::create().with_break_signal(Arc::new(AtomicBool::new(false)));
+        let repaint = reedline.repaint_signal();
+
+        repaint.request_repaint();
+        assert!(reedline.take_repaint_request());
+        assert!(
+            !reedline
+                .break_signal
+                .as_ref()
+                .unwrap()
+                .load(std::sync::atomic::Ordering::Relaxed),
+            "repaint must not toggle the break flag"
+        );
+
+        reedline
+            .break_signal
+            .as_ref()
+            .unwrap()
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            reedline
+                .break_signal
+                .as_ref()
+                .unwrap()
+                .swap(false, std::sync::atomic::Ordering::Relaxed),
+            "break flag must be independently observable"
+        );
+        assert!(
+            !reedline.take_repaint_request(),
+            "break must not leave a repaint pending"
+        );
+    }
+    #[test]
     fn signal_external_break_pattern_match() {
         let buffer_content = "some partial input".to_string();
         let signal = Signal::ExternalBreak(buffer_content.clone());


### PR DESCRIPTION
<!-- Thanks for contributing to Reedline! -->

## Summary <!-- Must Have -->
<!--
Motivate this PR: why did you open it, how did you arrive at this solution?
Mention any changes to Reedline's public API or observable behavior, or mention that there are none.
-->
So this fixes my own issue nushell/nushell#18642. It's meant to be composed with an upcoming Nushell PR, which I will link here when I have it up. My biggest motivation is that I'm working on changes to starship that should bring these different kinds of prompts to users, and nushell is my daily driver. Wanted it here too, of course :0

### Before <!-- Much Appreciated -->
<!--
Describe behavior, function or implementation BEFORE your changes.
If not applicable, just remove the heading.
-->

Before this, there existed no way to repaint the prompt after the first pass.

### After <!-- Much Appreciated -->
<!--
Describe behavior, function or implementation AFTER your changes.
If not applicable, just remove the heading.
-->
After this, the mechanism exists for repainting, opening use-cases for things like:
- An accurate time prompt
- Asynchronus git status (non-blocking)
- Gradient madness?? 

## Additional notes <!-- Optional -->
<!--
Anything else worth knowing. Link related issues with `closes nushell/reedline#123` / `fixes nushell/reedline#456` to auto-close them on merge.
-->

- I noticed that other features, like external_printer are gated, not sure if that should be the case here too.
- We don't have any real integration tests against a PTY which I was surprised to see, which makes true testing here hard, but I did verify myself.
