### PR TITLE
Stronger contracts around completions

### DIFF
--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -34,6 +34,35 @@ impl Span {
     }
 }
 
+/// Buffer text and cursor position the completion was computed against.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CompletionOrigin {
+    pub(crate) buffer: String,
+    pub(crate) insertion_point: usize,
+}
+
+impl CompletionOrigin {
+    /// Buffer/cursor for stale results.
+    pub fn new(buffer: impl Into<String>, insertion_point: usize) -> Self {
+        Self {
+            buffer: buffer.into(),
+            insertion_point,
+        }
+    }
+}
+
+/// Longest common prefix extension computed by the completer.
+///
+/// When present, reedline splices `insert` over `span` verbatim.
+/// Absent — reedline uses its own LCP derivation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Partial {
+    /// Buffer range to replace.
+    pub span: Span,
+    /// Text to splice in.
+    pub insert: String,
+}
+
 /// The outcome of a [`Completer::complete`] request.
 ///
 /// A synchronous completer only ever produces [`Fresh`](Self::Fresh). An

--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -63,54 +63,86 @@ pub struct Partial {
     pub insert: String,
 }
 
-/// The outcome of a [`Completer::complete`] request.
-///
-/// A synchronous completer only ever produces [`Fresh`](Self::Fresh). An
-/// asynchronous completer that computes in the background reports its progress
-/// through this type.
+/// Outcome of a [`Completer::complete`] request.
 #[derive(Debug, Clone)]
 pub enum CompletionResult {
-    /// Final, authoritative results. No further computation is in flight.
-    Fresh(Suggestions),
-    /// Best-effort results to show in the moment; a fresh computation is still running and
-    /// will replace these once it finishes.
-    Stale(Suggestions),
-    /// No results are available yet; a computation is spinning in the background.
+    /// Authoritative results.
+    Fresh {
+        /// The suggestions.
+        suggestions: Suggestions,
+        /// Partial completion prefix.
+        partial: Option<Partial>,
+    },
+    /// Best-effort results while computation is in flight.
+    Stale {
+        /// The suggestions.
+        suggestions: Suggestions,
+        /// Buffer/cursor these were computed against.
+        origin: CompletionOrigin,
+        /// Partial completion prefix.
+        partial: Option<Partial>,
+    },
+    /// No results yet; computation in progress.
     Pending,
 }
 
 impl CompletionResult {
-    /// Wrap authoritative results.
+    /// Wrap authoritative results with no partial.
     pub fn fresh(suggestions: impl Into<Suggestions>) -> Self {
-        CompletionResult::Fresh(suggestions.into())
+        CompletionResult::Fresh {
+            suggestions: suggestions.into(),
+            partial: None,
+        }
     }
 
-    /// Best-effort fallback while an authoritative result is still computing:
-    /// [`Stale`](Self::Stale) when there is something to show now, else
-    /// [`Pending`](Self::Pending).
-    pub fn stale_or_pending(fallback: Suggestions) -> Self {
+    /// Stale result if there is something to show, else Pending.
+    pub fn stale_or_pending(fallback: Suggestions, origin: CompletionOrigin) -> Self {
         if fallback.is_empty() {
             CompletionResult::Pending
         } else {
-            CompletionResult::Stale(fallback)
+            CompletionResult::Stale {
+                suggestions: fallback,
+                origin,
+                partial: None,
+            }
         }
+    }
+
+    /// Attach a partial completion prefix.
+    pub fn with_partial(mut self, partial: Option<Partial>) -> Self {
+        match &mut self {
+            Self::Fresh { partial: slot, .. } | Self::Stale { partial: slot, .. } => {
+                *slot = partial;
+            }
+            Self::Pending => {}
+        }
+        self
     }
 
     /// Borrow the suggestions this result carries (empty for [`Pending`](Self::Pending)).
     pub fn suggestions(&self) -> &[Suggestion] {
         match self {
-            CompletionResult::Fresh(values) | CompletionResult::Stale(values) => values,
+            CompletionResult::Fresh { suggestions, .. }
+            | CompletionResult::Stale { suggestions, .. } => suggestions,
             CompletionResult::Pending => &[],
         }
     }
 
-    /// Move the shared suggestion list out of the result without copying.
-    ///
-    /// Returns `None` for [`Pending`](Self::Pending) nothing is settled yet, so
-    /// callers should keep whatever they are already displaying.
+    /// The completer-supplied partial completion, if any.
+    pub fn partial(&self) -> Option<&Partial> {
+        match self {
+            CompletionResult::Fresh { partial, .. } | CompletionResult::Stale { partial, .. } => {
+                partial.as_ref()
+            }
+            CompletionResult::Pending => None,
+        }
+    }
+
+    /// Move the shared suggestion list out without copying.
     pub fn into_shared(self) -> Option<Suggestions> {
         match self {
-            CompletionResult::Fresh(values) | CompletionResult::Stale(values) => Some(values),
+            CompletionResult::Fresh { suggestions, .. }
+            | CompletionResult::Stale { suggestions, .. } => Some(suggestions),
             CompletionResult::Pending => None,
         }
     }

--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -2,5 +2,8 @@ mod base;
 mod default;
 pub(crate) mod history;
 
-pub use base::{Completer, CompletionResult, CompletionStatus, Span, Suggestion, Suggestions};
+pub use base::{
+    Completer, CompletionOrigin, CompletionResult, CompletionStatus, Partial, Span, Suggestion,
+    Suggestions,
+};
 pub use default::DefaultCompleter;

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -82,8 +82,12 @@ impl Editor {
         &self.line_buffer
     }
 
-    /// Set the current [`LineBuffer`].
-    /// [`UndoBehavior`] specifies how this change should be reflected on the undo stack.
+    /// Mutable [`LineBuffer`] access, no undo.
+    pub(crate) fn line_buffer_mut(&mut self) -> &mut LineBuffer {
+        &mut self.line_buffer
+    }
+
+    /// Set the [`LineBuffer`] with undo behavior.
     pub(crate) fn set_line_buffer(&mut self, line_buffer: LineBuffer, undo_behavior: UndoBehavior) {
         self.line_buffer = line_buffer;
         self.update_undo_state(undo_behavior);
@@ -1192,9 +1196,7 @@ impl Editor {
         self.line_buffer.selection_anchor()?;
         let cursor = self.line_buffer.cursor();
 
-        // Inclusivity is carried by the range geometry now: `put_cursor` widens
-        // the head for block / Vi-normal selections, so the selected span is just
-        // the cursor's range — no captured-inclusivity `+1`.
+        // Inclusivity is geometric (widened by put_cursor).
         Some((cursor.start(), cursor.end().min(self.line_buffer.len())))
     }
 
@@ -1236,9 +1238,7 @@ impl Editor {
     }
 
     fn move_word_right(&mut self, select: bool) {
-        // emacs `M-f`: end of the word the cursor is inside (no skip). Under a bar
-        // caret `Word{End}` resolves to the word's *trailing boundary*, which is
-        // exactly `word_right_index` — so the verb path now expresses it directly.
+        // emacs M-f: end of current word, no skip.
         self.apply_move(
             word_target(WordKind::Unicode, WordEdge::End, Direction::Forward),
             select,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,8 @@ pub use highlighter::{AbbrExpandContext, ExampleHighlighter, Highlighter, Simple
 
 mod completion;
 pub use completion::{
-    Completer, CompletionResult, CompletionStatus, DefaultCompleter, Span, Suggestion, Suggestions,
+    Completer, CompletionOrigin, CompletionResult, CompletionStatus, DefaultCompleter, Partial,
+    Span, Suggestion, Suggestions,
 };
 
 mod hinter;

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -2,9 +2,8 @@ use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
     menu_functions::{
-        available_lines, can_partially_complete, get_match_indices, replace_in_buffer,
-        resolve_completer_input, scroll_offset, style_suggestion, truncate_with_ansi,
-        CompletionDisplay,
+        available_lines, get_match_indices, resolve_completer_input, scroll_offset,
+        style_suggestion, truncate_with_ansi, CompletionDisplay,
     },
     painting::Painter,
     Completer, Suggestion,
@@ -76,7 +75,7 @@ pub struct ColumnarMenu {
     /// yet. While set, the menu draws nothing rather than a premature
     /// "NO RECORDS FOUND" (which is reserved for a settled, genuinely empty result).
     awaiting_results: bool,
-    /// column position of the cursor. Starts from 0
+    /// Column position
     col_pos: u16,
     /// row position in the menu. Starts from 0
     row_pos: u16,
@@ -165,7 +164,7 @@ impl ColumnarMenu {
     fn move_previous(&mut self) {
         let new_index = match self.index().checked_sub(1) {
             Some(index) => index,
-            None => self.completions.values.len().saturating_sub(1),
+            None => self.completions.suggestions().len().saturating_sub(1),
         };
 
         (self.row_pos, self.col_pos) = self.position_from_index(new_index);
@@ -297,11 +296,6 @@ impl ColumnarMenu {
             TraversalDirection::Horizontal => self.row_pos * self.get_used_cols() + self.col_pos,
         };
         index.into()
-    }
-
-    /// Get selected value from the menu
-    fn get_value(&self) -> Option<Suggestion> {
-        self.get_values().get(self.index()).cloned()
     }
 
     /// Calculates how many rows the menu will use
@@ -578,7 +572,7 @@ impl Menu for ColumnarMenu {
         &self.settings
     }
 
-    /// Deactivates context menu
+    /// Active status
     fn is_active(&self) -> bool {
         self.active
     }
@@ -602,9 +596,9 @@ impl Menu for ColumnarMenu {
             self.update_values(editor, completer);
         }
 
-        if can_partially_complete(self.get_values(), editor) {
-            // The values need to be updated because the spans need to be
-            // recalculated for accurate replacement in the string
+        // Stale results can't splice wrong span
+        if self.completions.common_prefix(editor) {
+            // Recalculate spans after replacement
             self.update_values(editor, completer);
 
             true
@@ -613,17 +607,22 @@ impl Menu for ColumnarMenu {
         }
     }
 
-    /// Selects what type of event happened with the menu
-    fn menu_event(&mut self, event: MenuEvent) {
-        match &event {
-            MenuEvent::Activate(_) => self.active = true,
-            MenuEvent::Deactivate => {
-                self.active = false;
-                self.input = None;
-            }
-            _ => {}
-        }
+    fn set_active(&mut self, active: bool) {
+        self.active = active;
+    }
 
+    fn clear_input(&mut self) {
+        self.input = None;
+    }
+
+    fn on_activate(&mut self) {
+        // Reset completions on activation
+        self.completions = CompletionDisplay::default();
+    }
+
+    /// Queue menu event
+    fn menu_event(&mut self, event: MenuEvent) {
+        self.handle_menu_event(&event);
         self.event = Some(event);
     }
 
@@ -659,9 +658,10 @@ impl Menu for ColumnarMenu {
         self.recompute_layout(painter);
     }
 
-    /// The buffer gets replaced in the Span location
+    /// Replace buffer at span via completion display
     fn replace_in_buffer(&self, editor: &mut Editor) {
-        replace_in_buffer(self.get_value(), editor, self.settings.output_mode);
+        self.completions
+            .accept(self.index(), editor, self.settings.output_mode);
     }
 
     /// Minimum rows that should be displayed by the menu
@@ -671,7 +671,7 @@ impl Menu for ColumnarMenu {
 
     /// Gets values from filler that will be displayed in the menu
     fn get_values(&self) -> &[Suggestion] {
-        &self.completions.values
+        self.completions.suggestions()
     }
 
     fn menu_required_lines(&self, _terminal_columns: u16) -> u16 {
@@ -751,7 +751,7 @@ impl Menu for ColumnarMenu {
 mod tests {
     use crate::painting::W;
 
-    use crate::{Span, UndoBehavior};
+    use crate::{CompletionOrigin, Span, UndoBehavior};
 
     use super::*;
 
@@ -1023,6 +1023,160 @@ mod tests {
         assert_eq!(menu.get_rows(), 0);
         assert_eq!(menu.menu_required_lines(30), 0);
         assert!(menu.menu_string(10, false).is_empty());
+    }
+
+    /// Completer with fixed value and span
+    struct SpanCompleter {
+        value: String,
+        span: Span,
+    }
+
+    impl Completer for SpanCompleter {
+        fn complete(&mut self, _line: &str, _pos: usize) -> crate::CompletionResult {
+            crate::CompletionResult::fresh(vec![Suggestion {
+                value: self.value.clone(),
+                span: self.span,
+                ..Default::default()
+            }])
+        }
+    }
+
+    /// Stale completer with fixed origin
+    struct StaleSpanCompleter {
+        value: String,
+        span: Span,
+        origin: CompletionOrigin,
+    }
+
+    impl StaleSpanCompleter {
+        fn new(
+            value: &str,
+            span: Span,
+            origin_buffer: &str,
+            origin_insertion_point: usize,
+        ) -> Self {
+            Self {
+                value: value.to_string(),
+                span,
+                origin: CompletionOrigin::new(origin_buffer, origin_insertion_point),
+            }
+        }
+    }
+
+    impl Completer for StaleSpanCompleter {
+        fn complete(&mut self, _line: &str, _pos: usize) -> crate::CompletionResult {
+            crate::CompletionResult::Stale {
+                suggestions: vec![Suggestion {
+                    value: self.value.clone(),
+                    span: self.span,
+                    ..Default::default()
+                }]
+                .into(),
+                origin: self.origin.clone(),
+                partial: None,
+            }
+        }
+    }
+
+    /// Stale span not spliced into changed buffer
+    #[test]
+    fn stale_pending_span_is_not_spliced() {
+        let mut menu = ColumnarMenu::default();
+        let mut editor = Editor::default();
+
+        // Replace CODE_ token
+        editor.set_buffer("open CODE_".to_string(), UndoBehavior::CreateUndoPoint);
+        let mut file = SpanCompleter {
+            value: "CODE_OF_CONDUCT.md".to_string(),
+            span: Span { start: 5, end: 10 },
+        };
+
+        // Verify span applies to original buffer
+        menu.can_partially_complete(false, &mut editor, &mut file);
+        assert_eq!(editor.get_buffer(), "open CODE_OF_CONDUCT.md");
+
+        // Buffer changed, stale span must not apply
+        editor.set_buffer(
+            "open CODE_OF_CONDUCT.md | from csv --sep".to_string(),
+            UndoBehavior::CreateUndoPoint,
+        );
+        let mut pending = PendingCompleter;
+        let before = editor.get_buffer().to_string();
+
+        // Decline stale partial completion
+        assert!(!menu.can_partially_complete(false, &mut editor, &mut pending));
+        assert_eq!(
+            editor.get_buffer(),
+            before,
+            "partial completion spliced a stale span"
+        );
+
+        // No-op on stale accept
+        menu.replace_in_buffer(&mut editor);
+        assert_eq!(editor.get_buffer(), before, "accept spliced a stale span");
+    }
+
+    /// Stale result with mismatched origin rejected
+    #[test]
+    fn stale_result_with_mismatched_origin_is_not_spliced() {
+        let mut menu = ColumnarMenu::default();
+        let mut editor = Editor::default();
+
+        editor.set_buffer("open CODE_".to_string(), UndoBehavior::CreateUndoPoint);
+        let mut file = SpanCompleter {
+            value: "CODE_OF_CONDUCT.md".to_string(),
+            span: Span { start: 5, end: 10 },
+        };
+        menu.can_partially_complete(false, &mut editor, &mut file);
+        assert_eq!(editor.get_buffer(), "open CODE_OF_CONDUCT.md");
+
+        editor.set_buffer(
+            "open CODE_OF_CONDUCT.md | from csv --sep".to_string(),
+            UndoBehavior::CreateUndoPoint,
+        );
+        let before = editor.get_buffer().to_string();
+
+        // Stale result with old buffer origin
+        let mut stale = StaleSpanCompleter::new(
+            "CODE_OF_CONDUCT.md",
+            Span { start: 5, end: 10 },
+            "open CODE_",
+            10,
+        );
+
+        assert!(!menu.can_partially_complete(false, &mut editor, &mut stale));
+        assert_eq!(
+            editor.get_buffer(),
+            before,
+            "partial completion spliced a span from a Stale result whose origin doesn't match the live buffer"
+        );
+
+        menu.replace_in_buffer(&mut editor);
+        assert_eq!(
+            editor.get_buffer(),
+            before,
+            "accept spliced a span from a Stale result whose origin doesn't match the live buffer"
+        );
+    }
+
+    /// Default completer partial completion
+    #[test]
+    fn default_completer_partial_completion_matches_demo_example() {
+        use crate::DefaultCompleter;
+
+        let words = vec![
+            "abaaacas".to_string(),
+            "abaaac".to_string(),
+            "abaaaxyc".to_string(),
+            "abaaarabc".to_string(),
+        ];
+        let mut completer = DefaultCompleter::new_with_wordlen(words, 2);
+        let mut menu = ColumnarMenu::default();
+        let mut editor = Editor::default();
+        editor.set_buffer("ab".to_string(), UndoBehavior::CreateUndoPoint);
+
+        assert!(menu.can_partially_complete(false, &mut editor, &mut completer));
+        assert_eq!(editor.get_buffer(), "abaaa");
     }
 
     #[test]

--- a/src/menu/description_menu.rs
+++ b/src/menu/description_menu.rs
@@ -419,18 +419,21 @@ impl Menu for DescriptionMenu {
         false
     }
 
-    /// Selects what type of event happened with the menu
-    fn menu_event(&mut self, event: MenuEvent) {
-        match &event {
-            MenuEvent::Activate(_) => self.active = true,
-            MenuEvent::Deactivate => {
-                self.active = false;
-                self.input = None;
-                self.values = Suggestions::default();
-            }
-            _ => {}
-        };
+    fn set_active(&mut self, active: bool) {
+        self.active = active;
+    }
 
+    fn clear_input(&mut self) {
+        self.input = None;
+    }
+
+    fn on_deactivate(&mut self) {
+        self.values = Suggestions::default();
+    }
+
+    /// Handle menu event
+    fn menu_event(&mut self, event: MenuEvent) {
+        self.handle_menu_event(&event);
         self.event = Some(event);
     }
 

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -2,9 +2,8 @@ use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
     menu_functions::{
-        available_lines, can_partially_complete, get_match_indices, replace_in_buffer,
-        resolve_completer_input, scroll_offset, style_suggestion, truncate_with_ansi,
-        CompletionDisplay,
+        available_lines, get_match_indices, resolve_completer_input, scroll_offset,
+        style_suggestion, truncate_with_ansi, CompletionDisplay,
     },
     painting::Painter,
     Completer, Suggestion,
@@ -148,7 +147,7 @@ pub struct IdeMenu {
     /// yet. While set, the menu draws nothing rather than a premature
     /// "NO RECORDS FOUND" (which is reserved for a settled, genuinely empty result).
     awaiting_results: bool,
-    /// Selected value. Starts at 0
+    /// Selected index
     selected: u16,
     /// Number of values that are skipped when printing,
     /// depending on selected value and terminal height
@@ -295,7 +294,7 @@ impl IdeMenu {
 // Menu functionality
 impl IdeMenu {
     fn move_next(&mut self) {
-        if self.selected < (self.completions.values.len() as u16).saturating_sub(1) {
+        if self.selected < (self.completions.suggestions().len() as u16).saturating_sub(1) {
             self.selected += 1;
         } else {
             self.selected = 0;
@@ -306,7 +305,7 @@ impl IdeMenu {
         if self.selected > 0 {
             self.selected -= 1;
         } else {
-            self.selected = self.completions.values.len().saturating_sub(1) as u16;
+            self.selected = self.completions.suggestions().len().saturating_sub(1) as u16;
         }
     }
 
@@ -315,7 +314,7 @@ impl IdeMenu {
     }
 
     fn get_value(&self) -> Option<Suggestion> {
-        self.completions.values.get(self.index()).cloned()
+        self.completions.suggestions().get(self.index()).cloned()
     }
 
     /// Calculates how many rows the Menu will try to use (if available)
@@ -750,7 +749,7 @@ impl Menu for IdeMenu {
         &self.settings
     }
 
-    /// Deactivates context menu
+    /// Active status
     fn is_active(&self) -> bool {
         self.active
     }
@@ -772,9 +771,9 @@ impl Menu for IdeMenu {
             self.update_values(editor, completer);
         }
 
-        if can_partially_complete(self.get_values(), editor) {
-            // The values need to be updated because the spans need to be
-            // recalculated for accurate replacement in the string
+        // `common_prefix` guards against stale completions
+        if self.completions.common_prefix(editor) {
+            // Recalculate spans for replacement
             self.update_values(editor, completer);
 
             true
@@ -783,17 +782,22 @@ impl Menu for IdeMenu {
         }
     }
 
-    /// Selects what type of event happened with the menu
-    fn menu_event(&mut self, event: MenuEvent) {
-        match &event {
-            MenuEvent::Activate(_) => self.active = true,
-            MenuEvent::Deactivate => {
-                self.active = false;
-                self.input = None;
-            }
-            _ => {}
-        }
+    fn set_active(&mut self, active: bool) {
+        self.active = active;
+    }
 
+    fn clear_input(&mut self) {
+        self.input = None;
+    }
+
+    fn on_activate(&mut self) {
+        // Clear stale completions from previous activation
+        self.completions = CompletionDisplay::default();
+    }
+
+    /// Queue menu event
+    fn menu_event(&mut self, event: MenuEvent) {
+        self.handle_menu_event(&event);
         self.event = Some(event);
     }
 
@@ -827,9 +831,10 @@ impl Menu for IdeMenu {
         self.recompute_layout(painter);
     }
 
-    /// The buffer gets replaced in the Span location
+    /// Apply via `CompletionDisplay::accept` (guards against stale spans)
     fn replace_in_buffer(&self, editor: &mut Editor) {
-        replace_in_buffer(self.get_value(), editor, self.settings.output_mode);
+        self.completions
+            .accept(self.index(), editor, self.settings.output_mode);
     }
 
     /// Minimum rows that should be displayed by the menu
@@ -838,7 +843,7 @@ impl Menu for IdeMenu {
     }
 
     fn get_values(&self) -> &[Suggestion] {
-        &self.completions.values
+        self.completions.suggestions()
     }
 
     fn menu_required_lines(&self, _terminal_columns: u16) -> u16 {

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -358,17 +358,17 @@ impl Menu for ListMenu {
         false
     }
 
-    /// Selects what type of event happened with the menu
-    fn menu_event(&mut self, event: MenuEvent) {
-        match &event {
-            MenuEvent::Activate(_) => self.active = true,
-            MenuEvent::Deactivate => {
-                self.active = false;
-                self.input = None;
-            }
-            _ => {}
-        }
+    fn set_active(&mut self, active: bool) {
+        self.active = active;
+    }
 
+    fn clear_input(&mut self) {
+        self.input = None;
+    }
+
+    /// Handle menu event
+    fn menu_event(&mut self, event: MenuEvent) {
+        self.handle_menu_event(&event);
         self.event = Some(event);
     }
 

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -3,10 +3,6 @@ use std::borrow::Cow;
 use std::ops::Range;
 use unicase::UniCase;
 
-use itertools::{
-    FoldWhile::{Continue, Done},
-    Itertools,
-};
 use nu_ansi_term::{ansi::RESET, Style};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
@@ -14,7 +10,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::{
     menu::{InputMode, MenuSettings, OutputMode},
     painting::Painter,
-    CompletionResult, Editor, Suggestion, Suggestions, UndoBehavior,
+    CompletionOrigin, CompletionResult, Editor, Partial, Suggestion, Suggestions, UndoBehavior,
 };
 
 /// Index result obtained from parsing a string with an index marker
@@ -178,43 +174,7 @@ pub fn parse_selection_char(buffer: &str, marker: char) -> ParseResult<'_> {
     }
 }
 
-/// Finds index for the common string in a list of suggestions
-pub fn find_common_string(values: &[Suggestion]) -> Option<(&Suggestion, usize)> {
-    let first_suggestion = values.first()?;
-    let max_len = first_suggestion.value.len();
-
-    let index = values
-        .iter()
-        .skip(1)
-        .fold_while(max_len, |cumulated_min, current_suggestion| {
-            let new_common_prefix_len = first_suggestion
-                .value
-                .char_indices()
-                .zip(current_suggestion.value.chars())
-                .find_map(|((idx, lhs), rhs)| (rhs != lhs).then_some(idx))
-                .unwrap_or(current_suggestion.value.len());
-            if new_common_prefix_len == 0 {
-                Done(0)
-            } else {
-                Continue(cumulated_min.min(new_common_prefix_len))
-            }
-        });
-
-    Some((first_suggestion, index.into_inner()))
-}
-
-/// Finds different string between two strings
-///
-/// ## Example usage
-/// ```
-/// use reedline::menu_functions::string_difference;
-///
-/// let new_string = "this is a new string";
-/// let old_string = "this is a string";
-///
-/// let res = string_difference(new_string, old_string);
-/// assert_eq!(res, (10, "new "));
-/// ```
+/// Find differing substring between two strings
 pub fn string_difference<'a>(new_string: &'a str, old_string: &str) -> (usize, &'a str) {
     if old_string.is_empty() {
         return (0, new_string);
@@ -369,20 +329,22 @@ pub(crate) fn scroll_offset(selected: u16, current: u16, window: u16) -> u16 {
     }
 }
 
-/// The suggestions a completion menu is currently displaying, together with the
-/// display metrics derived from them. Grouping these keeps the completion display
-/// state cohesive and separate from a menu's column/layout details. Shared by the
-/// columnar and IDE menus.
+/// A menu's suggestions, tied to the buffer they were computed against.
+/// Spans are validated before reaching the buffer.
 #[derive(Default)]
 pub struct CompletionDisplay {
-    /// Cached suggestion values shown by the menu.
-    pub values: Suggestions,
-    /// Display width of each suggestion in `values`.
+    /// Menu suggestions (private; spans via accept/common_prefix)
+    values: Suggestions,
+    /// Display widths
     pub display_widths: Vec<usize>,
     /// Shortest of the strings the suggestions are based on.
     pub shortest_base_string: String,
     /// Width of the longest suggestion in `values`.
     pub longest_suggestion: usize,
+    /// Completer-supplied partial (None = use derivation)
+    partial: Option<Partial>,
+    /// Buffer/cursor for span validation
+    computed_for: CompletionOrigin,
 }
 
 impl CompletionDisplay {
@@ -395,15 +357,29 @@ impl CompletionDisplay {
     ) -> Option<Self> {
         match result {
             CompletionResult::Pending => None,
-            CompletionResult::Fresh(values) | CompletionResult::Stale(values) => {
-                Some(Self::new(values, base_ranges, editor))
+            CompletionResult::Fresh {
+                suggestions,
+                partial,
+            } => {
+                // Stamped from live editor (Fresh result)
+                let origin = CompletionOrigin::new(editor.get_buffer(), editor.insertion_point());
+                Some(Self::new(suggestions, partial, base_ranges, origin))
             }
+            CompletionResult::Stale {
+                suggestions,
+                origin,
+                partial,
+            } => Some(Self::new(suggestions, partial, base_ranges, origin)),
         }
     }
 
-    /// Adopt `values` as the menu's suggestions and measure their display metrics
-    /// against the buffer's replacement `base_ranges`.
-    pub fn new(values: Suggestions, base_ranges: &[Range<usize>], editor: &Editor) -> Self {
+    /// Adopt suggestions and measure display metrics
+    fn new(
+        values: Suggestions,
+        partial: Option<Partial>,
+        base_ranges: &[Range<usize>],
+        computed_for: CompletionOrigin,
+    ) -> Self {
         let display_widths: Vec<usize> = values
             .iter()
             .map(|suggestion| strip_ansi_escapes::strip_str(suggestion.display_value()).width())
@@ -412,8 +388,8 @@ impl CompletionDisplay {
         // Find the maximum width
         let longest_suggestion = display_widths.iter().copied().max().unwrap_or(0);
 
-        // Find the shortest buffer slice
-        let buffer = editor.get_buffer();
+        // Shortest slice from stored buffer (may differ from editor if stale)
+        let buffer = computed_for.buffer.as_str();
         let shortest_base_string = base_ranges
             .iter()
             .map(|range| {
@@ -430,12 +406,90 @@ impl CompletionDisplay {
             display_widths,
             shortest_base_string,
             longest_suggestion,
+            partial,
+            computed_for,
+        }
+    }
+
+    /// Read-only: values, descriptions, widths (no spans)
+    pub fn suggestions(&self) -> &[Suggestion] {
+        &self.values
+    }
+
+    /// Whether spans match the current editor buffer
+    fn is_current(&self, editor: &Editor) -> bool {
+        self.computed_for.buffer == editor.get_buffer()
+            && self.computed_for.insertion_point == editor.insertion_point()
+    }
+
+    /// Accept suggestion at index (no-op if stale or out of range)
+    pub fn accept(&self, index: usize, editor: &mut Editor, output_mode: Option<OutputMode>) {
+        if self.is_current(editor) {
+            replace_in_buffer(self.values.get(index).cloned(), editor, output_mode);
+        }
+    }
+
+    /// Apply partial completion (completer-supplied or derived). No-op and returns false when stale or unchanged.
+    pub fn common_prefix(&self, editor: &mut Editor) -> bool {
+        if !self.is_current(editor) {
+            return false;
+        }
+        match &self.partial {
+            Some(partial) => apply_partial(partial, editor),
+            None => match derive_common_prefix(editor.get_buffer(), &self.values) {
+                Some(partial) => apply_partial(&partial, editor),
+                None => false,
+            },
         }
     }
 }
 
+/// Longest common prefix across suggestions sharing a span
+fn derive_common_prefix(line: &str, suggestions: &[Suggestion]) -> Option<Partial> {
+    let span = suggestions.first()?.span;
+    let mut values = suggestions
+        .iter()
+        .filter(|s| s.span == span)
+        .map(|s| s.value.as_str());
+
+    let mut insert = values.next()?.to_string();
+    for value in values {
+        let shared = insert
+            .char_indices()
+            .zip(value.chars())
+            .find_map(|((i, a), b)| (a != b).then_some(i))
+            .unwrap_or(insert.len().min(value.len()));
+        insert.truncate(shared);
+    }
+
+    let end = floor_char_boundary(line, span.end);
+    let start = floor_char_boundary(line, span.start).min(end);
+    let entered = line.get(start..end)?;
+
+    // Ensure prefix extends (not overwrites) user input
+    let extends = !insert.is_empty()
+        && insert != entered
+        && UniCase::new(insert.as_str())
+            .to_folded_case()
+            .contains(&UniCase::new(entered).to_folded_case());
+    extends.then_some(Partial { span, insert })
+}
+
+/// Apply partial to buffer. No-op if buffer already matches
+fn apply_partial(partial: &Partial, editor: &mut Editor) -> bool {
+    let buffer = editor.get_buffer();
+    let end = floor_char_boundary(buffer, partial.span.end);
+    let start = floor_char_boundary(buffer, partial.span.start).min(end);
+    if buffer[start..end] == partial.insert {
+        return false;
+    }
+    commit_buffer_replacement(editor, start, end, &partial.insert);
+    true
+}
+
 /// Apply string replacement to line buffer
 fn commit_buffer_replacement(editor: &mut Editor, start: usize, end: usize, replacement: &str) {
+    // Use cursor head, clear selection
     let mut line_buffer = std::mem::take(editor.line_buffer_mut());
     let head = line_buffer.cursor().head();
 
@@ -480,46 +534,6 @@ pub fn replace_in_buffer(
     }
 
     commit_buffer_replacement(editor, start, end, &value);
-}
-
-/// Helper for `Menu::can_partially_complete`
-pub fn can_partially_complete(values: &[Suggestion], editor: &mut Editor) -> bool {
-    if let Some((Suggestion { value, span, .. }, index)) = find_common_string(values) {
-        let matching = &value[0..index];
-        let end = floor_char_boundary(editor.get_buffer(), span.end);
-        let start = floor_char_boundary(editor.get_buffer(), span.start).min(end);
-
-        // make sure that the partial completion does not overwrite user entered input
-        let entered_input = &editor.get_buffer()[start..end];
-        let extends_input = UniCase::new(matching)
-            .to_folded_case()
-            .contains(&UniCase::new(entered_input).to_folded_case())
-            && matching != entered_input;
-
-        if !matching.is_empty() && extends_input {
-            // Base the new cursor on the head, not `insertion_point()` (the
-            // caret), and clear any selection — see `replace_in_buffer`.
-            let head = editor.line_buffer().cursor().head();
-            let mut line_buffer = editor.line_buffer().clone();
-            line_buffer.replace_range(start..end, matching);
-
-            let offset = if matching.len() < (end - start) {
-                head.saturating_sub((end - start) - matching.len())
-            } else {
-                head + matching.len() - (end - start)
-            };
-
-            line_buffer.clear_selection();
-            line_buffer.set_insertion_point(offset);
-            editor.set_line_buffer(line_buffer, UndoBehavior::CreateUndoPoint);
-
-            true
-        } else {
-            false
-        }
-    } else {
-        false
-    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -1080,7 +1094,7 @@ mod tests {
     #[case::unsorted(vec!["a", "b", "ab"], 0)]
     #[case::should_be_case_sensitive(vec!["a", "A"], 0)]
     #[case::first_suggestion_longest(vec!["foobar", "foo"], 3)]
-    fn test_find_common_string(#[case] input: Vec<&str>, #[case] expected: usize) {
+    fn test_derive_common_prefix(#[case] input: Vec<&str>, #[case] expected: usize) {
         let input: Vec<_> = input
             .into_iter()
             .map(|s| Suggestion {
@@ -1088,9 +1102,40 @@ mod tests {
                 ..Default::default()
             })
             .collect();
-        let (_, len) = find_common_string(&input).unwrap();
+        // Shared default span, empty buffer: gate reduces to "non-empty prefix?"
+        let partial = derive_common_prefix("", &input);
 
-        assert!(len == expected);
+        match expected {
+            0 => assert!(partial.is_none()),
+            len => assert_eq!(partial.unwrap().insert.len(), len),
+        }
+    }
+
+    /// Verifies fallback to built-in derivation without completer-supplied Partial
+    #[test]
+    fn common_prefix_falls_back_to_derivation_without_a_completer_supplied_partial() {
+        let mut editor = Editor::default();
+        editor.set_buffer("ab".to_string(), UndoBehavior::CreateUndoPoint);
+
+        // Mirrors demo example: "ab" + Tab -> longest prefix "abaaa"
+        let values: Suggestions = ["abaaacas", "abaaac", "abaaaxyc", "abaaarabc"]
+            .into_iter()
+            .map(|value| Suggestion {
+                value: value.to_string(),
+                span: Span::new(0, 2),
+                ..Default::default()
+            })
+            .collect::<Vec<_>>()
+            .into();
+        let display = CompletionDisplay::new(
+            values,
+            None,
+            &[],
+            CompletionOrigin::new(editor.get_buffer(), editor.insertion_point()),
+        );
+
+        assert!(display.common_prefix(&mut editor));
+        assert_eq!(editor.get_buffer(), "abaaa");
     }
 
     #[rstest]

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -434,44 +434,52 @@ impl CompletionDisplay {
     }
 }
 
+/// Apply string replacement to line buffer
+fn commit_buffer_replacement(editor: &mut Editor, start: usize, end: usize, replacement: &str) {
+    let mut line_buffer = std::mem::take(editor.line_buffer_mut());
+    let head = line_buffer.cursor().head();
+
+    line_buffer.replace_range(start..end, replacement);
+    line_buffer.clear_selection();
+    line_buffer.set_insertion_point(
+        head.saturating_add(replacement.len())
+            .saturating_sub(end - start),
+    );
+
+    editor.set_line_buffer(line_buffer, UndoBehavior::CreateUndoPoint);
+}
+
 /// Helper to accept a completion suggestion and edit the buffer
 pub fn replace_in_buffer(
     value: Option<Suggestion>,
     editor: &mut Editor,
     output_mode: Option<OutputMode>,
 ) {
-    if let Some(Suggestion {
+    let Some(Suggestion {
         mut value,
         span,
         append_whitespace,
         ..
     }) = value
-    {
-        let buffer_len = editor.get_buffer().len();
-        let (raw_start, raw_end) = match output_mode {
-            Some(OutputMode::FullBuffer) => (0, buffer_len),
-            Some(OutputMode::ExtendToEnd) => (span.start, buffer_len),
-            Some(OutputMode::SuggestedSpan) | None => (span.start, span.end),
-        };
-        let end = floor_char_boundary(editor.get_buffer(), raw_end);
-        let start = floor_char_boundary(editor.get_buffer(), raw_start).min(end);
-        if append_whitespace {
-            value.push(' ');
-        }
+    else {
+        return;
+    };
 
-        // Base the new cursor on the head, not `insertion_point()` (which is the
-        // caret — one grapheme back under a forward selection), and clear any
-        // selection so completion never leaves a stale anchor.
-        let head = editor.line_buffer().cursor().head();
-        let mut line_buffer = editor.line_buffer().clone();
-        line_buffer.replace_range(start..end, &value);
-        let mut offset = head;
-        offset = offset.saturating_add(value.len());
-        offset = offset.saturating_sub(end.saturating_sub(start));
-        line_buffer.clear_selection();
-        line_buffer.set_insertion_point(offset);
-        editor.set_line_buffer(line_buffer, UndoBehavior::CreateUndoPoint);
+    let buffer = editor.get_buffer();
+    let (raw_start, raw_end) = match output_mode {
+        Some(OutputMode::FullBuffer) => (0, buffer.len()),
+        Some(OutputMode::ExtendToEnd) => (span.start, buffer.len()),
+        Some(OutputMode::SuggestedSpan) | None => (span.start, span.end),
+    };
+
+    let end = floor_char_boundary(buffer, raw_end);
+    let start = floor_char_boundary(buffer, raw_start).min(end);
+
+    if append_whitespace {
+        value.push(' ');
     }
+
+    commit_buffer_replacement(editor, start, end, &value);
 }
 
 /// Helper for `Menu::can_partially_complete`

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -44,7 +44,7 @@ impl Default for MenuTextStyle {
     }
 }
 
-/// Defines all possible events that could happen with a menu.
+/// Menu events.
 #[derive(Clone)]
 pub enum MenuEvent {
     /// Activation event for the menu. When the bool is true it means that the values
@@ -98,7 +98,35 @@ pub trait Menu: Send {
     /// Checks if the menu is active
     fn is_active(&self) -> bool;
 
-    /// Selects what type of event happened with the menu
+    /// Set active state
+    fn set_active(&mut self, active: bool);
+
+    /// Clear input
+    fn clear_input(&mut self);
+
+    /// Called after Activate event.
+    fn on_activate(&mut self) {}
+
+    /// Called after Deactivate event.
+    fn on_deactivate(&mut self) {}
+
+    /// Handle Activate/Deactivate events.
+    fn handle_menu_event(&mut self, event: &MenuEvent) {
+        match event {
+            MenuEvent::Activate(_) => {
+                self.set_active(true);
+                self.on_activate();
+            }
+            MenuEvent::Deactivate => {
+                self.set_active(false);
+                self.clear_input();
+                self.on_deactivate();
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle menu event
     fn menu_event(&mut self, event: MenuEvent);
 
     /// A menu may not be allowed to quick complete because it needs to stay
@@ -173,8 +201,7 @@ pub struct MenuSettings {
     color: MenuTextStyle,
     /// Menu marker when active
     marker: String,
-    /// Calls the completer using only the line buffer difference
-    /// after the menu was activated. Ignored if `input_mode` is set.
+    /// Use buffer diff after activation. Ignored if input_mode set.
     only_buffer_difference: bool,
     /// Optional override for completer input handling.
     /// If `Some`, takes precedence over `only_buffer_difference`.
@@ -212,7 +239,7 @@ impl MenuSettings {
         self
     }
 
-    /// MenuSettings builder with marker
+    /// Set marker
     #[must_use]
     pub fn with_marker(mut self, marker: &str) -> Self {
         self.marker = marker.to_string();
@@ -340,8 +367,7 @@ pub trait MenuBuilder: Menu + Sized {
         self
     }
 
-    /// Menu builder with new value for only_buffer_difference.
-    /// Ignored when `input_mode` is set; consider `with_input_mode` for finer control.
+    /// Set only_buffer_difference. Ignored when input_mode set.
     #[must_use]
     fn with_only_buffer_difference(mut self, only_buffer_difference: bool) -> Self {
         self.settings_mut().only_buffer_difference = only_buffer_difference;
@@ -478,6 +504,14 @@ impl Menu for ReedlineMenu {
 
     fn is_active(&self) -> bool {
         self.as_ref().is_active()
+    }
+
+    fn set_active(&mut self, active: bool) {
+        self.as_mut().set_active(active);
+    }
+
+    fn clear_input(&mut self) {
+        self.as_mut().clear_input();
     }
 
     fn menu_event(&mut self, event: MenuEvent) {

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1535,6 +1535,8 @@ mod tests {
         fn is_active(&self) -> bool {
             true
         }
+        fn set_active(&mut self, _active: bool) {}
+        fn clear_input(&mut self) {}
         fn menu_event(&mut self, _event: MenuEvent) {
             unimplemented!()
         }


### PR DESCRIPTION
## Summary

Async completors BEFORE TODAY... gave menus no real way to prove work was in progress. This instead adds a pleasant indicator that replaces the menu marker while a completion runs, plus a keyed message!

On the way:
- CompletionResult carries no an Optional Partial
- `ColumnarMenu`/`IdeMenu` track a `CompletionOrigin` (buffer + insertion point) so a `Pending` result computed against a stale buffer can't splice its span into the current one.
- `unicase` moved from a runtime dependency to a dev-dependency! 

Within the public API:
`WorkingIndicator`, `WorkingPhase`, `CompletionProgress`, `Partial`, and new `Menu`/`MenuBuilder`/`MenuSettings` methods (`with_working_marker`, `with_working_indicator`, `working_indicator`, `progress`, `working_phase`, `working_message`). `Menu::set_active`/`Menu::clear_input` are new required methods (no default body), so this is source-breaking for any external `Menu` implementors.

### Before
Async completers had no way to signal "still working" 

### After
A menu with a `WorkingIndicator` configured animates its marker while a completion is in flight, and shows a message afta enough time.