### PR TITLE
visual indication of completion

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -928,6 +928,9 @@ impl Reedline {
 
         self.repaint(prompt)?;
 
+        // Working phase of active menu at last paint.
+        let mut painted_working_phase = None;
+
         loop {
             // Call idle callback if set (for processing external events like GUI updates)
             #[cfg(feature = "idle_callback")]
@@ -976,12 +979,11 @@ impl Reedline {
             // Anything BUT idle means work is in flight. We need to keep polling.
             let completer_pending = status != CompletionStatus::Idle;
 
-            if let Some(menu) = (status == CompletionStatus::Ready)
-                .then(|| self.menus.iter_mut().find(|m| m.is_active()))
-                .flatten()
-            {
+            let active_menu = self.menus.iter().position(|m| m.is_active());
+
+            if let Some(idx) = active_menu.filter(|_| status == CompletionStatus::Ready) {
                 // latest request finished, so repopulate
-                menu.update_values(
+                self.menus[idx].update_values(
                     &mut self.editor,
                     self.completer.as_mut(),
                     self.history.as_ref(),
@@ -989,8 +991,16 @@ impl Reedline {
                 self.repaint(prompt)?;
             }
 
-            // Helper function that returns true if the input is complete and
-            // can be sent to the hosting application.
+            // Advance the in-flight indicator.
+            let working_phase = active_menu.and_then(|idx| self.menus[idx].working_phase());
+            if working_phase != painted_working_phase {
+                painted_working_phase = working_phase;
+                if working_phase.is_some() {
+                    self.repaint(prompt)?;
+                }
+            }
+
+            // Check if last event is Enter.
             fn completed(events: &[Event]) -> bool {
                 if let Some(event) = events.last() {
                     matches!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,9 +289,9 @@ pub use validator::{DefaultValidator, ValidationResult, Validator};
 
 mod menu;
 pub use menu::{
-    menu_functions, ColumnarMenu, DescriptionMenu, DescriptionMode, DescriptionPosition, IdeMenu,
-    InputMode, ListMenu, Menu, MenuBuilder, MenuEvent, MenuTextStyle, OutputMode, ReedlineMenu,
-    TraversalDirection,
+    menu_functions, ColumnarMenu, CompletionProgress, DescriptionMenu, DescriptionMode,
+    DescriptionPosition, IdeMenu, InputMode, ListMenu, Menu, MenuBuilder, MenuEvent, MenuTextStyle,
+    OutputMode, ReedlineMenu, TraversalDirection, WorkingIndicator, WorkingPhase,
 };
 
 mod terminal_extensions;

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -1,4 +1,4 @@
-use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
+use super::{CompletionProgress, Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
     menu_functions::{
@@ -71,10 +71,8 @@ pub struct ColumnarMenu {
     working_details: ColumnDetails,
     /// Suggestions currently displayed and their derived display metrics
     completions: CompletionDisplay,
-    /// Whether a background completion is still in flight with nothing to show
-    /// yet. While set, the menu draws nothing rather than a premature
-    /// "NO RECORDS FOUND" (which is reserved for a settled, genuinely empty result).
-    awaiting_results: bool,
+    /// In-flight completion state
+    progress: CompletionProgress,
     /// Column position
     col_pos: u16,
     /// row position in the menu. Starts from 0
@@ -97,7 +95,7 @@ impl Default for ColumnarMenu {
             min_rows: 3,
             working_details: ColumnDetails::default(),
             completions: CompletionDisplay::default(),
-            awaiting_results: false,
+            progress: CompletionProgress::default(),
             col_pos: 0,
             row_pos: 0,
             skip_rows: 0,
@@ -301,9 +299,15 @@ impl ColumnarMenu {
     /// Calculates how many rows the menu will use
     fn get_rows(&self) -> u16 {
         match self.get_values().len() as u16 {
-            // No reason to save space if we're waiting for results.
-            0 if self.awaiting_results => 0,
-            // Should be one row for actual empty results
+            // No space while working indicator is still in grace period
+            0 if self.progress.is_working()
+                && !self
+                    .working_phase()
+                    .map_or(false, |phase| phase.spelled_out) =>
+            {
+                0
+            }
+            // One row for "no records" or working message
             0 => 1,
             total_values => (total_values + self.get_cols() - 1) / self.get_cols(),
         }
@@ -572,6 +576,11 @@ impl Menu for ColumnarMenu {
         &self.settings
     }
 
+    /// Progress
+    fn progress(&self) -> CompletionProgress {
+        self.progress
+    }
+
     /// Active status
     fn is_active(&self) -> bool {
         self.active
@@ -618,6 +627,7 @@ impl Menu for ColumnarMenu {
     fn on_activate(&mut self) {
         // Reset completions on activation
         self.completions = CompletionDisplay::default();
+        self.progress = CompletionProgress::default();
     }
 
     /// Queue menu event
@@ -636,7 +646,7 @@ impl Menu for ColumnarMenu {
         let (input, pos) = resolve_completer_input(editor, &mut self.input, &self.settings);
 
         let (result, base_ranges) = completer.complete_with_base_ranges(&input, pos);
-        self.awaiting_results = result.is_pending();
+        self.progress.update(&result);
         if let Some(completions) = CompletionDisplay::from_result(result, &base_ranges, editor) {
             self.completions = completions;
             self.reset_position();
@@ -680,10 +690,8 @@ impl Menu for ColumnarMenu {
 
     fn menu_string(&self, available_lines: u16, use_ansi_coloring: bool) -> String {
         if self.get_values().is_empty() {
-            if self.awaiting_results {
-                // A background completion is still running; draw nothing rather
-                // than flashing "NO RECORDS FOUND" before the results land.
-                String::new()
+            if self.progress.is_working() {
+                self.working_message(use_ansi_coloring)
             } else {
                 self.no_records_msg(use_ansi_coloring)
             }
@@ -749,9 +757,11 @@ impl Menu for ColumnarMenu {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use crate::painting::W;
 
-    use crate::{CompletionOrigin, Span, UndoBehavior};
+    use crate::{CompletionOrigin, Span, UndoBehavior, WorkingIndicator};
 
     use super::*;
 
@@ -1006,7 +1016,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_completion_draws_nothing_instead_of_no_records() {
+    fn pending_completion_never_reads_as_no_records() {
         let mut menu = ColumnarMenu::default().with_name("testmenu");
         let mut editor = Editor::default();
 
@@ -1015,14 +1025,151 @@ mod tests {
         setup_menu(&mut menu, &mut editor, &mut empty, (30, 10));
         assert_eq!(menu.get_rows(), 1);
         assert!(menu.menu_string(10, false).contains("NO RECORDS FOUND"));
+        assert_eq!(menu.indicator(), menu.settings.marker);
 
-        // A pending result (background work still in flight) reserves no space and
-        // draws nothing, so the menu never flashes "NO RECORDS FOUND".
+        // No space while in grace period
         let mut pending = PendingCompleter;
         setup_menu(&mut menu, &mut editor, &mut pending, (30, 10));
         assert_eq!(menu.get_rows(), 0);
         assert_eq!(menu.menu_required_lines(30), 0);
         assert!(menu.menu_string(10, false).is_empty());
+
+        // Row reserved for working message
+        menu.progress = CompletionProgress::working_for(Duration::from_secs(5));
+        assert_eq!(menu.get_rows(), 1);
+        assert_eq!(menu.menu_required_lines(30), 1);
+        assert!(!menu.menu_string(10, false).contains("NO RECORDS FOUND"));
+        assert!(menu.menu_string(10, false).contains("searching"));
+    }
+
+    #[test]
+    fn working_indicator_escalates_with_the_length_of_the_wait() {
+        let mut menu = ColumnarMenu::default().with_name("testmenu");
+        let mut editor = Editor::default();
+
+        let mut pending = PendingCompleter;
+        setup_menu(&mut menu, &mut editor, &mut pending, (30, 10));
+
+        // Grace period: no visible change
+        menu.progress = CompletionProgress::working_for(Duration::from_millis(10));
+        assert_eq!(menu.indicator(), menu.settings.marker);
+        assert!(menu.menu_string(10, false).is_empty());
+        assert_eq!(menu.working_phase(), None);
+
+        // Past grace: marker active, no row reserved
+        menu.progress = CompletionProgress::working_for(Duration::from_millis(500));
+        assert_ne!(menu.indicator(), menu.settings.marker);
+        assert!(menu.menu_string(10, false).is_empty());
+        assert_eq!(menu.get_rows(), 0);
+        assert_eq!(
+            menu.working_phase().map(|phase| phase.spelled_out),
+            Some(false)
+        );
+
+        // Long wait: spelled out and row reserved
+        menu.progress = CompletionProgress::working_for(Duration::from_secs(5));
+        assert!(menu.menu_string(10, false).contains("searching"));
+        assert_eq!(menu.get_rows(), 1);
+        assert_eq!(
+            menu.working_phase().map(|phase| phase.spelled_out),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn working_marker_cycles_through_its_frames() {
+        let indicator = WorkingIndicator::new(["a", "b", "c", "d"])
+            .with_grace(Duration::from_millis(100))
+            .with_period(Duration::from_millis(400));
+
+        // Before grace: nothing
+        assert_eq!(indicator.marker(Some(Duration::from_millis(99))), None);
+        // Quarter-period frames wrap around
+        assert_eq!(
+            indicator.marker(Some(Duration::from_millis(100))),
+            Some("a")
+        );
+        assert_eq!(
+            indicator.marker(Some(Duration::from_millis(250))),
+            Some("b")
+        );
+        assert_eq!(
+            indicator.marker(Some(Duration::from_millis(350))),
+            Some("c")
+        );
+        assert_eq!(
+            indicator.marker(Some(Duration::from_millis(450))),
+            Some("d")
+        );
+        assert_eq!(
+            indicator.marker(Some(Duration::from_millis(550))),
+            Some("a")
+        );
+        // Settled: no frame
+        assert_eq!(indicator.marker(None), None);
+    }
+
+    /// Short period still advances frames
+    #[test]
+    fn a_period_shorter_than_the_frame_count_still_advances() {
+        let indicator = WorkingIndicator::new(["a", "b", "c", "d"])
+            .with_grace(Duration::from_millis(0))
+            .with_period(Duration::from_nanos(3));
+
+        assert_eq!(indicator.marker(Some(Duration::from_nanos(0))), Some("a"));
+        assert_eq!(indicator.marker(Some(Duration::from_nanos(1))), Some("b"));
+        assert_eq!(indicator.marker(Some(Duration::from_nanos(2))), Some("c"));
+        assert_eq!(indicator.marker(Some(Duration::from_nanos(3))), Some("d"));
+    }
+
+    #[test]
+    fn a_single_frame_is_a_static_marker() {
+        let mut menu = ColumnarMenu::default()
+            .with_name("testmenu")
+            .with_working_marker("~ ");
+        let mut editor = Editor::default();
+
+        let mut pending = PendingCompleter;
+        setup_menu(&mut menu, &mut editor, &mut pending, (30, 10));
+
+        menu.progress = CompletionProgress::working_for(Duration::from_millis(500));
+        assert_eq!(menu.indicator(), "~ ");
+        menu.progress = CompletionProgress::working_for(Duration::from_millis(900));
+        assert_eq!(menu.indicator(), "~ ");
+    }
+
+    /// Completer with stale values while fresh result pending
+    struct StaleCompleter;
+
+    impl Completer for StaleCompleter {
+        fn complete(&mut self, line: &str, pos: usize) -> crate::CompletionResult {
+            crate::CompletionResult::Stale {
+                suggestions: vec![Suggestion {
+                    value: "stale".to_string(),
+                    span: crate::Span::new(0, 0),
+                    ..Default::default()
+                }]
+                .into(),
+                origin: CompletionOrigin::new(line, pos),
+                partial: None,
+            }
+        }
+    }
+
+    #[test]
+    fn stale_completion_shows_values_and_still_marks_itself_working() {
+        let mut menu = ColumnarMenu::default().with_name("testmenu");
+        let mut editor = Editor::default();
+
+        let mut stale = StaleCompleter;
+        setup_menu(&mut menu, &mut editor, &mut stale, (30, 10));
+
+        // Stale values displayed with marker
+        assert!(menu.menu_string(10, false).contains("STALE"));
+        // Working marker shown, values preserved
+        menu.progress = CompletionProgress::working_for(Duration::from_millis(500));
+        assert_ne!(menu.indicator(), menu.settings.marker);
+        assert!(menu.menu_string(10, false).contains("STALE"));
     }
 
     /// Completer with fixed value and span

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -1,4 +1,4 @@
-use super::{Menu, MenuBuilder, MenuEvent, MenuSettings};
+use super::{CompletionProgress, Menu, MenuBuilder, MenuEvent, MenuSettings};
 use crate::{
     core_editor::Editor,
     menu_functions::{
@@ -143,10 +143,8 @@ pub struct IdeMenu {
     working_details: IdeMenuDetails,
     /// Suggestions currently displayed and their derived display metrics
     completions: CompletionDisplay,
-    /// Whether a background completion is still in flight with nothing to show
-    /// yet. While set, the menu draws nothing rather than a premature
-    /// "NO RECORDS FOUND" (which is reserved for a settled, genuinely empty result).
-    awaiting_results: bool,
+    /// In-flight completion state
+    progress: CompletionProgress,
     /// Selected index
     selected: u16,
     /// Number of values that are skipped when printing,
@@ -166,7 +164,7 @@ impl Default for IdeMenu {
             default_details: DefaultIdeMenuDetails::default(),
             working_details: IdeMenuDetails::default(),
             completions: CompletionDisplay::default(),
-            awaiting_results: false,
+            progress: CompletionProgress::default(),
             selected: 0,
             skip_values: 0,
             event: None,
@@ -322,10 +320,15 @@ impl IdeMenu {
         let mut values = self.get_values().len() as u16;
 
         if values == 0 {
-            // While a background completion is still in flight there is nothing to
-            // show yet, so reserve no space; otherwise the empty menu is a settled
-            // result and reserves 1 line for the no_records_msg.
-            return if self.awaiting_results { 0 } else { 1 };
+            // Reserve only when working phase has a spelled-out message
+            let reserve_for_working = self
+                .working_phase()
+                .map_or(false, |phase| phase.spelled_out);
+            return if self.progress.is_working() && !reserve_for_working {
+                0
+            } else {
+                1
+            };
         }
 
         if self.default_details.border.is_some() {
@@ -749,6 +752,11 @@ impl Menu for IdeMenu {
         &self.settings
     }
 
+    /// Progress
+    fn progress(&self) -> CompletionProgress {
+        self.progress
+    }
+
     /// Active status
     fn is_active(&self) -> bool {
         self.active
@@ -793,6 +801,7 @@ impl Menu for IdeMenu {
     fn on_activate(&mut self) {
         // Clear stale completions from previous activation
         self.completions = CompletionDisplay::default();
+        self.progress = CompletionProgress::default();
     }
 
     /// Queue menu event
@@ -809,7 +818,7 @@ impl Menu for IdeMenu {
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
         let (input, pos) = resolve_completer_input(editor, &mut self.input, &self.settings);
         let (result, base_ranges) = completer.complete_with_base_ranges(&input, pos);
-        self.awaiting_results = result.is_pending();
+        self.progress.update(&result);
         if let Some(completions) = CompletionDisplay::from_result(result, &base_ranges, editor) {
             self.completions = completions;
             self.reset_position();
@@ -853,10 +862,8 @@ impl Menu for IdeMenu {
 
     fn menu_string(&self, available_lines: u16, use_ansi_coloring: bool) -> String {
         if self.get_values().is_empty() {
-            if self.awaiting_results {
-                // A background completion is still running; draw nothing rather
-                // than flashing "NO RECORDS FOUND" before the results land.
-                String::new()
+            if self.progress.is_working() {
+                self.working_message(use_ansi_coloring)
             } else {
                 self.no_records_msg(use_ansi_coloring)
             }

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -229,9 +229,29 @@ pub trait Menu: Send {
         &self.settings().name
     }
 
-    /// Menu indicator
+    /// Completion progress for in-flight work.
+    fn progress(&self) -> CompletionProgress {
+        CompletionProgress::default()
+    }
+
+    /// Marker; animated frame if work in flight.
     fn indicator(&self) -> &str {
-        &self.settings().marker
+        let settings = self.settings();
+        settings
+            .working
+            .marker(self.progress().elapsed())
+            .unwrap_or(&settings.marker)
+    }
+
+    /// Current working phase, or None.
+    fn working_phase(&self) -> Option<WorkingPhase> {
+        self.settings().working.phase(self.progress().elapsed())
+    }
+
+    /// Message shown while completion is running.
+    fn working_message(&self, use_ansi_coloring: bool) -> String {
+        self.settings()
+            .working_message(self.progress(), use_ansi_coloring)
     }
 
     /// Checks if the menu is active
@@ -538,6 +558,19 @@ pub trait MenuBuilder: Menu + Sized {
         self
     }
 
+    /// Set static working marker
+    #[must_use]
+    fn with_working_marker(self, marker: &str) -> Self {
+        self.with_working_indicator(WorkingIndicator::new([marker]))
+    }
+
+    /// Set full in-flight indicator
+    #[must_use]
+    fn with_working_indicator(mut self, working: WorkingIndicator) -> Self {
+        self.settings_mut().working = working;
+        self
+    }
+
     /// Set only_buffer_difference. Ignored when input_mode set.
     #[must_use]
     fn with_only_buffer_difference(mut self, only_buffer_difference: bool) -> Self {
@@ -667,6 +700,10 @@ impl Menu for ReedlineMenu {
 
     fn name(&self) -> &str {
         self.as_ref().name()
+    }
+
+    fn progress(&self) -> CompletionProgress {
+        self.as_ref().progress()
     }
 
     fn indicator(&self) -> &str {

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -340,6 +340,8 @@ pub struct MenuSettings {
     color: MenuTextStyle,
     /// Menu marker when active
     marker: String,
+    /// Working indicator; replaces marker during in-flight work.
+    working: WorkingIndicator,
     /// Use buffer diff after activation. Ignored if input_mode set.
     only_buffer_difference: bool,
     /// Optional override for completer input handling.
@@ -356,6 +358,7 @@ impl Default for MenuSettings {
             name: "menu".to_string(),
             color: MenuTextStyle::default(),
             marker: "| ".to_string(),
+            working: WorkingIndicator::default(),
             only_buffer_difference: false,
             input_mode: None,
             output_mode: None,
@@ -376,6 +379,35 @@ impl MenuSettings {
     pub fn with_color(mut self, color: MenuTextStyle) -> Self {
         self.color = color;
         self
+    }
+
+    /// Static marker for in-flight work
+    #[must_use]
+    pub fn with_working_marker(self, marker: &str) -> Self {
+        self.with_working_indicator(WorkingIndicator::new([marker]))
+    }
+
+    /// Set working indicator
+    #[must_use]
+    pub fn with_working_indicator(mut self, working: WorkingIndicator) -> Self {
+        self.working = working;
+        self
+    }
+
+    /// Working indicator reference
+    pub fn working_indicator(&self) -> &WorkingIndicator {
+        &self.working
+    }
+
+    /// Message after patience elapsed; empty otherwise.
+    fn working_message(&self, progress: CompletionProgress, use_ansi_coloring: bool) -> String {
+        match self.working.message(progress.elapsed()) {
+            Some(msg) if use_ansi_coloring => {
+                format!("{}{}{}", self.color.text_style.prefix(), msg, RESET)
+            }
+            Some(msg) => msg.to_string(),
+            None => String::new(),
+        }
     }
 
     /// Set marker

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -6,7 +6,10 @@ pub mod menu_functions;
 
 use crate::core_editor::Editor;
 use crate::History;
-use crate::{completion::history::HistoryCompleter, painting::Painter, Completer, Suggestion};
+use crate::{
+    completion::history::HistoryCompleter, painting::Painter, Completer, CompletionResult,
+    Suggestion,
+};
 pub use columnar_menu::ColumnarMenu;
 pub use columnar_menu::TraversalDirection;
 pub use description_menu::DescriptionMenu;
@@ -14,7 +17,8 @@ pub use ide_menu::DescriptionMode;
 pub use ide_menu::IdeMenu;
 pub use list_menu::DescriptionPosition;
 pub use list_menu::ListMenu;
-use nu_ansi_term::{Color, Style};
+use nu_ansi_term::{ansi::RESET, Color, Style};
+use std::time::{Duration, Instant};
 
 /// Struct to store the menu style
 pub struct MenuTextStyle {
@@ -41,6 +45,141 @@ impl Default for MenuTextStyle {
             selected_match_style: Color::Green.bold().reverse().underline(),
             match_style: Style::default().underline(),
         }
+    }
+}
+
+/// In-flight completion indicator: animated marker + optional message.
+#[derive(Debug, Clone)]
+pub struct WorkingIndicator {
+    /// Animation frames
+    frames: Vec<String>,
+    /// Duration for one full frame cycle.
+    period: Duration,
+    /// Debounce: how long before the indicator shows.
+    grace: Duration,
+    /// Duration before message appears
+    patience: Duration,
+    /// Message shown when the wait is long enough.
+    message: String,
+}
+
+impl Default for WorkingIndicator {
+    fn default() -> Self {
+        // ASCII spinner: single-column in all terminals
+        Self::new(["- ", "\\ ", "| ", "/ "])
+    }
+}
+
+impl WorkingIndicator {
+    /// New indicator with default timings.
+    #[must_use]
+    pub fn new<I: IntoIterator<Item = impl Into<String>>>(frames: I) -> Self {
+        Self {
+            frames: frames.into_iter().map(Into::into).collect(),
+            period: Duration::from_millis(800),
+            grace: Duration::from_millis(120),
+            patience: Duration::from_secs(2),
+            message: "searching...".to_string(),
+        }
+    }
+
+    /// Set period.
+    #[must_use]
+    pub fn with_period(mut self, period: Duration) -> Self {
+        self.period = period;
+        self
+    }
+
+    /// Set grace period.
+    #[must_use]
+    pub fn with_grace(mut self, grace: Duration) -> Self {
+        self.grace = grace;
+        self
+    }
+
+    /// Set patience.
+    #[must_use]
+    pub fn with_patience(mut self, patience: Duration) -> Self {
+        self.patience = patience;
+        self
+    }
+
+    /// Set message.
+    #[must_use]
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = message.into();
+        self
+    }
+
+    /// Current visible state, or None during grace period.
+    pub fn phase(&self, elapsed: Option<Duration>) -> Option<WorkingPhase> {
+        let elapsed = elapsed.filter(|&e| !self.frames.is_empty() && e >= self.grace)?;
+        let nanos = self.period.as_nanos();
+        // Nanos per frame; minimum 1 step per tick.
+        let step = if nanos == 0 {
+            0
+        } else {
+            (nanos / self.frames.len() as u128).max(1)
+        };
+        let ticks = (elapsed - self.grace).as_nanos().checked_div(step);
+
+        Some(WorkingPhase {
+            frame: ticks.map_or(0, |t| (t % self.frames.len() as u128) as usize),
+            spelled_out: elapsed >= self.patience,
+        })
+    }
+
+    fn marker(&self, elapsed: Option<Duration>) -> Option<&str> {
+        Some(self.frames[self.phase(elapsed)?.frame].as_str())
+    }
+
+    fn message(&self, elapsed: Option<Duration>) -> Option<&str> {
+        self.phase(elapsed)?.spelled_out.then_some(&*self.message)
+    }
+}
+
+/// Snapshot of WorkingIndicator at an instant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkingPhase {
+    /// Current frame index
+    pub frame: usize,
+    /// Whether message is also shown
+    pub spelled_out: bool,
+}
+
+/// Completion start instant, or None.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CompletionProgress {
+    since: Option<Instant>,
+}
+
+impl CompletionProgress {
+    /// Create progress already at a given elapsed time.
+    pub fn working_for(elapsed: Duration) -> Self {
+        let now = Instant::now();
+        Self {
+            since: Some(now.checked_sub(elapsed).unwrap_or(now)),
+        }
+    }
+
+    /// Start/stop clock on work in flight; idempotent start.
+    pub fn update(&mut self, result: &CompletionResult) {
+        match result {
+            CompletionResult::Fresh { .. } => self.since = None,
+            CompletionResult::Stale { .. } | CompletionResult::Pending => {
+                self.since.get_or_insert_with(Instant::now);
+            }
+        }
+    }
+
+    /// Whether a completion is still in flight.
+    pub fn is_working(&self) -> bool {
+        self.since.is_some()
+    }
+
+    /// Elapsed time since start.
+    pub fn elapsed(&self) -> Option<Duration> {
+        self.since.map(|since| since.elapsed())
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Reedline! -->

## Summary <!-- Must Have -->
<!--
Motivate this PR: why did you open it, how did you arrive at this solution?
Mention any changes to Reedline's public API or observable behavior, or mention that there are none.
-->
This adds really cute completion indicators to reedline! Effectively a series of dots, pulsating in/out. Included with this is a clearer APIs around completion status, through workingphase and completion progress. 

### Before <!-- Much Appreciated -->
<!--
Describe behavior, function or implementation BEFORE your changes.
If not applicable, just remove the heading.
-->
- Completion rendered as a static marker.
- Background work was tracked a boolean.

### After <!-- Much Appreciated -->
<!--
Describe behavior, function or implementation AFTER your changes.
If not applicable, just remove the heading.
-->
-  Completions are communicated as a dynamic state. This opens up doors for further extensibility (like 1-100 for bars and things)
- Added apis for communicating when completion values are stale or un-stale, through working_indicator and working_marker.

## Additional notes <!-- Optional -->
<!--
Anything else worth knowing. Link related issues with `closes #123` / `fixes #456` to auto-close them on merge.
-->
