### PR TITLE
fix(painter): don't re-use a bottom-flush prompt anchor after a scroll

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -146,6 +146,12 @@ pub struct Reedline {
     history_cursor_on_excluded: bool,
     input_mode: InputMode,
 
+    // Set when a menu event that re-queries the completer (Activate/Edit) is
+    // dispatched. The host completer can shell out and scroll the terminal, so
+    // the next paint re-verifies the prompt anchor. Consumed in `repaint`.
+    // See #1130.
+    completer_may_have_scrolled: bool,
+
     // State of the painter after a `ReedlineEvent::ExecuteHostCommand` was requested, used after
     // execution to decide if we can re-use the previous prompt or paint a new one.
     suspended_state: Option<PainterSuspendedState>,
@@ -303,6 +309,7 @@ impl Reedline {
             history_excluded_item: None,
             history_cursor_on_excluded: false,
             input_mode: InputMode::Regular,
+            completer_may_have_scrolled: false,
             suspended_state: None,
             last_render_snapshot: None,
             painter,
@@ -1270,6 +1277,7 @@ impl Reedline {
                 if self.active_menu().is_none() {
                     if let Some(menu) = self.menus.iter_mut().find(|menu| menu.name() == name) {
                         menu.menu_event(MenuEvent::Activate(self.quick_completions));
+                        self.completer_may_have_scrolled = true;
 
                         if self.quick_completions && menu.can_quick_complete() {
                             menu.update_values(
@@ -1355,6 +1363,8 @@ impl Reedline {
                     })
             }
             ReedlineEvent::MenuPageNext => {
+                // A page load re-queries the completer (list menu).
+                self.completer_may_have_scrolled |= self.active_menu().is_some();
                 self.active_menu()
                     .map_or(Ok(EventStatus::Inapplicable), |menu| {
                         menu.menu_event(MenuEvent::NextPage);
@@ -1362,6 +1372,8 @@ impl Reedline {
                     })
             }
             ReedlineEvent::MenuPagePrevious => {
+                // A page load re-queries the completer (list menu).
+                self.completer_may_have_scrolled |= self.active_menu().is_some();
                 self.active_menu()
                     .map_or(Ok(EventStatus::Inapplicable), |menu| {
                         menu.menu_event(MenuEvent::PreviousPage);
@@ -1498,6 +1510,7 @@ impl Reedline {
                             }
                             _ => {
                                 menu.menu_event(MenuEvent::Edit(self.quick_completions));
+                                self.completer_may_have_scrolled = true;
                                 menu.update_values(
                                     &mut self.editor,
                                     self.completer.as_mut(),
@@ -1525,6 +1538,7 @@ impl Reedline {
                         menu.menu_event(MenuEvent::Deactivate);
                     } else {
                         menu.menu_event(MenuEvent::Edit(self.quick_completions));
+                        self.completer_may_have_scrolled = true;
                     }
                 }
                 Ok(EventStatus::Handled)
@@ -2316,6 +2330,16 @@ impl Reedline {
                     &self.painter,
                 );
             }
+        }
+
+        // A menu Activate/Edit re-queried the host completer, which owns the tty
+        // and may shell out to a program that scrolls the terminal (nushell's
+        // external completer running `fzf --height`). Mark the anchor stale so
+        // the paint below re-verifies it instead of trusting a row the content
+        // may have scrolled past. Navigation and idle repaints keep the cached
+        // anchor. See #1130.
+        if std::mem::take(&mut self.completer_may_have_scrolled) {
+            self.painter.invalidate_prompt_start_row();
         }
 
         let menu = self.menus.iter().find(|menu| menu.is_active());

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -271,17 +271,18 @@ impl Drop for Reedline {
     }
 }
 
-/// Mark the painter's cached prompt anchor stale after a menu event that re-queries the
-/// completer.
+/// Mark the painter's cached prompt anchor stale around a menu running its completer,
+/// which may have left the cached row pointing at content that has scrolled. See
+/// [`ReedlineMenu::queries_host_completer`] for why only some completers count, and
+/// #1130 for the bug.
 ///
-/// A host-supplied completer owns the tty while it runs and may shell out to a program
-/// that scrolls the terminal (nushell's external completer running `fzf --height`),
-/// leaving the cached row pointing at content that has moved. Skipped for a menu the
-/// same keystroke deactivated, whose queued event nothing will consume, and for
-/// reedline's own history completer, which never yields the terminal, so neither costs a
-/// `cursor::position()` round-trip. Menu events that only move the selection never reach
-/// the completer and call [`Menu::menu_event`] directly. See #1130.
-fn note_completer_query(menu: &ReedlineMenu, painter: &mut Painter) {
+/// Also skipped for a menu the same keystroke deactivated, whose queued event nothing
+/// goes on to consume.
+///
+/// Call this from every event that reaches the completer, which is not the same set as
+/// the events that change the menu's selection: `MenuNext` splices a partial completion
+/// and queries, while `MenuPrevious` only moves and does not.
+fn invalidate_anchor_if_host_completer_runs(menu: &ReedlineMenu, painter: &mut Painter) {
     if menu.is_active() && menu.queries_host_completer() {
         painter.invalidate_prompt_start_row();
     }
@@ -1286,7 +1287,7 @@ impl Reedline {
                 if self.active_menu().is_none() {
                     if let Some(menu) = self.menus.iter_mut().find(|menu| menu.name() == name) {
                         menu.menu_event(MenuEvent::Activate(self.quick_completions));
-                        note_completer_query(menu, &mut self.painter);
+                        invalidate_anchor_if_host_completer_runs(menu, &mut self.painter);
 
                         if self.quick_completions && menu.can_quick_complete() {
                             menu.update_values(
@@ -1328,6 +1329,7 @@ impl Reedline {
                                 self.completer.as_mut(),
                                 self.history.as_ref(),
                             );
+                            invalidate_anchor_if_host_completer_runs(menu, &mut self.painter);
                         }
                         menu.menu_event(MenuEvent::NextElement);
                         Ok(EventStatus::Handled)
@@ -1371,11 +1373,13 @@ impl Reedline {
                         Ok(EventStatus::Handled)
                     })
             }
+            // These two spell out `active_menu()`, since that borrows all of `self` and
+            // the painter has to stay reachable alongside the menu.
             ReedlineEvent::MenuPageNext => {
                 match self.menus.iter_mut().find(|menu| menu.is_active()) {
                     Some(menu) => {
                         menu.menu_event(MenuEvent::NextPage);
-                        note_completer_query(menu, &mut self.painter);
+                        invalidate_anchor_if_host_completer_runs(menu, &mut self.painter);
                         Ok(EventStatus::Handled)
                     }
                     None => Ok(EventStatus::Inapplicable),
@@ -1385,7 +1389,7 @@ impl Reedline {
                 match self.menus.iter_mut().find(|menu| menu.is_active()) {
                     Some(menu) => {
                         menu.menu_event(MenuEvent::PreviousPage);
-                        note_completer_query(menu, &mut self.painter);
+                        invalidate_anchor_if_host_completer_runs(menu, &mut self.painter);
                         Ok(EventStatus::Handled)
                     }
                     None => Ok(EventStatus::Inapplicable),
@@ -1521,7 +1525,7 @@ impl Reedline {
                             }
                             _ => {
                                 menu.menu_event(MenuEvent::Edit(self.quick_completions));
-                                note_completer_query(menu, &mut self.painter);
+                                invalidate_anchor_if_host_completer_runs(menu, &mut self.painter);
                                 menu.update_values(
                                     &mut self.editor,
                                     self.completer.as_mut(),
@@ -1549,7 +1553,7 @@ impl Reedline {
                         menu.menu_event(MenuEvent::Deactivate);
                     } else {
                         menu.menu_event(MenuEvent::Edit(self.quick_completions));
-                        note_completer_query(menu, &mut self.painter);
+                        invalidate_anchor_if_host_completer_runs(menu, &mut self.painter);
                     }
                 }
                 Ok(EventStatus::Handled)
@@ -3466,6 +3470,57 @@ mod tests {
             .unwrap();
         assert!(menu_is_active(&reedline));
         reedline
+    }
+
+    /// Engine with a completion menu open over "th" and partial completions on, so
+    /// `MenuNext` reaches the completer through `can_partially_complete`.
+    fn engine_with_partial_completion_menu() -> Reedline {
+        let completer = Box::new(DefaultCompleter::new_with_wordlen(
+            vec![String::from("this"), String::from("that")],
+            1,
+        ));
+        let completion_menu = ReedlineMenu::EngineCompleter(Box::new(
+            ColumnarMenu::default().with_name("completion_menu"),
+        ));
+        let mut reedline = Reedline::create()
+            .with_completer(completer)
+            .with_menu(completion_menu)
+            .with_partial_completions(true);
+
+        reedline.run_edit_commands(&[EditCommand::InsertString(String::from("th"))]);
+        reedline
+            .handle_event(
+                &DefaultPrompt::default(),
+                ReedlineEvent::Menu(String::from("completion_menu")),
+            )
+            .unwrap();
+        assert!(menu_is_active(&reedline));
+        reedline
+    }
+
+    /// The anchor cache exists to keep `cursor::position()` off the hot path (#1090),
+    /// so an event may only spend that round-trip when it actually runs a host
+    /// completer. Which events those are does not follow from whether the menu's
+    /// selection moved: `MenuNext` splices a partial completion first, `MenuPrevious`
+    /// does not. See #1130.
+    #[rstest]
+    #[case::next_queries_the_completer(ReedlineEvent::MenuNext, false)]
+    #[case::previous_only_moves(ReedlineEvent::MenuPrevious, true)]
+    fn menu_events_invalidate_the_anchor_only_when_they_query(
+        #[case] event: ReedlineEvent,
+        #[case] stays_verified: bool,
+    ) {
+        let mut reedline = engine_with_partial_completion_menu();
+        reedline.painter.force_prompt_anchored_for_test(0);
+
+        reedline
+            .handle_event(&DefaultPrompt::default(), event)
+            .unwrap();
+
+        assert_eq!(
+            reedline.painter.prompt_anchor_is_verified_for_test(),
+            stays_verified
+        );
     }
 
     fn send_edit(reedline: &mut Reedline, command: EditCommand) {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -146,12 +146,6 @@ pub struct Reedline {
     history_cursor_on_excluded: bool,
     input_mode: InputMode,
 
-    // Set when a menu event that re-queries the completer (Activate/Edit) is
-    // dispatched. The host completer can shell out and scroll the terminal, so
-    // the next paint re-verifies the prompt anchor. Consumed in `repaint`.
-    // See #1130.
-    completer_may_have_scrolled: bool,
-
     // State of the painter after a `ReedlineEvent::ExecuteHostCommand` was requested, used after
     // execution to decide if we can re-use the previous prompt or paint a new one.
     suspended_state: Option<PainterSuspendedState>,
@@ -277,6 +271,22 @@ impl Drop for Reedline {
     }
 }
 
+/// Mark the painter's cached prompt anchor stale after a menu event that re-queries the
+/// completer.
+///
+/// A host-supplied completer owns the tty while it runs and may shell out to a program
+/// that scrolls the terminal (nushell's external completer running `fzf --height`),
+/// leaving the cached row pointing at content that has moved. Skipped for a menu the
+/// same keystroke deactivated, whose queued event nothing will consume, and for
+/// reedline's own history completer, which never yields the terminal, so neither costs a
+/// `cursor::position()` round-trip. Menu events that only move the selection never reach
+/// the completer and call [`Menu::menu_event`] directly. See #1130.
+fn note_completer_query(menu: &ReedlineMenu, painter: &mut Painter) {
+    if menu.is_active() && menu.queries_host_completer() {
+        painter.invalidate_prompt_start_row();
+    }
+}
+
 impl Reedline {
     const FILTERED_ITEM_ID: HistoryItemId = HistoryItemId(i64::MAX);
 
@@ -309,7 +319,6 @@ impl Reedline {
             history_excluded_item: None,
             history_cursor_on_excluded: false,
             input_mode: InputMode::Regular,
-            completer_may_have_scrolled: false,
             suspended_state: None,
             last_render_snapshot: None,
             painter,
@@ -1277,7 +1286,7 @@ impl Reedline {
                 if self.active_menu().is_none() {
                     if let Some(menu) = self.menus.iter_mut().find(|menu| menu.name() == name) {
                         menu.menu_event(MenuEvent::Activate(self.quick_completions));
-                        self.completer_may_have_scrolled = true;
+                        note_completer_query(menu, &mut self.painter);
 
                         if self.quick_completions && menu.can_quick_complete() {
                             menu.update_values(
@@ -1363,22 +1372,24 @@ impl Reedline {
                     })
             }
             ReedlineEvent::MenuPageNext => {
-                // A page load re-queries the completer (list menu).
-                self.completer_may_have_scrolled |= self.active_menu().is_some();
-                self.active_menu()
-                    .map_or(Ok(EventStatus::Inapplicable), |menu| {
+                match self.menus.iter_mut().find(|menu| menu.is_active()) {
+                    Some(menu) => {
                         menu.menu_event(MenuEvent::NextPage);
+                        note_completer_query(menu, &mut self.painter);
                         Ok(EventStatus::Handled)
-                    })
+                    }
+                    None => Ok(EventStatus::Inapplicable),
+                }
             }
             ReedlineEvent::MenuPagePrevious => {
-                // A page load re-queries the completer (list menu).
-                self.completer_may_have_scrolled |= self.active_menu().is_some();
-                self.active_menu()
-                    .map_or(Ok(EventStatus::Inapplicable), |menu| {
+                match self.menus.iter_mut().find(|menu| menu.is_active()) {
+                    Some(menu) => {
                         menu.menu_event(MenuEvent::PreviousPage);
+                        note_completer_query(menu, &mut self.painter);
                         Ok(EventStatus::Handled)
-                    })
+                    }
+                    None => Ok(EventStatus::Inapplicable),
+                }
             }
             ReedlineEvent::HistoryHintComplete => {
                 let hint = self.hinter.as_mut().map(|h| h.complete_hint());
@@ -1510,7 +1521,7 @@ impl Reedline {
                             }
                             _ => {
                                 menu.menu_event(MenuEvent::Edit(self.quick_completions));
-                                self.completer_may_have_scrolled = true;
+                                note_completer_query(menu, &mut self.painter);
                                 menu.update_values(
                                     &mut self.editor,
                                     self.completer.as_mut(),
@@ -1538,7 +1549,7 @@ impl Reedline {
                         menu.menu_event(MenuEvent::Deactivate);
                     } else {
                         menu.menu_event(MenuEvent::Edit(self.quick_completions));
-                        self.completer_may_have_scrolled = true;
+                        note_completer_query(menu, &mut self.painter);
                     }
                 }
                 Ok(EventStatus::Handled)
@@ -2330,16 +2341,6 @@ impl Reedline {
                     &self.painter,
                 );
             }
-        }
-
-        // A menu Activate/Edit re-queried the host completer, which owns the tty
-        // and may shell out to a program that scrolls the terminal (nushell's
-        // external completer running `fzf --height`). Mark the anchor stale so
-        // the paint below re-verifies it instead of trusting a row the content
-        // may have scrolled past. Navigation and idle repaints keep the cached
-        // anchor. See #1130.
-        if std::mem::take(&mut self.completer_may_have_scrolled) {
-            self.painter.invalidate_prompt_start_row();
         }
 
         let menu = self.menus.iter().find(|menu| menu.is_active());

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -395,6 +395,19 @@ impl ReedlineMenu {
         }
     }
 
+    /// Whether updating this menu runs a completer supplied by the host.
+    ///
+    /// Host completers own the tty while they run and may shell out to a program that
+    /// scrolls the terminal (nushell's external completer running `fzf --height`),
+    /// leaving the painter's cached prompt anchor pointing at the wrong row.
+    /// Reedline cannot tell whether a given completer does that, so any host completer
+    /// is assumed to. [`HistoryMenu`](Self::HistoryMenu) is the one case it can rule
+    /// out: it is answered by reedline's own in-process [`HistoryCompleter`], which
+    /// never yields the terminal. See #1130.
+    pub(crate) fn queries_host_completer(&self) -> bool {
+        !matches!(self, Self::HistoryMenu(_))
+    }
+
     pub(crate) fn can_partially_complete(
         &mut self,
         values_updated: bool,
@@ -571,7 +584,26 @@ impl Menu for ReedlineMenu {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DefaultCompleter;
     use rstest::rstest;
+
+    /// The prompt anchor is only re-verified for menus that can run host code, since
+    /// that is the only thing reedline cannot see past. A history menu is answered
+    /// in-process, so it must not pay a `cursor::position()` round-trip per keystroke.
+    /// See #1130.
+    #[test]
+    fn only_a_host_completer_can_have_scrolled_the_terminal() {
+        let menu = || Box::new(ColumnarMenu::default()) as Box<dyn Menu>;
+
+        assert!(ReedlineMenu::EngineCompleter(menu()).queries_host_completer());
+        assert!(ReedlineMenu::WithCompleter {
+            menu: menu(),
+            completer: Box::<DefaultCompleter>::default(),
+        }
+        .queries_host_completer());
+
+        assert!(!ReedlineMenu::HistoryMenu(menu()).queries_host_completer());
+    }
 
     #[rstest]
     #[case::bool_only_false(false, None, InputMode::CursorPrefix)]

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1219,6 +1219,13 @@ impl Painter {
     pub(crate) fn force_prompt_anchored_for_test(&mut self, row: u16) {
         self.prompt_start_row = PromptStartRow::Verified(row);
     }
+
+    /// Whether the cached anchor is still trusted, so a test can pin which events cost
+    /// a re-verify and which keep #1090's query-free path.
+    #[cfg(test)]
+    pub(crate) fn prompt_anchor_is_verified_for_test(&self) -> bool {
+        matches!(self.prompt_start_row, PromptStartRow::Verified(_))
+    }
 }
 
 #[cfg(test)]

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -562,37 +562,27 @@ impl Painter {
             self.just_resized = false;
         }
 
-        // Lines and distance parameters
-        let remaining_lines = self.remaining_lines();
-        let required_lines = lines.required_lines(screen_width, false, menu);
-
-        // Marking the painter state as larger buffer to avoid animations
-        self.large_buffer = required_lines >= screen_height;
-
-        // True if the prompt has scrolled above the cached
-        // `prompt_start_row` and the caller must re-anchor at row 0.
-        // When not verified, query the terminal; promote to verified if
-        // the query confirms no drift, so later paints can skip it.
+        // Reconcile a stale anchor: something yielded the tty (a resize, or an
+        // external completer running e.g. `fzf --height`) and may have scrolled
+        // our content since the last paint.
         let should_reset_anchor = match self.prompt_start_row {
             PromptStartRow::Verified(_) => false,
-            PromptStartRow::Stale(row) => match cursor::position() {
-                // The `+1` handles the case where the previous output
-                // ended without a newline, leaving the cursor on the
-                // same row as the next prompt.
-                Ok(position) => {
-                    let drifted = position.1 + 1 < row;
-                    if !drifted {
-                        self.prompt_start_row.mark_verified(row);
+            PromptStartRow::Stale(row) => {
+                // Cursor above the cached row => content scrolled up while the
+                // tty was yielded. Re-anchor to the cursor (ground truth) rather
+                // than homing to row 0, which would yank the prompt to the top.
+                // The `+1` allows for output that left the cursor on the prompt
+                // row. See nushell/reedline#1130.
+                match cursor::position() {
+                    Ok(position) if position.1 + 1 < row => {
+                        self.prompt_start_row.mark_verified(position.1);
                     }
-                    drifted
+                    Ok(_) | Err(_) => self.prompt_start_row.mark_verified(row),
                 }
-                Err(_) => false,
-            },
-            // `initialize_prompt_position` runs before any
-            // `repaint_buffer`, so this branch is unreachable in normal
-            // flow. Panic loudly in debug builds; in release, force a
-            // re-anchor since the alternative is drawing over screen
-            // content at row 0 with no scroll.
+                false
+            }
+            // Unreachable in normal flow (initialize_prompt_position runs
+            // first); in release, reset rather than draw over row 0 content.
             PromptStartRow::Unverified => {
                 debug_assert!(
                     false,
@@ -601,6 +591,14 @@ impl Painter {
                 true
             }
         };
+
+        // Distance parameters, computed after reconciling so they reflect the
+        // re-anchored row.
+        let remaining_lines = self.remaining_lines();
+        let required_lines = lines.required_lines(screen_width, false, menu);
+
+        // Marking the painter state as larger buffer to avoid animations
+        self.large_buffer = required_lines >= screen_height;
 
         // Moving the start position of the cursor based on the size of the required lines
         if self.large_buffer || should_reset_anchor {

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -153,6 +153,10 @@ impl Write for W {
 #[derive(Debug, PartialEq, Eq)]
 pub struct PainterSuspendedState {
     previous_prompt_rows_range: RangeInclusive<u16>,
+    /// Whether the prompt reached the last row of the screen it was captured on.
+    /// Recorded here rather than tested at re-use, since by then the screen may have
+    /// been resized by whatever ran in between.
+    was_flush_at_bottom: bool,
 }
 
 /// Screen bounds of the right prompt when it is visible.
@@ -193,30 +197,23 @@ enum PromptRowSelector {
 fn select_prompt_row(
     suspended_state: Option<&PainterSuspendedState>,
     (column, row): (u16, u16), // NOTE: Positions are 0 based here
-    screen_height: u16,
 ) -> PromptRowSelector {
     if let Some(painter_state) = suspended_state {
-        // The painter was suspended, try to re-use the last prompt position to avoid
-        // unnecessarily making new prompts.
+        // The painter was suspended, so re-use the last prompt position rather than
+        // making a new prompt, as long as the cursor came back inside it.
         //
-        // Re-use is only sound when the previous prompt did not sit flush against
-        // the bottom of the screen. When it did, a suspended program that scrolls
-        // the terminal (e.g. an fzf keybinding with little room left) leaves the
-        // cursor pinned on the bottom row, still inside the stored range, which
-        // is indistinguishable from an in-place return. Re-using there re-anchors
-        // the prompt over the scrolled-up output. Fall through to a fresh prompt
-        // in that ambiguous case. See nushell/reedline#1130.
-        let last_row = screen_height.saturating_sub(1);
-        if *painter_state.previous_prompt_rows_range.end() < last_row
+        // Re-use is only sound when the previous prompt did not sit flush against the
+        // bottom of the screen. When it did, a suspended program that scrolls the
+        // terminal (an fzf keybinding with little room left) returns with the cursor
+        // pinned on the bottom row, still inside the stored range, which is
+        // indistinguishable from an in-place return. Re-using there would redraw the
+        // prompt over the scrolled-up output, so fall through to a fresh prompt in that
+        // ambiguous case. See nushell/reedline#1130.
+        if !painter_state.was_flush_at_bottom
             && painter_state.previous_prompt_rows_range.contains(&row)
         {
-            // Cursor is still in the range of the previous prompt, re-use it.
             let start_row = *painter_state.previous_prompt_rows_range.start();
             return PromptRowSelector::UseExistingPrompt { start_row };
-        } else {
-            // There was some output, the cursor is outside of the range of the
-            // previous prompt, or the prompt was flush at the bottom and may have
-            // scrolled, so make a fresh new prompt.
         }
     }
 
@@ -461,6 +458,9 @@ impl Painter {
         let final_row = start_row + self.last_required_lines;
         PainterSuspendedState {
             previous_prompt_rows_range: start_row..=final_row,
+            // `final_row` can overshoot the last visible row for a prompt at the very
+            // bottom, so this is `>=` rather than an equality.
+            was_flush_at_bottom: final_row >= self.screen_height().saturating_sub(1),
         }
     }
 
@@ -484,8 +484,7 @@ impl Painter {
                 size
             }
         };
-        let prompt_selector =
-            select_prompt_row(suspended_state, cursor::position()?, self.screen_height());
+        let prompt_selector = select_prompt_row(suspended_state, cursor::position()?);
         let new_row = match prompt_selector {
             PromptRowSelector::UseExistingPrompt { start_row } => start_row,
             PromptRowSelector::MakeNewPrompt { new_row } => {
@@ -1228,6 +1227,7 @@ mod tests {
     use crate::menu::MenuEvent;
     use crate::{Color, Completer, Editor, PromptHistorySearch, Suggestion};
     use pretty_assertions::assert_eq;
+    use rstest::rstest;
     use std::borrow::Cow;
     use std::sync::{Arc, Mutex};
 
@@ -1341,7 +1341,7 @@ mod tests {
     #[test]
     fn test_select_new_prompt_with_no_state_no_output() {
         assert_eq!(
-            select_prompt_row(None, (0, 12), 24),
+            select_prompt_row(None, (0, 12)),
             PromptRowSelector::MakeNewPrompt { new_row: 12 }
         );
     }
@@ -1349,7 +1349,7 @@ mod tests {
     #[test]
     fn test_select_new_prompt_with_no_state_but_output() {
         assert_eq!(
-            select_prompt_row(None, (3, 12), 24),
+            select_prompt_row(None, (3, 12)),
             PromptRowSelector::MakeNewPrompt { new_row: 13 }
         );
     }
@@ -1358,14 +1358,14 @@ mod tests {
     fn test_select_existing_prompt() {
         let state = PainterSuspendedState {
             previous_prompt_rows_range: 11..=13,
+            was_flush_at_bottom: false,
         };
-        // Prompt sits well above the bottom of a 24-row screen, so re-use holds.
         assert_eq!(
-            select_prompt_row(Some(&state), (0, 12), 24),
+            select_prompt_row(Some(&state), (0, 12)),
             PromptRowSelector::UseExistingPrompt { start_row: 11 }
         );
         assert_eq!(
-            select_prompt_row(Some(&state), (3, 12), 24),
+            select_prompt_row(Some(&state), (3, 12)),
             PromptRowSelector::UseExistingPrompt { start_row: 11 }
         );
     }
@@ -1379,24 +1379,36 @@ mod tests {
     // output, so the ambiguous bottom case must make a fresh prompt instead.
     #[test]
     fn test_select_prompt_row_does_not_reuse_when_flush_at_bottom() {
-        // Screen height 8 (rows 0..=7); prompt occupied rows 5..=7 and the
-        // range reaches the last row (7).
         let state = PainterSuspendedState {
             previous_prompt_rows_range: 5..=7,
+            was_flush_at_bottom: true,
         };
         assert_eq!(
-            select_prompt_row(Some(&state), (0, 7), 8),
+            select_prompt_row(Some(&state), (0, 7)),
             PromptRowSelector::MakeNewPrompt { new_row: 7 }
         );
+    }
 
-        // `state_before_suspension` can even push `final_row` past the last
-        // visible row when the prompt is at the very bottom; still no re-use.
-        let overshoot = PainterSuspendedState {
-            previous_prompt_rows_range: 5..=8,
-        };
+    // The flush-at-bottom fact is captured against the screen the prompt was
+    // suspended on, since whatever runs in between may resize the terminal.
+    #[rstest]
+    #[case::well_above_bottom(2, 3, false)]
+    #[case::reaches_last_row(5, 2, true)]
+    // A prompt at the very bottom pushes `final_row` past the last visible row.
+    #[case::overshoots_last_row(5, 3, true)]
+    fn test_state_before_suspension_records_flush_at_bottom(
+        #[case] start_row: u16,
+        #[case] required_lines: u16,
+        #[case] expected: bool,
+    ) {
+        let mut painter = Painter::new(W::sink());
+        painter.handle_resize(80, 8); // rows 0..=7
+        painter.prompt_start_row.mark_verified(start_row);
+        painter.last_required_lines = required_lines;
+
         assert_eq!(
-            select_prompt_row(Some(&overshoot), (0, 7), 8),
-            PromptRowSelector::MakeNewPrompt { new_row: 7 }
+            painter.state_before_suspension().was_flush_at_bottom,
+            expected
         );
     }
 

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -565,32 +565,26 @@ impl Painter {
         // Reconcile a stale anchor: something yielded the tty (a resize, or an
         // external completer running e.g. `fzf --height`) and may have scrolled
         // our content since the last paint.
-        let should_reset_anchor = match self.prompt_start_row {
-            PromptStartRow::Verified(_) => false,
-            PromptStartRow::Stale(row) => {
-                // Cursor above the cached row => content scrolled up while the
-                // tty was yielded. Re-anchor to the cursor (ground truth) rather
-                // than homing to row 0, which would yank the prompt to the top.
-                // The `+1` allows for output that left the cursor on the prompt
-                // row. See nushell/reedline#1130.
-                match cursor::position() {
-                    Ok(position) if position.1 + 1 < row => {
-                        self.prompt_start_row.mark_verified(position.1);
-                    }
-                    Ok(_) | Err(_) => self.prompt_start_row.mark_verified(row),
-                }
-                false
-            }
-            // Unreachable in normal flow (initialize_prompt_position runs
-            // first); in release, reset rather than draw over row 0 content.
-            PromptStartRow::Unverified => {
-                debug_assert!(
-                    false,
-                    "repaint_buffer reached before initialize_prompt_position"
-                );
-                true
-            }
-        };
+        if let PromptStartRow::Stale(row) = self.prompt_start_row {
+            // Cursor above the cached row => content scrolled up while the tty
+            // was yielded. Re-anchor to the cursor (ground truth) rather than
+            // homing to row 0, which would yank the prompt to the top. The `+1`
+            // allows for output that left the cursor on the prompt row.
+            // See nushell/reedline#1130.
+            let anchor = match cursor::position() {
+                Ok((_, cursor_row)) if cursor_row + 1 < row => cursor_row,
+                _ => row,
+            };
+            self.prompt_start_row.mark_verified(anchor);
+        }
+
+        // Unreachable in normal flow (initialize_prompt_position runs first);
+        // in release, home to row 0 rather than draw over the content there.
+        let anchor_uninitialized = self.prompt_start_row == PromptStartRow::Unverified;
+        debug_assert!(
+            !anchor_uninitialized,
+            "repaint_buffer reached before initialize_prompt_position"
+        );
 
         // Distance parameters, computed after reconciling so they reflect the
         // re-anchored row.
@@ -601,7 +595,7 @@ impl Painter {
         self.large_buffer = required_lines >= screen_height;
 
         // Moving the start position of the cursor based on the size of the required lines
-        if self.large_buffer || should_reset_anchor {
+        if self.large_buffer || anchor_uninitialized {
             for _ in 0..screen_height.saturating_sub(lines_before_cursor) {
                 self.stdout.queue(Print(&coerce_crlf("\n")))?;
             }

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -193,17 +193,30 @@ enum PromptRowSelector {
 fn select_prompt_row(
     suspended_state: Option<&PainterSuspendedState>,
     (column, row): (u16, u16), // NOTE: Positions are 0 based here
+    screen_height: u16,
 ) -> PromptRowSelector {
     if let Some(painter_state) = suspended_state {
         // The painter was suspended, try to re-use the last prompt position to avoid
         // unnecessarily making new prompts.
-        if painter_state.previous_prompt_rows_range.contains(&row) {
+        //
+        // Re-use is only sound when the previous prompt did not sit flush against
+        // the bottom of the screen. When it did, a suspended program that scrolls
+        // the terminal (e.g. an fzf keybinding with little room left) leaves the
+        // cursor pinned on the bottom row, still inside the stored range, which
+        // is indistinguishable from an in-place return. Re-using there re-anchors
+        // the prompt over the scrolled-up output. Fall through to a fresh prompt
+        // in that ambiguous case. See nushell/reedline#1130.
+        let last_row = screen_height.saturating_sub(1);
+        if *painter_state.previous_prompt_rows_range.end() < last_row
+            && painter_state.previous_prompt_rows_range.contains(&row)
+        {
             // Cursor is still in the range of the previous prompt, re-use it.
             let start_row = *painter_state.previous_prompt_rows_range.start();
             return PromptRowSelector::UseExistingPrompt { start_row };
         } else {
-            // There was some output or cursor is outside of the range of previous prompt make a
-            // fresh new prompt.
+            // There was some output, the cursor is outside of the range of the
+            // previous prompt, or the prompt was flush at the bottom and may have
+            // scrolled, so make a fresh new prompt.
         }
     }
 
@@ -471,7 +484,8 @@ impl Painter {
                 size
             }
         };
-        let prompt_selector = select_prompt_row(suspended_state, cursor::position()?);
+        let prompt_selector =
+            select_prompt_row(suspended_state, cursor::position()?, self.screen_height());
         let new_row = match prompt_selector {
             PromptRowSelector::UseExistingPrompt { start_row } => start_row,
             PromptRowSelector::MakeNewPrompt { new_row } => {
@@ -1335,7 +1349,7 @@ mod tests {
     #[test]
     fn test_select_new_prompt_with_no_state_no_output() {
         assert_eq!(
-            select_prompt_row(None, (0, 12)),
+            select_prompt_row(None, (0, 12), 24),
             PromptRowSelector::MakeNewPrompt { new_row: 12 }
         );
     }
@@ -1343,7 +1357,7 @@ mod tests {
     #[test]
     fn test_select_new_prompt_with_no_state_but_output() {
         assert_eq!(
-            select_prompt_row(None, (3, 12)),
+            select_prompt_row(None, (3, 12), 24),
             PromptRowSelector::MakeNewPrompt { new_row: 13 }
         );
     }
@@ -1353,13 +1367,44 @@ mod tests {
         let state = PainterSuspendedState {
             previous_prompt_rows_range: 11..=13,
         };
+        // Prompt sits well above the bottom of a 24-row screen, so re-use holds.
         assert_eq!(
-            select_prompt_row(Some(&state), (0, 12)),
+            select_prompt_row(Some(&state), (0, 12), 24),
             PromptRowSelector::UseExistingPrompt { start_row: 11 }
         );
         assert_eq!(
-            select_prompt_row(Some(&state), (3, 12)),
+            select_prompt_row(Some(&state), (3, 12), 24),
             PromptRowSelector::UseExistingPrompt { start_row: 11 }
+        );
+    }
+
+    // Regression test for nushell/reedline#1130.
+    //
+    // A multi-line prompt flush against the bottom of the screen is suspended
+    // for an fzf-style keybinding. The program scrolls the terminal and returns
+    // with the cursor pinned on the bottom row, still inside the stored range.
+    // Re-using the old anchor would redraw the prompt over the scrolled-up
+    // output, so the ambiguous bottom case must make a fresh prompt instead.
+    #[test]
+    fn test_select_prompt_row_does_not_reuse_when_flush_at_bottom() {
+        // Screen height 8 (rows 0..=7); prompt occupied rows 5..=7 and the
+        // range reaches the last row (7).
+        let state = PainterSuspendedState {
+            previous_prompt_rows_range: 5..=7,
+        };
+        assert_eq!(
+            select_prompt_row(Some(&state), (0, 7), 8),
+            PromptRowSelector::MakeNewPrompt { new_row: 7 }
+        );
+
+        // `state_before_suspension` can even push `final_row` past the last
+        // visible row when the prompt is at the very bottom; still no re-use.
+        let overshoot = PainterSuspendedState {
+            previous_prompt_rows_range: 5..=8,
+        };
+        assert_eq!(
+            select_prompt_row(Some(&overshoot), (0, 7), 8),
+            PromptRowSelector::MakeNewPrompt { new_row: 7 }
         );
     }
 

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -199,16 +199,12 @@ fn select_prompt_row(
     (column, row): (u16, u16), // NOTE: Positions are 0 based here
 ) -> PromptRowSelector {
     if let Some(painter_state) = suspended_state {
-        // The painter was suspended, so re-use the last prompt position rather than
-        // making a new prompt, as long as the cursor came back inside it.
-        //
-        // Re-use is only sound when the previous prompt did not sit flush against the
-        // bottom of the screen. When it did, a suspended program that scrolls the
-        // terminal (an fzf keybinding with little room left) returns with the cursor
-        // pinned on the bottom row, still inside the stored range, which is
-        // indistinguishable from an in-place return. Re-using there would redraw the
-        // prompt over the scrolled-up output, so fall through to a fresh prompt in that
-        // ambiguous case. See nushell/reedline#1130.
+        // Re-use the previous prompt position when the cursor came back inside it,
+        // unless that prompt sat flush against the bottom of the screen. A suspended
+        // program that scrolled the terminal returns with the cursor pinned on the
+        // bottom row, still inside the stored range and indistinguishable from an
+        // in-place return, so re-using there would redraw over the scrolled-up output.
+        // See nushell/reedline#1130.
         if !painter_state.was_flush_at_bottom
             && painter_state.previous_prompt_rows_range.contains(&row)
         {
@@ -561,9 +557,9 @@ impl Painter {
             self.just_resized = false;
         }
 
-        // Reconcile a stale anchor: something yielded the tty (a resize, or an
-        // external completer running e.g. `fzf --height`) and may have scrolled
-        // our content since the last paint.
+        // Reconcile a stale anchor: something yielded the tty since the last paint
+        // (a resize, an external completer, `$EDITOR`) and may have scrolled our
+        // content.
         if let PromptStartRow::Stale(row) = self.prompt_start_row {
             // Cursor above the cached row => content scrolled up while the tty
             // was yielded. Re-anchor to the cursor (ground truth) rather than


### PR DESCRIPTION
## Summary <!-- Must Have -->
<!--
Motivate this PR: why did you open it, how did you arrive at this solution?
Mention any changes to Reedline's public API or observable behavior, or mention that there are none.
-->
When an external completer scrolls the terminal (`fzf --height` with little room below the prompt), the prompt landed in the wrong palce after the menu closed, since nushell/reedline#1090 trusts a `Verified` anchor without re-querying and the completer path never marked it stale.

Two commits:

#### re-anchor the prompt to the cursor after an external scroll
- After a menu `Activate`/`Edit`/page re-queries the completer, mark the anchor stale so the next paint re-verifies it.
- On drift, re-anchor to the queried cursor row instead of homing to row 0, which yanked the prompt to the top.
- The stale flag is gated to completer-querying events, so navigation and idle repaints keep nushell/reedline#1090's query-free path.
- Fixes nushell/reedline#1130.
But might be redundant depending on what comes out of the discussion in nushell/nushell#18771.

#### don't re-use a bottom-flush prompt anchor after a scroll
- A separate latent bug on the suspend/resume path (`ExecuteHostCommand`):
  `select_prompt_row` re-used a prompt range flush against the screen bottom and drew over scrolled-up output.
- Not a regression (identical on 0.48)
