### PR TITLE
Take the external-print anchor from the terminal, not a count

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1180,12 +1180,24 @@ impl Painter {
             self.stdout.queue(Print(line))?.queue(Print("\r\n"))?;
             row = row.saturating_add(1).min(max_row);
         }
-        // Track the row by counting `\r\n`s — matches reedline's
-        // historical behavior. The drift check is one-sided so a
-        // message that secretly scrolls more rows than we counted
-        // (embedded `\n`, certain CSI sequences) can still incorrectly
-        // anchor.
-        self.prompt_start_row = PromptStartRow::Stale(row);
+        // The lines above are only *queued*, so the terminal's cursor has not
+        // moved yet: a row counted forward from `starting_row` names a position
+        // the terminal has not reached. Recorded as `Stale`, the next paint
+        // re-verifies it against the real, still-earlier cursor, reads that as
+        // the prompt having scrolled off the top, and re-anchors by printing a
+        // whole screen of newlines -- wiping the display (#1005).
+        //
+        // Counting was also only as good as its assumption that a message
+        // occupies exactly one row, which fails as soon as one wraps or carries
+        // its own control sequences. Flush and ask instead: one round-trip per
+        // batch of messages, not per message, so the flicker the comment above
+        // guards against is unaffected.
+        self.stdout.flush()?;
+        let row = match cursor::position() {
+            Ok((_, actual)) => actual,
+            Err(_) => row,
+        };
+        self.prompt_start_row = PromptStartRow::Verified(row);
         Ok(())
     }
 

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1193,11 +1193,15 @@ impl Painter {
         // batch of messages, not per message, so the flicker the comment above
         // guards against is unaffected.
         self.stdout.flush()?;
-        let row = match cursor::position() {
-            Ok((_, actual)) => actual,
-            Err(_) => row,
+        self.prompt_start_row = match cursor::position() {
+            // Measured, so later paints can skip the drift check.
+            Ok((_, actual)) => PromptStartRow::Verified(actual),
+            // No answer, so all that is left is the count this function stopped
+            // trusting. `Stale` at least keeps the next paint checking it;
+            // `Verified` would skip the check and paint against a row the
+            // terminal may never have reached.
+            Err(_) => PromptStartRow::Stale(row),
         };
-        self.prompt_start_row = PromptStartRow::Verified(row);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

`print_external_message` queues its lines without flushing, then records the new prompt anchor by counting one row per message. Nothing has been flushed at that point, so the terminal's cursor has not moved — the anchor names a row the terminal has not reached. Stored as `Stale`, the next paint re-verifies it against the real, still-earlier cursor, reads the gap as the prompt having scrolled off the top, and re-anchors the only way it can: by printing a screenful of newlines. That is the wipe in #1005.

I ran into it in a shell I'm writing, where job notifications arrive in batches, and traced it with an instrumented painter before changing anything.

No public API change, and no observable behaviour change beyond the wipe no longer happening.

### Before

Two or more messages sent while the prompt sits near the top of the screen wipe the display. A single message never triggers it, and a full screen is immune — both follow from the arithmetic (`pos.1 + 1 < row`, and `row` being clamped by `.min(max_row)`), worked through in #1005.

### After

The anchor is taken from `cursor::position()` after a flush, so it matches the terminal and the drift check has nothing to misread.

## Additional notes

- The flush is once per batch rather than per message, so the flicker the retained comment warns about is unaffected.
- It also drops the assumption that each message occupies exactly one row, which the replaced comment already called unsafe for messages that wrap or carry control sequences.
- 1209 tests pass. `painting::painter::tests::crossterm_defaults_were_the_bright_palette_entries` fails identically with and without this change on clean `main` here (Windows), so it is pre-existing.

Fixes #1005.
