### PR TITLE
fix: dont expand abbr eagerly on submit

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1950,6 +1950,17 @@ impl Reedline {
             // The first char in the buffer is a space or there are consecutive spaces
             return None;
         }
+
+        if submitted
+            && buffer[word_end..]
+                .chars()
+                .next()
+                .map_or(false, |ch| !ch.is_whitespace())
+        {
+            // The cursor is in the middle of a word, e.g. "hello|world"
+            return None;
+        }
+
         if !self.highlighter.should_expand_abbr(
             buffer,
             word_start,
@@ -3060,6 +3071,42 @@ mod tests {
             reedline_with_abbrevs_and_default_string_lit_check(&[("gc", "git commit")]);
         set_buffer_at_end(&mut reedline, "   ");
         assert!(reedline.try_expand_abbreviation_at_cursor(true).is_none());
+    }
+
+    #[test]
+    fn abbreviation_mid_word_cursor_on_submit_returns_none() {
+        let mut reedline =
+            reedline_with_abbrevs_and_default_string_lit_check(&[("gc", "git commit")]);
+        set_buffer_at_end(&mut reedline, "gcsomething");
+        reedline.run_edit_commands(&[EditCommand::MoveToPosition {
+            position: 2,
+            select: false,
+        }]);
+        assert!(
+            reedline.try_expand_abbreviation_at_cursor(true).is_none(),
+            "must not expand the prefix of a word when the cursor is mid-word"
+        );
+    }
+
+    #[test]
+    fn abbreviation_expands_before_trailing_text_on_submit() {
+        let mut reedline =
+            reedline_with_abbrevs_and_default_string_lit_check(&[("gc", "git commit")]);
+        set_buffer_at_end(&mut reedline, "gc rest");
+        reedline.run_edit_commands(&[EditCommand::MoveToPosition {
+            position: 2,
+            select: false,
+        }]);
+        let event = reedline.try_expand_abbreviation_at_cursor(true);
+        assert!(
+            event.is_some(),
+            "expected expansion at a real word boundary"
+        );
+        reedline.run_edit_commands(&match event.unwrap() {
+            ReedlineEvent::Edit(cmds) => cmds,
+            _ => panic!("expected Edit event"),
+        });
+        assert_eq!(reedline.current_buffer_contents(), "git commit rest");
     }
 
     // Feed one key as its own batch, mirroring real interactive input where each


### PR DESCRIPTION
<!-- Thanks for contributing to Reedline! -->

## Summary <!-- Must Have -->
<!--
Motivate this PR: why did you open it, how did you arrive at this solution?
Mention any changes to Reedline's public API or observable behavior, or mention that there are none.
-->

fixes #1124 

### Before <!-- Much Appreciated -->
<!--
Describe behavior, function or implementation BEFORE your changes.
If not applicable, just remove the heading.
-->

when `enter` was pressed, any characters before the cursor were treated as an separate word when the cursor was in the middle of a word. then a sequence like `gs|gs<enter>` where the cursor position is shown with `|` would result in an expansion of the first `gs` -> ie `git statusgs`

### After <!-- Much Appreciated -->
<!--
Describe behavior, function or implementation AFTER your changes.
If not applicable, just remove the heading.
-->

this behavior is no longer observed