### PR TITLE
Add `with_persistent_menus` option

### DIFF
--- a/examples/persistent_menus.rs
+++ b/examples/persistent_menus.rs
@@ -1,0 +1,98 @@
+// Create a reedline object with persistent menus
+// cargo run --example persistent_menus
+//
+// "he" [Tab] opens the completion menu filtered to the "hello ..." entries.
+// Erase with [Backspace] — even past "h" to an empty line — and the menu
+// stays open, refiltering back up to the full list of options.
+//
+// Change `with_persistent_menus(true)` to `false` to see the default
+// behavior: with quick completions on, the first [Backspace] dismisses the
+// menu; without quick completions, the menu closes once the line is empty.
+
+use reedline::{
+    default_emacs_keybindings, ColumnarMenu, Completer, DefaultPrompt, Emacs, KeyCode,
+    KeyModifiers, Keybindings, MenuBuilder, Reedline, ReedlineEvent, ReedlineMenu, Signal, Span,
+    Suggestion,
+};
+use std::io;
+
+// Prefix completer that also suggests on an empty line (like a shell does);
+// `DefaultCompleter` returns nothing for empty input, which would make the
+// kept-open menu invisible right when this example wants to show it.
+struct PrefixCompleter {
+    commands: Vec<String>,
+}
+
+impl Completer for PrefixCompleter {
+    fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+        let filter = &line[..pos];
+        self.commands
+            .iter()
+            .filter(|command| command.starts_with(filter))
+            .map(|command| Suggestion {
+                value: command.clone(),
+                span: Span::new(0, pos),
+                ..Suggestion::default()
+            })
+            .collect()
+    }
+}
+
+fn add_menu_keybindings(keybindings: &mut Keybindings) {
+    keybindings.add_binding(
+        KeyModifiers::NONE,
+        KeyCode::Tab,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::Menu("completion_menu".to_string()),
+            ReedlineEvent::MenuNext,
+        ]),
+    );
+}
+
+fn main() -> io::Result<()> {
+    let commands = vec![
+        "hello world".into(),
+        "hello world reedline".into(),
+        "hello world something".into(),
+        "history 1".into(),
+        "history 2".into(),
+        "test".into(),
+        "this is the reedline crate".into(),
+        "clear".into(),
+        "exit".into(),
+        "logout".into(),
+        "login".into(),
+    ];
+
+    let completer = Box::new(PrefixCompleter { commands });
+
+    let completion_menu = Box::new(ColumnarMenu::default().with_name("completion_menu"));
+
+    let mut keybindings = default_emacs_keybindings();
+    add_menu_keybindings(&mut keybindings);
+
+    let edit_mode = Box::new(Emacs::new(keybindings));
+
+    let mut line_editor = Reedline::create()
+        .with_completer(completer)
+        .with_menu(ReedlineMenu::EngineCompleter(completion_menu))
+        .with_quick_completions(true)
+        .with_persistent_menus(true)
+        .with_edit_mode(edit_mode);
+
+    let prompt = DefaultPrompt::default();
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {buffer}");
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3124,25 +3124,13 @@ mod tests {
         assert_eq!(reedline.current_buffer_contents(), "67x");
     }
 
-    #[rstest]
-    #[case(false, false)]
-    #[case(false, true)]
-    #[case(true, false)]
-    #[case(true, true)]
-    fn test_menu_persistence_while_erasing(#[case] quick: bool, #[case] persistent: bool) {
-        fn menu_is_active(reedline: &Reedline) -> bool {
-            reedline.menus.iter().any(|menu| menu.is_active())
-        }
-        fn backspace(reedline: &mut Reedline) {
-            reedline
-                .handle_event(
-                    &DefaultPrompt::default(),
-                    ReedlineEvent::Edit(vec![EditCommand::Backspace]),
-                )
-                .unwrap();
-        }
+    fn menu_is_active(reedline: &Reedline) -> bool {
+        reedline.menus.iter().any(|menu| menu.is_active())
+    }
 
-        // "th" matches two words, so quick completions don't auto-select on activation
+    /// Engine with a completion menu activated on a "th" buffer. "th" matches
+    /// two words, so quick completions don't auto-select on activation.
+    fn engine_with_active_menu(quick: bool, persistent: bool) -> Reedline {
         let completer = Box::new(DefaultCompleter::new_with_wordlen(
             vec![
                 String::from("test"),
@@ -3168,16 +3156,46 @@ mod tests {
             )
             .unwrap();
         assert!(menu_is_active(&reedline));
+        reedline
+    }
+
+    fn send_edit(reedline: &mut Reedline, command: EditCommand) {
+        reedline
+            .handle_event(
+                &DefaultPrompt::default(),
+                ReedlineEvent::Edit(vec![command]),
+            )
+            .unwrap();
+    }
+
+    #[rstest]
+    #[case(false, false)]
+    #[case(false, true)]
+    #[case(true, false)]
+    #[case(true, true)]
+    fn test_menu_persistence_while_erasing(#[case] quick: bool, #[case] persistent: bool) {
+        let mut reedline = engine_with_active_menu(quick, persistent);
 
         // quick completions close the menu on any backspace unless menus are persistent
-        backspace(&mut reedline);
+        send_edit(&mut reedline, EditCommand::Backspace);
         assert_eq!(reedline.current_buffer_contents(), "t");
         assert_eq!(menu_is_active(&reedline), persistent || !quick);
 
         // emptying the buffer closes the menu unless menus are persistent
-        backspace(&mut reedline);
+        send_edit(&mut reedline, EditCommand::Backspace);
         assert!(reedline.current_buffer_contents().is_empty());
         assert_eq!(menu_is_active(&reedline), persistent);
+    }
+
+    #[rstest]
+    #[case(EditCommand::BackspaceWord)]
+    #[case(EditCommand::MoveToLineStart { select: false })]
+    fn test_menu_persistence_covers_all_quick_dismissal_commands(#[case] command: EditCommand) {
+        for persistent in [false, true] {
+            let mut reedline = engine_with_active_menu(true, persistent);
+            send_edit(&mut reedline, command.clone());
+            assert_eq!(menu_is_active(&reedline), persistent);
+        }
     }
 
     /// A hinter that always offers a fixed suggestion, so the completion flow can

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -163,6 +163,7 @@ pub struct Reedline {
     completer: Box<dyn Completer + Send>,
     quick_completions: bool,
     partial_completions: bool,
+    persistent_menus: bool,
 
     // Highlight the edit buffer
     highlighter: Box<dyn Highlighter>,
@@ -283,6 +284,7 @@ impl Reedline {
             completer,
             quick_completions: false,
             partial_completions: false,
+            persistent_menus: false,
             highlighter: buffer_highlighter,
             visual_selection_style,
             hinter,
@@ -439,6 +441,19 @@ impl Reedline {
     #[must_use]
     pub fn with_partial_completions(mut self, partial_completions: bool) -> Self {
         self.partial_completions = partial_completions;
+        self
+    }
+
+    /// Make active menus persist while the line is edited: erasing characters
+    /// or emptying the line refilters the menu instead of dismissing it.
+    ///
+    /// When disabled (the default), an active menu is deactivated by a backspace
+    /// when quick completions are on, and by any edit that leaves the line
+    /// buffer empty. A persistent menu still closes on Esc, Ctrl-C, or when a
+    /// value is accepted.
+    #[must_use]
+    pub fn with_persistent_menus(mut self, persistent_menus: bool) -> Self {
+        self.persistent_menus = persistent_menus;
         self
     }
 
@@ -1411,7 +1426,9 @@ impl Reedline {
                         match commands.first() {
                             Some(&EditCommand::Backspace)
                             | Some(&EditCommand::BackspaceWord)
-                            | Some(&EditCommand::MoveToLineStart { select: false }) => {
+                            | Some(&EditCommand::MoveToLineStart { select: false })
+                                if !self.persistent_menus =>
+                            {
                                 menu.menu_event(MenuEvent::Deactivate)
                             }
                             _ => {
@@ -1439,7 +1456,7 @@ impl Reedline {
                             }
                         }
                     }
-                    if self.editor.line_buffer().get_buffer().is_empty() {
+                    if !self.persistent_menus && self.editor.line_buffer().get_buffer().is_empty() {
                         menu.menu_event(MenuEvent::Deactivate);
                     } else {
                         menu.menu_event(MenuEvent::Edit(self.quick_completions));
@@ -3105,6 +3122,62 @@ mod tests {
         let insertion = EditCommand::InsertString(String::from("x"));
         reedline.run_edit_commands(&[insertion]);
         assert_eq!(reedline.current_buffer_contents(), "67x");
+    }
+
+    #[rstest]
+    #[case(false, false)]
+    #[case(false, true)]
+    #[case(true, false)]
+    #[case(true, true)]
+    fn test_menu_persistence_while_erasing(#[case] quick: bool, #[case] persistent: bool) {
+        fn menu_is_active(reedline: &Reedline) -> bool {
+            reedline.menus.iter().any(|menu| menu.is_active())
+        }
+        fn backspace(reedline: &mut Reedline) {
+            reedline
+                .handle_event(
+                    &DefaultPrompt::default(),
+                    ReedlineEvent::Edit(vec![EditCommand::Backspace]),
+                )
+                .unwrap();
+        }
+
+        // "th" matches two words, so quick completions don't auto-select on activation
+        let completer = Box::new(DefaultCompleter::new_with_wordlen(
+            vec![
+                String::from("test"),
+                String::from("this"),
+                String::from("that"),
+            ],
+            1,
+        ));
+        let completion_menu = ReedlineMenu::EngineCompleter(Box::new(
+            ColumnarMenu::default().with_name("completion_menu"),
+        ));
+        let mut reedline = Reedline::create()
+            .with_completer(completer)
+            .with_menu(completion_menu)
+            .with_quick_completions(quick)
+            .with_persistent_menus(persistent);
+
+        reedline.run_edit_commands(&[EditCommand::InsertString(String::from("th"))]);
+        reedline
+            .handle_event(
+                &DefaultPrompt::default(),
+                ReedlineEvent::Menu(String::from("completion_menu")),
+            )
+            .unwrap();
+        assert!(menu_is_active(&reedline));
+
+        // quick completions close the menu on any backspace unless menus are persistent
+        backspace(&mut reedline);
+        assert_eq!(reedline.current_buffer_contents(), "t");
+        assert_eq!(menu_is_active(&reedline), persistent || !quick);
+
+        // emptying the buffer closes the menu unless menus are persistent
+        backspace(&mut reedline);
+        assert!(reedline.current_buffer_contents().is_empty());
+        assert_eq!(menu_is_active(&reedline), persistent);
     }
 
     /// A hinter that always offers a fixed suggestion, so the completion flow can


### PR DESCRIPTION
Disclosure: the code was written by an AI agentunder my direction; I can't review Rust line-by-line myself. What was verified: the full reedline test suite plus a new 4-case test matrix (quick × persistent), cargo fmt --check / clippy with CI flags, and manual behavior checks in a live nushell build with both flag values. I've wanted this behavior for a long time and drove the design decisions. Please review accordingly.

## Summary

When a menu is active and the user erases the characters they typed to filter it, the engine dismisses the menu. Two hardcoded paths in `engine.rs` do this: with quick completions on, any `Backspace`/`BackspaceWord`/`MoveToLineStart` deactivates the menu; and regardless of quick completions, any edit that leaves the line buffer empty deactivates it. Neither was configurable.

Erasing the filter is a natural part of browsing completions — narrowing too far and backing up shouldn't throw the menu away, especially since activating a menu on an empty buffer is already valid and shows all values.

Public API change: a new builder option, `Reedline::with_persistent_menus(bool)`, default `false`. With the default, observable behavior is unchanged. With `true`, edits refilter an active menu instead of dismissing it; the menu still closes on `Esc`, `Ctrl-C`, or when a value is accepted.

### Before

With a menu open, erasing input dismisses it:

- quick completions on: the first backspace closes the menu;
- quick completions off: the menu survives backspaces until an edit empties the line buffer, then closes.

### After

Default (`with_persistent_menus(false)`): same as before.

`with_persistent_menus(true)`: erasing characters (or emptying the line) sends `MenuEvent::Edit` like any other edit, so the menu stays open and refilters — down to the full unfiltered list on an empty buffer.

## Additional notes

A follow-up nushell PR wires this as `$env.config.completions.persistent_menus` once a reedline release includes it.

Covered by a new `rstest` case matrix (quick × persistent) in `src/engine.rs`.
