### PR TITLE
test(editor): keep case-transform selections inside the buffer

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -3505,13 +3505,13 @@ mod test {
     #[rstest]
     #[case("foo bar baz", 0, 3, EditCommand::LowercaseSelection, "foo bar baz")]
     #[case("Foo Bar Baz", 0, 7, EditCommand::LowercaseSelection, "foo bar Baz")]
-    #[case("FOO BAR BAZ", 0, 12, EditCommand::LowercaseSelection, "foo bar baz")]
+    #[case("FOO BAR BAZ", 0, 11, EditCommand::LowercaseSelection, "foo bar baz")]
     #[case("foo bar baz", 0, 3, EditCommand::UppercaseSelection, "FOO bar baz")]
     #[case("Foo Bar Baz", 0, 7, EditCommand::UppercaseSelection, "FOO BAR Baz")]
-    #[case("FOO BAR BAZ", 0, 12, EditCommand::UppercaseSelection, "FOO BAR BAZ")]
+    #[case("FOO BAR BAZ", 0, 11, EditCommand::UppercaseSelection, "FOO BAR BAZ")]
     #[case("foo bar baz", 0, 3, EditCommand::SwitchcaseSelection, "FOO bar baz")]
     #[case("Foo Bar Baz", 0, 7, EditCommand::SwitchcaseSelection, "fOO bAR Baz")]
-    #[case("FOO BAR BAZ", 0, 12, EditCommand::SwitchcaseSelection, "foo bar baz")]
+    #[case("FOO BAR BAZ", 0, 11, EditCommand::SwitchcaseSelection, "foo bar baz")]
     fn test_lower_upper_switchcase_selection(
         #[case] input: &str,
         #[case] selection_start: usize,


### PR DESCRIPTION
<!-- Thanks for contributing to Reedline! -->

## Summary <!-- Must Have -->
<!--
Motivate this PR: why did you open it, how did you arrive at this solution?
Mention any changes to Reedline's public API or observable behavior, or mention that there are none.
-->
`main` is red at 18146e6 (#1087).
Three `rstest` cases in `test_lower_upper_switchcase_selection` select to byte 12 of `"FOO BAR BAZ"`, which is 11 bytes.
`move_to_position` thus lands one past the end and trips `debug_assert!(buf.is_char_boundary(pos))` in `prev_grapheme_boundary`, panicking with `pos must be a char boundary`.

Moves the three cases to 11.

## Additional notes <!-- Optional -->
<!--
Anything else worth knowing. Link related issues with `closes #123` / `fixes #456` to auto-close them on merge.
-->

These cases were never correct, they just had nothing to trip over.
The `debug_assert` landed in 71f68ab (#1100), after #1087 branched off bab11cfd, and #1087's CI last ran in May against that older base.