### PR TITLE
fix(painter): pin the cursor when a line fills the terminal width

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -626,20 +626,13 @@ impl Painter {
             None
         };
 
-        // `SavePosition` may have recorded a deferred wrap (see
-        // `ends_at_right_margin`), which restores to either side of the margin.
-        // Place the cursor absolutely instead.
-        //
         // It has to happen *here*, after every print: the position
         // `SavePosition` recorded is also the print head for the text after the
         // cursor, so disambiguating it earlier either writes a glyph onto an
         // unreserved row or overwrites the cell the next row's first grapheme
         // belongs in. Nothing is drawn at this point, so a bare move disturbs
         // neither.
-        match margin_cursor_row {
-            Some(row) => self.stdout.queue(MoveTo(0, row))?,
-            None => self.stdout.queue(RestorePosition)?,
-        };
+        self.queue_cursor_placement(margin_cursor_row)?;
 
         if let Some(shapes) = cursor_config {
             let shape = match &prompt_mode {
@@ -850,19 +843,26 @@ impl Painter {
         None
     }
 
-    fn print_right_prompt(
+    /// `printed_before` is the text this paint put on screen ahead of the save
+    /// below, which is what decides whether that save landed on the margin. It
+    /// arrives unjoined and is only walked past the early return, so a paint
+    /// with no right prompt pays nothing for it.
+    fn print_right_prompt<'a>(
         &mut self,
         lines: &PromptLines,
         layout: &PromptLayout,
-        margin_row: Option<u16>,
+        printed_before: impl IntoIterator<Item = &'a str>,
     ) -> Result<()> {
         let Some(rp) = &layout.right_prompt else {
             return Ok(());
         };
+        let (start_col, row) = (rp.start_col, rp.row);
+
+        let margin_row = self.margin_cursor_row(printed_before);
 
         self.stdout
             .queue(SavePosition)?
-            .queue(cursor::MoveTo(rp.start_col, rp.row))?;
+            .queue(cursor::MoveTo(start_col, row))?;
 
         // Emit right prompt marker (OSC 133;P;k=r)
         if let Some(markers) = &self.semantic_markers {
@@ -873,11 +873,20 @@ impl Painter {
         self.stdout
             .queue(Print(&coerce_crlf(&lines.prompt_str_right)))?;
 
+        self.queue_cursor_placement(margin_row)
+    }
+
+    /// Put the cursor back where the paint left it, given the row
+    /// [`Self::margin_cursor_row`] decided on.
+    ///
+    /// `SavePosition` may have recorded a deferred wrap, which restores to
+    /// either side of the margin depending on the terminal, so on the margin the
+    /// cursor is placed absolutely instead of restored.
+    fn queue_cursor_placement(&mut self, margin_row: Option<u16>) -> Result<()> {
         match margin_row {
             Some(row) => self.stdout.queue(MoveTo(0, row))?,
             None => self.stdout.queue(RestorePosition)?,
         };
-
         Ok(())
     }
 
@@ -920,7 +929,8 @@ impl Painter {
     }
 
     /// The absolute row the cursor must be moved to, when `printed` (the text
-    /// this paint actually emitted before the cursor) ends at the right margin.
+    /// this paint actually emitted before the cursor, in the order it was
+    /// emitted) ends at the right margin.
     ///
     /// `None` off the margin, where `RestorePosition` is unambiguous. Each print
     /// path answers for its own output rather than the caller reconstructing it:
@@ -933,7 +943,7 @@ impl Painter {
     /// there is no position to move to: the terminal would clamp the move to the
     /// first column of the bottom row, which is a whole row's travel from the
     /// text. `RestorePosition` at least lands next to it.
-    fn margin_cursor_row(&self, printed: &str) -> Option<u16> {
+    fn margin_cursor_row<'a>(&self, printed: impl IntoIterator<Item = &'a str>) -> Option<u16> {
         let rows = deferred_wrap_row(printed, self.screen_width())?;
         let row = self.prompt_start_row.last_known_row().saturating_add(rows);
         (row < self.screen_height()).then_some(row)
@@ -975,14 +985,11 @@ impl Painter {
                 .queue(SetForegroundColor(prompt.get_prompt_right_color()))?;
         }
 
-        // Only a *placed* right prompt saves and restores, so skip building the
-        // prefix when there is none: this runs on every paint.
-        let margin_row = if layout.right_prompt.is_some() {
-            self.margin_cursor_row(&(lines.prompt_str_left.to_string() + &lines.prompt_indicator))
-        } else {
-            None
-        };
-        self.print_right_prompt(lines, layout, margin_row)?;
+        self.print_right_prompt(
+            lines,
+            layout,
+            [&*lines.prompt_str_left, &lines.prompt_indicator],
+        )?;
 
         // Emit command input start marker (OSC 133;B) after prompt (including right prompt)
         if let Some(markers) = &self.semantic_markers {
@@ -1000,9 +1007,11 @@ impl Painter {
             .queue(SavePosition)?
             .queue(Print(&lines.after_cursor))?;
 
-        let cursor_row = self.margin_cursor_row(
-            &(lines.prompt_str_left.to_string() + &lines.prompt_indicator + &lines.before_cursor),
-        );
+        let cursor_row = self.margin_cursor_row([
+            &*lines.prompt_str_left,
+            &lines.prompt_indicator,
+            &lines.before_cursor,
+        ]);
 
         if let Some(menu) = menu {
             self.print_menu(menu, use_ansi_coloring, layout)?;
@@ -1055,12 +1064,7 @@ impl Painter {
             }
 
             // Judged from the *skipped* prompt, which is what reached the screen.
-            let margin_row = if layout.right_prompt.is_some() {
-                self.margin_cursor_row(prompt_skipped)
-            } else {
-                None
-            };
-            self.print_right_prompt(lines, layout, margin_row)?;
+            self.print_right_prompt(lines, layout, [prompt_skipped])?;
         }
 
         if use_ansi_coloring {
@@ -1090,9 +1094,8 @@ impl Painter {
         self.stdout.queue(SavePosition)?;
 
         // Computed from the *skipped* text, which is what reached the screen.
-        let cursor_row = self.margin_cursor_row(
-            &(prompt_skipped.to_string() + indicator_skipped + before_cursor_skipped),
-        );
+        let cursor_row =
+            self.margin_cursor_row([prompt_skipped, indicator_skipped, before_cursor_skipped]);
 
         if let Some(menu) = menu {
             // TODO: Also solve the difficult problem of displaying (parts of)
@@ -1580,26 +1583,38 @@ mod tests {
         )
     }
 
-    /// Replay `bytes` into a character grid, returning the final cursor, the
-    /// highest row a glyph reached, and the rendered screen.
+    /// What a terminal ends up in after a byte stream.
+    #[derive(Debug)]
+    struct Replayed {
+        /// Row, column, and whether a wrap is deferred. Compared as a unit,
+        /// since a cursor that agrees on two of the three is still ambiguous.
+        cursor: (u16, u16, bool),
+        /// The highest row a glyph actually reached, to check against the rows
+        /// the paint reserved.
+        max_written: u16,
+        /// The rendered screen: rows right-trimmed and concatenated, with no
+        /// separator, so a case can state the text it expects without also
+        /// stating where it wrapped. Row structure is covered by `cursor` and
+        /// `max_written` rather than here.
+        screen: String,
+    }
+
+    /// Replay `bytes` into a character grid.
     ///
     /// `save_carries_pending` picks which way DECSC/DECRC treat a deferred wrap,
     /// so the same stream can be read as either kind of terminal would.
-    fn replay(
-        bytes: &str,
-        width: u16,
-        save_carries_pending: bool,
-    ) -> (u16, u16, bool, u16, String) {
-        let (mut row, mut col, mut pending) = (0u16, 0u16, false);
-        let (mut srow, mut scol, mut spend) = (0u16, 0u16, false);
-        let mut max_written = 0u16;
-        let mut grid: Vec<Vec<char>> = vec![];
-        let put = |r: u16, c: u16, ch: char, g: &mut Vec<Vec<char>>| {
+    fn replay(bytes: &str, width: u16, save_carries_pending: bool) -> Replayed {
+        fn put(r: u16, c: u16, ch: char, width: u16, g: &mut Vec<Vec<char>>) {
             while g.len() <= r as usize {
                 g.push(vec![' '; width as usize]);
             }
             g[r as usize][c as usize] = ch;
-        };
+        }
+
+        let (mut row, mut col, mut pending) = (0u16, 0u16, false);
+        let (mut srow, mut scol, mut spend) = (0u16, 0u16, false);
+        let mut max_written = 0u16;
+        let mut grid: Vec<Vec<char>> = vec![];
         let b: Vec<char> = bytes.chars().collect();
         let mut i = 0;
         while i < b.len() {
@@ -1656,7 +1671,7 @@ mod tests {
                         col = 0;
                         pending = false;
                     }
-                    put(row, col, ch, &mut grid);
+                    put(row, col, ch, width, &mut grid);
                     max_written = max_written.max(row);
                     if col + 1 >= width {
                         pending = true;
@@ -1667,11 +1682,15 @@ mod tests {
                 }
             }
         }
-        let screen: String = grid
+        let screen = grid
             .iter()
             .map(|r| r.iter().collect::<String>().trim_end().to_string())
             .collect();
-        (row, col, pending, max_written, screen)
+        Replayed {
+            cursor: (row, col, pending),
+            max_written,
+            screen,
+        }
     }
 
     /// The three assertions below must hold *together*: two earlier fixes for
@@ -1698,16 +1717,14 @@ mod tests {
         let lines = make_lines("> ", "", "", &before, after);
         let (out, reserved, _) = capture_repaint(&lines, 0);
 
-        let (r1, c1, p1, rows1, screen1) = replay(&out, 20, true);
-        let (r2, c2, p2, rows2, screen2) = replay(&out, 20, false);
+        let (first, second) = (replay(&out, 20, true), replay(&out, 20, false));
 
         assert_eq!(
-            (r1, c1, p1),
-            (r2, c2, p2),
+            first.cursor, second.cursor,
             "n={n} after={after:?}: cursor depends on how DECSC treats the \
              pending-wrap flag; emitted {out:?}"
         );
-        let written = rows1.max(rows2);
+        let written = first.max_written.max(second.max_written);
         assert!(
             written < reserved,
             "n={n} after={after:?}: wrote to row {written} with only {reserved} \
@@ -1715,11 +1732,11 @@ mod tests {
         );
         let expected = format!("> {before}{after}");
         assert_eq!(
-            screen1, expected,
+            first.screen, expected,
             "n={n} after={after:?}: screen was corrupted"
         );
         assert_eq!(
-            screen2, expected,
+            second.screen, expected,
             "n={n} after={after:?}: screen was corrupted"
         );
     }
@@ -1747,11 +1764,9 @@ mod tests {
         let (out, _reserved, large) = capture_repaint(&lines, 0);
         assert!(large, "n={n}: meant to exercise the large-buffer path");
 
-        let (r1, c1, p1, ..) = replay(&out, 20, true);
-        let (r2, c2, p2, ..) = replay(&out, 20, false);
+        let (first, second) = (replay(&out, 20, true), replay(&out, 20, false));
         assert_eq!(
-            (r1, c1, p1),
-            (r2, c2, p2),
+            first.cursor, second.cursor,
             "n={n}: cursor depends on how DECSC treats the pending-wrap flag; \
              emitted {out:?}"
         );
@@ -1775,16 +1790,14 @@ mod tests {
         let (out, reserved, large) = capture_repaint(&lines, 0);
         assert!(!large, "meant to exercise the small-buffer path");
 
-        let (r1, c1, p1, rows1, screen1) = replay(&out, 20, true);
-        let (r2, c2, p2, rows2, screen2) = replay(&out, 20, false);
+        let (first, second) = (replay(&out, 20, true), replay(&out, 20, false));
 
         assert_eq!(
-            (r1, c1, p1),
-            (r2, c2, p2),
+            first.cursor, second.cursor,
             "cursor depends on how DECSC treats the pending-wrap flag across the \
              right prompt's save/restore; emitted {out:?}"
         );
-        let written = rows1.max(rows2);
+        let written = first.max_written.max(second.max_written);
         assert!(
             written < reserved,
             "wrote to row {written} with only {reserved} row(s) reserved"
@@ -1792,8 +1805,8 @@ mod tests {
         // Row 0 is the prompt's first line with `R` in the last cell, row 1 the
         // filled line, row 2 the input. `replay` concatenates right-trimmed rows.
         let expected = format!("ab{}R{}Z", " ".repeat(17), "x".repeat(20));
-        assert_eq!(screen1, expected, "screen was corrupted");
-        assert_eq!(screen2, expected, "screen was corrupted");
+        assert_eq!(first.screen, expected, "screen was corrupted");
+        assert_eq!(second.screen, expected, "screen was corrupted");
     }
 
     /// The same save, on the large-buffer path, which prints a *skipped* prompt
@@ -1815,18 +1828,19 @@ mod tests {
         let (out, _reserved, large) = capture_repaint(&lines, 0);
         assert!(large, "meant to exercise the large-buffer path");
 
-        let (r1, c1, p1, _, screen1) = replay(&out, 20, true);
-        let (r2, c2, p2, _, screen2) = replay(&out, 20, false);
+        let (first, second) = (replay(&out, 20, true), replay(&out, 20, false));
 
         assert_eq!(
-            (r1, c1, p1),
-            (r2, c2, p2),
+            first.cursor, second.cursor,
             "cursor depends on how DECSC treats the pending-wrap flag across the \
              right prompt's save/restore; emitted {out:?}"
         );
         // Asserted against each other rather than a literal: what a large buffer
         // puts on screen is a trimmed window, but it must not differ by terminal.
-        assert_eq!(screen1, screen2, "screen depends on the DECSC convention");
+        assert_eq!(
+            first.screen, second.screen,
+            "screen depends on the DECSC convention"
+        );
     }
 
     /// Content that fills the screen exactly puts the deferred wrap on a row the

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -2,7 +2,7 @@ use crate::terminal_extensions::semantic_prompt::{PromptKind, SemanticPromptMark
 use crate::{CursorConfig, PromptEditMode, PromptViMode};
 
 use {
-    super::utils::{coerce_crlf, estimate_required_lines, line_width},
+    super::utils::{coerce_crlf, ends_at_right_margin, estimate_required_lines, line_width},
     crate::{
         menu::{Menu, ReedlineMenu},
         painting::PromptLines,
@@ -609,11 +609,11 @@ impl Painter {
 
         let layout = self.compute_layout(lines, menu);
 
-        if self.large_buffer {
-            self.print_large_buffer(prompt, lines, menu, use_ansi_coloring, &layout)?;
+        let margin_cursor_row = if self.large_buffer {
+            self.print_large_buffer(prompt, lines, menu, use_ansi_coloring, &layout)?
         } else {
-            self.print_small_buffer(prompt, lines, menu, use_ansi_coloring, &layout)?;
-        }
+            self.print_small_buffer(prompt, lines, menu, use_ansi_coloring, &layout)?
+        };
 
         self.last_layout = Some(layout);
 
@@ -626,7 +626,20 @@ impl Painter {
             None
         };
 
-        self.stdout.queue(RestorePosition)?;
+        // `SavePosition` may have recorded a deferred wrap (see
+        // `ends_at_right_margin`), which restores to either side of the margin.
+        // Place the cursor absolutely instead.
+        //
+        // It has to happen *here*, after every print: the position
+        // `SavePosition` recorded is also the print head for the text after the
+        // cursor, so disambiguating it earlier either writes a glyph onto an
+        // unreserved row or overwrites the cell the next row's first grapheme
+        // belongs in. Nothing is drawn at this point, so a bare move disturbs
+        // neither.
+        match margin_cursor_row {
+            Some(row) => self.stdout.queue(MoveTo(0, row))?,
+            None => self.stdout.queue(RestorePosition)?,
+        };
 
         if let Some(shapes) = cursor_config {
             let shape = match &prompt_mode {
@@ -897,6 +910,22 @@ impl Painter {
         Ok(())
     }
 
+    /// The absolute row the cursor must be moved to, when `printed` (the text
+    /// this paint actually emitted before the cursor) ends at the right margin.
+    ///
+    /// `None` off the margin, where `RestorePosition` is unambiguous. Each print
+    /// path answers for its own output rather than the caller reconstructing it:
+    /// a large buffer prints line-skipped text, so the rows it occupies are not
+    /// the rows the untrimmed buffer would.
+    fn margin_cursor_row(&self, printed: &str) -> Option<u16> {
+        let width = self.screen_width();
+        if !ends_at_right_margin(printed, width) {
+            return None;
+        }
+        let rows = estimate_required_lines(printed, width) as u16;
+        Some(self.prompt_start_row.last_known_row().saturating_add(rows))
+    }
+
     fn print_small_buffer(
         &mut self,
         prompt: &dyn Prompt,
@@ -904,7 +933,7 @@ impl Painter {
         menu: Option<&ReedlineMenu>,
         use_ansi_coloring: bool,
         layout: &PromptLayout,
-    ) -> Result<()> {
+    ) -> Result<Option<u16>> {
         // Emit prompt start marker (OSC 133;A;k=i for primary prompt)
         if let Some(markers) = &self.semantic_markers {
             self.stdout
@@ -951,13 +980,17 @@ impl Painter {
             .queue(SavePosition)?
             .queue(Print(&lines.after_cursor))?;
 
+        let cursor_row = self.margin_cursor_row(
+            &(lines.prompt_str_left.to_string() + &lines.prompt_indicator + &lines.before_cursor),
+        );
+
         if let Some(menu) = menu {
             self.print_menu(menu, use_ansi_coloring, layout)?;
         } else {
             self.stdout.queue(Print(&lines.hint))?;
         }
 
-        Ok(())
+        Ok(cursor_row)
     }
 
     fn print_large_buffer(
@@ -967,7 +1000,7 @@ impl Painter {
         menu: Option<&ReedlineMenu>,
         use_ansi_coloring: bool,
         layout: &PromptLayout,
-    ) -> Result<()> {
+    ) -> Result<Option<u16>> {
         let screen_width = self.screen_width();
         let screen_height = self.screen_height();
         let cursor_distance = lines.distance_from_prompt(screen_width);
@@ -1030,6 +1063,11 @@ impl Painter {
         self.stdout.queue(Print(before_cursor_skipped))?;
         self.stdout.queue(SavePosition)?;
 
+        // Computed from the *skipped* text, which is what reached the screen.
+        let cursor_row = self.margin_cursor_row(
+            &(prompt_skipped.to_string() + indicator_skipped + before_cursor_skipped),
+        );
+
         if let Some(menu) = menu {
             // TODO: Also solve the difficult problem of displaying (parts of)
             // the content after the cursor with the completion menu
@@ -1054,7 +1092,7 @@ impl Painter {
             self.stdout.queue(Print(hint_skipped))?;
         }
 
-        Ok(())
+        Ok(cursor_row)
     }
 
     /// Updates prompt origin and offset to handle a screen resize event
@@ -1222,6 +1260,7 @@ mod tests {
     use crate::menu::MenuEvent;
     use crate::{Completer, Editor, PromptHistorySearch, Suggestion};
     use pretty_assertions::assert_eq;
+    use rstest::rstest;
     use std::borrow::Cow;
     use std::sync::{Arc, Mutex};
 
@@ -1495,6 +1534,225 @@ mod tests {
         p.repaint_buffer(prompt, lines, PromptEditMode::Default, None, false, &None)
             .expect("repaint_buffer failed");
         String::from_utf8_lossy(p.stdout.captured()).into_owned()
+    }
+
+    /// Replay `bytes` into a character grid, returning the final cursor, the
+    /// highest row a glyph reached, and the rendered screen.
+    ///
+    /// `save_carries_pending` picks which way DECSC/DECRC treat a deferred wrap,
+    /// so the same stream can be read as either kind of terminal would.
+    fn replay(
+        bytes: &str,
+        width: u16,
+        save_carries_pending: bool,
+    ) -> (u16, u16, bool, u16, String) {
+        let (mut row, mut col, mut pending) = (0u16, 0u16, false);
+        let (mut srow, mut scol, mut spend) = (0u16, 0u16, false);
+        let mut max_written = 0u16;
+        let mut grid: Vec<Vec<char>> = vec![];
+        let put = |r: u16, c: u16, ch: char, g: &mut Vec<Vec<char>>| {
+            while g.len() <= r as usize {
+                g.push(vec![' '; width as usize]);
+            }
+            g[r as usize][c as usize] = ch;
+        };
+        let b: Vec<char> = bytes.chars().collect();
+        let mut i = 0;
+        while i < b.len() {
+            match b[i] {
+                '\x1b' if i + 1 < b.len() && b[i + 1] == '7' => {
+                    (srow, scol, spend) = (row, col, pending && save_carries_pending);
+                    i += 2;
+                }
+                '\x1b' if i + 1 < b.len() && b[i + 1] == '8' => {
+                    (row, col, pending) = (srow, scol, spend);
+                    i += 2;
+                }
+                '\x1b' if i + 1 < b.len() && b[i + 1] == '[' => {
+                    let mut j = i + 2;
+                    while j < b.len() && !('\x40'..='\x7e').contains(&b[j]) {
+                        j += 1;
+                    }
+                    let params: String = b[i + 2..j.min(b.len())].iter().collect();
+                    if j < b.len() && b[j] == 'H' {
+                        let mut it = params.split(';');
+                        row = it
+                            .next()
+                            .unwrap_or("1")
+                            .parse::<u16>()
+                            .unwrap_or(1)
+                            .saturating_sub(1);
+                        col = it
+                            .next()
+                            .unwrap_or("1")
+                            .parse::<u16>()
+                            .unwrap_or(1)
+                            .saturating_sub(1);
+                        pending = false;
+                    } else if j < b.len() && b[j] == 'G' {
+                        col = params.parse::<u16>().unwrap_or(1).saturating_sub(1);
+                        pending = false;
+                    }
+                    i = j + 1;
+                }
+                '\n' => {
+                    row += 1;
+                    col = 0;
+                    pending = false;
+                    i += 1;
+                }
+                '\r' => {
+                    col = 0;
+                    pending = false;
+                    i += 1;
+                }
+                ch => {
+                    if pending {
+                        row += 1;
+                        col = 0;
+                        pending = false;
+                    }
+                    put(row, col, ch, &mut grid);
+                    max_written = max_written.max(row);
+                    if col + 1 >= width {
+                        pending = true;
+                    } else {
+                        col += 1;
+                    }
+                    i += 1;
+                }
+            }
+        }
+        let screen: String = grid
+            .iter()
+            .map(|r| r.iter().collect::<String>().trim_end().to_string())
+            .collect();
+        (row, col, pending, max_written, screen)
+    }
+
+    /// Same as [`capture_with_reservation`] but reports whether the paint took
+    /// the large-buffer path, so a case can assert it exercised the one it meant
+    /// to: `large_buffer` turns on at `required_lines >= screen_height`, which is
+    /// a buffer length rather than anything the caller states directly.
+    fn capture_with_mode(lines: &PromptLines) -> (String, u16, bool) {
+        let mut p = Painter::new(W::capture());
+        p.terminal_size = (20, 10);
+        p.prompt_start_row.mark_verified(0);
+        p.prompt_height = 1;
+        p.repaint_buffer(
+            &TestPrompt,
+            lines,
+            PromptEditMode::Default,
+            None,
+            false,
+            &None,
+        )
+        .expect("repaint_buffer failed");
+        (
+            String::from_utf8_lossy(p.stdout.captured()).into_owned(),
+            p.last_required_lines,
+            p.large_buffer,
+        )
+    }
+
+    fn capture_with_reservation(lines: &PromptLines) -> (String, u16) {
+        let mut p = Painter::new(W::capture());
+        p.terminal_size = (20, 10);
+        p.prompt_start_row.mark_verified(0);
+        p.prompt_height = 1;
+        p.repaint_buffer(
+            &TestPrompt,
+            lines,
+            PromptEditMode::Default,
+            None,
+            false,
+            &None,
+        )
+        .expect("repaint_buffer failed");
+        let reserved = p.last_required_lines;
+        (
+            String::from_utf8_lossy(p.stdout.captured()).into_owned(),
+            reserved,
+        )
+    }
+
+    /// The three assertions below must hold *together*: two earlier fixes for
+    /// this bug each satisfied some and broke another, so any one of them alone
+    /// passes a broken painter.
+    ///
+    /// `"> "` is 2 columns of a 20-column terminal, so `n == 18` and `n == 38`
+    /// land the cursor exactly on a margin.
+    #[rstest]
+    #[case(17, "")]
+    #[case(18, "")]
+    #[case(19, "")]
+    #[case(37, "")]
+    #[case(38, "")]
+    #[case(17, "XYZ")]
+    #[case(18, "XYZ")]
+    #[case(19, "XYZ")]
+    #[case(38, "XYZ")]
+    fn a_paint_pins_the_cursor_without_disturbing_the_screen(
+        #[case] n: usize,
+        #[case] after: &str,
+    ) {
+        let before = "a".repeat(n);
+        let lines = make_lines("> ", "", "", &before, after);
+        let (out, reserved) = capture_with_reservation(&lines);
+
+        let (r1, c1, p1, rows1, screen1) = replay(&out, 20, true);
+        let (r2, c2, p2, rows2, screen2) = replay(&out, 20, false);
+
+        assert_eq!(
+            (r1, c1, p1),
+            (r2, c2, p2),
+            "n={n} after={after:?}: cursor depends on how DECSC treats the \
+             pending-wrap flag; emitted {out:?}"
+        );
+        let written = rows1.max(rows2);
+        assert!(
+            written < reserved,
+            "n={n} after={after:?}: wrote to row {written} with only {reserved} \
+             row(s) reserved; the next erase-below would leave it on screen"
+        );
+        let expected = format!("> {before}{after}");
+        assert_eq!(
+            screen1, expected,
+            "n={n} after={after:?}: screen was corrupted"
+        );
+        assert_eq!(
+            screen2, expected,
+            "n={n} after={after:?}: screen was corrupted"
+        );
+    }
+
+    /// The same three invariants on the large-buffer path, which prints
+    /// line-skipped text: the rows it puts on screen are not the rows the whole
+    /// buffer would need, so the margin has to be judged from what was actually
+    /// emitted.
+    ///
+    /// 20x10 terminal, so `large_buffer` turns on past ~200 columns of content.
+    /// `"> "` is 2 columns, making `n == 218` and `n == 238` exact multiples.
+    #[rstest]
+    #[case(218, "")]
+    #[case(238, "")]
+    #[case(217, "XYZ")]
+    #[case(218, "XYZ")]
+    #[case(238, "XYZ")]
+    fn a_large_buffer_paint_pins_the_cursor_too(#[case] n: usize, #[case] after: &str) {
+        let before = "a".repeat(n);
+        let lines = make_lines("> ", "", "", &before, after);
+        let (out, _reserved, large) = capture_with_mode(&lines);
+        assert!(large, "n={n}: meant to exercise the large-buffer path");
+
+        let (r1, c1, p1, ..) = replay(&out, 20, true);
+        let (r2, c2, p2, ..) = replay(&out, 20, false);
+        assert_eq!(
+            (r1, c1, p1),
+            (r2, c2, p2),
+            "n={n} after={after:?}: cursor depends on how DECSC treats the \
+             pending-wrap flag; emitted {out:?}"
+        );
     }
 
     #[test]

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1550,17 +1550,34 @@ mod tests {
         }
     }
 
-    /// Paint once into a capture buffer and return the exact bytes emitted.
+    /// Paint once into a capture buffer, returning the exact bytes emitted, the
+    /// rows the paint reserved, and whether it took the large-buffer path.
+    ///
     /// `anchor_row` is the cached prompt-start row; it is marked verified so the
     /// painter takes the no-drift path and never queries the real terminal.
-    fn capture_repaint(prompt: &dyn Prompt, lines: &PromptLines, anchor_row: u16) -> String {
+    ///
+    /// `large_buffer` comes back so a case can assert it exercised the path it
+    /// meant to: it turns on at `required_lines >= screen_height`, which is a
+    /// buffer length rather than anything the caller states directly.
+    fn capture_repaint(lines: &PromptLines, anchor_row: u16) -> (String, u16, bool) {
         let mut p = Painter::new(W::capture());
         p.terminal_size = (20, 10);
         p.prompt_start_row.mark_verified(anchor_row);
         p.prompt_height = 1;
-        p.repaint_buffer(prompt, lines, PromptEditMode::Default, None, false, &None)
-            .expect("repaint_buffer failed");
-        String::from_utf8_lossy(p.stdout.captured()).into_owned()
+        p.repaint_buffer(
+            &TestPrompt,
+            lines,
+            PromptEditMode::Default,
+            None,
+            false,
+            &None,
+        )
+        .expect("repaint_buffer failed");
+        (
+            String::from_utf8_lossy(p.stdout.captured()).into_owned(),
+            p.last_required_lines,
+            p.large_buffer,
+        )
     }
 
     /// Replay `bytes` into a character grid, returning the final cursor, the
@@ -1657,36 +1674,6 @@ mod tests {
         (row, col, pending, max_written, screen)
     }
 
-    /// Same as [`capture_with_reservation`] but reports whether the paint took
-    /// the large-buffer path, so a case can assert it exercised the one it meant
-    /// to: `large_buffer` turns on at `required_lines >= screen_height`, which is
-    /// a buffer length rather than anything the caller states directly.
-    fn capture_with_mode(lines: &PromptLines) -> (String, u16, bool) {
-        let mut p = Painter::new(W::capture());
-        p.terminal_size = (20, 10);
-        p.prompt_start_row.mark_verified(0);
-        p.prompt_height = 1;
-        p.repaint_buffer(
-            &TestPrompt,
-            lines,
-            PromptEditMode::Default,
-            None,
-            false,
-            &None,
-        )
-        .expect("repaint_buffer failed");
-        (
-            String::from_utf8_lossy(p.stdout.captured()).into_owned(),
-            p.last_required_lines,
-            p.large_buffer,
-        )
-    }
-
-    fn capture_with_reservation(lines: &PromptLines) -> (String, u16) {
-        let (out, reserved, _) = capture_with_mode(lines);
-        (out, reserved)
-    }
-
     /// The three assertions below must hold *together*: two earlier fixes for
     /// this bug each satisfied some and broke another, so any one of them alone
     /// passes a broken painter.
@@ -1709,7 +1696,7 @@ mod tests {
     ) {
         let before = "a".repeat(n);
         let lines = make_lines("> ", "", "", &before, after);
-        let (out, reserved) = capture_with_reservation(&lines);
+        let (out, reserved, _) = capture_repaint(&lines, 0);
 
         let (r1, c1, p1, rows1, screen1) = replay(&out, 20, true);
         let (r2, c2, p2, rows2, screen2) = replay(&out, 20, false);
@@ -1757,7 +1744,7 @@ mod tests {
         let before = "a".repeat(n);
         let after = "y".repeat(220);
         let lines = make_lines("> ", "", "", &before, &after);
-        let (out, _reserved, large) = capture_with_mode(&lines);
+        let (out, _reserved, large) = capture_repaint(&lines, 0);
         assert!(large, "n={n}: meant to exercise the large-buffer path");
 
         let (r1, c1, p1, ..) = replay(&out, 20, true);
@@ -1785,7 +1772,7 @@ mod tests {
         // placed; the second is 20, landing the cursor on the margin.
         let left = format!("ab\n{}", "x".repeat(20));
         let lines = make_lines(&left, "", "R", "Z", "");
-        let (out, reserved, large) = capture_with_mode(&lines);
+        let (out, reserved, large) = capture_repaint(&lines, 0);
         assert!(!large, "meant to exercise the small-buffer path");
 
         let (r1, c1, p1, rows1, screen1) = replay(&out, 20, true);
@@ -1825,7 +1812,7 @@ mod tests {
         // height without adding rows before the cursor.
         let after = "y".repeat(200);
         let lines = make_lines(&left, "", "R", "Z", &after);
-        let (out, _reserved, large) = capture_with_mode(&lines);
+        let (out, _reserved, large) = capture_repaint(&lines, 0);
         assert!(large, "meant to exercise the large-buffer path");
 
         let (r1, c1, p1, _, screen1) = replay(&out, 20, true);
@@ -1855,7 +1842,7 @@ mod tests {
     fn a_paint_that_fills_the_screen_does_not_move_off_it(#[case] n: usize) {
         let before = "a".repeat(n);
         let lines = make_lines("> ", "", "", &before, "");
-        let (out, ..) = capture_with_mode(&lines);
+        let (out, ..) = capture_repaint(&lines, 0);
 
         // crossterm encodes MoveTo(0, row) as "\x1b[{row+1};1H"; rows 10 and up
         // are off a ten-row screen.
@@ -1877,7 +1864,7 @@ mod tests {
         // as "\x1b[J", so that contiguous pair is exactly the bug (#1062).
         // Deliberately coupled to crossterm's escape encoding — it's the
         // byte-level contract we care about.
-        let out = capture_repaint(&TestPrompt, &make_lines("> ", "", "RP", "hello", ""), 0);
+        let (out, ..) = capture_repaint(&make_lines("> ", "", "RP", "hello", ""), 0);
         assert!(
             !out.contains("\x1b[1;1H\x1b[J"),
             "erase-below at home cell (0,0) would make tmux snapshot the prompt to history; emitted: {out:?}"
@@ -1889,7 +1876,7 @@ mod tests {
         // Sanity: away from the home cell the plain MoveTo + erase-below is
         // correct (tmux is not triggered), so the workaround must not apply
         // there. MoveTo(0,3) == "\x1b[4;1H".
-        let out = capture_repaint(&TestPrompt, &make_lines("> ", "", "RP", "hello", ""), 3);
+        let (out, ..) = capture_repaint(&make_lines("> ", "", "RP", "hello", ""), 3);
         assert!(
             out.contains("\x1b[4;1H\x1b[J"),
             "expected an erase-below from the anchor row; emitted: {out:?}"

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -2,7 +2,7 @@ use crate::terminal_extensions::semantic_prompt::{PromptKind, SemanticPromptMark
 use crate::{CursorConfig, PromptEditMode, PromptViMode};
 
 use {
-    super::utils::{coerce_crlf, ends_at_right_margin, estimate_required_lines, line_width},
+    super::utils::{coerce_crlf, deferred_wrap_row, estimate_required_lines, line_width},
     crate::{
         menu::{Menu, ReedlineMenu},
         painting::PromptLines,
@@ -934,11 +934,7 @@ impl Painter {
     /// first column of the bottom row, which is a whole row's travel from the
     /// text. `RestorePosition` at least lands next to it.
     fn margin_cursor_row(&self, printed: &str) -> Option<u16> {
-        let width = self.screen_width();
-        if !ends_at_right_margin(printed, width) {
-            return None;
-        }
-        let rows = estimate_required_lines(printed, width) as u16;
+        let rows = deferred_wrap_row(printed, self.screen_width())?;
         let row = self.prompt_start_row.last_known_row().saturating_add(rows);
         (row < self.screen_height()).then_some(row)
     }

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -926,13 +926,21 @@ impl Painter {
     /// path answers for its own output rather than the caller reconstructing it:
     /// a large buffer prints line-skipped text, so the rows it occupies are not
     /// the rows the untrimmed buffer would.
+    ///
+    /// Also `None` when the row the cursor belongs on is past the bottom of the
+    /// screen. Text that fills the screen exactly leaves the deferred wrap
+    /// pointing at a row the terminal has not scrolled into existence yet, so
+    /// there is no position to move to: the terminal would clamp the move to the
+    /// first column of the bottom row, which is a whole row's travel from the
+    /// text. `RestorePosition` at least lands next to it.
     fn margin_cursor_row(&self, printed: &str) -> Option<u16> {
         let width = self.screen_width();
         if !ends_at_right_margin(printed, width) {
             return None;
         }
         let rows = estimate_required_lines(printed, width) as u16;
-        Some(self.prompt_start_row.last_known_row().saturating_add(rows))
+        let row = self.prompt_start_row.last_known_row().saturating_add(rows);
+        (row < self.screen_height()).then_some(row)
     }
 
     fn print_small_buffer(
@@ -1679,24 +1687,8 @@ mod tests {
     }
 
     fn capture_with_reservation(lines: &PromptLines) -> (String, u16) {
-        let mut p = Painter::new(W::capture());
-        p.terminal_size = (20, 10);
-        p.prompt_start_row.mark_verified(0);
-        p.prompt_height = 1;
-        p.repaint_buffer(
-            &TestPrompt,
-            lines,
-            PromptEditMode::Default,
-            None,
-            false,
-            &None,
-        )
-        .expect("repaint_buffer failed");
-        let reserved = p.last_required_lines;
-        (
-            String::from_utf8_lossy(p.stdout.captured()).into_owned(),
-            reserved,
-        )
+        let (out, reserved, _) = capture_with_mode(lines);
+        (out, reserved)
     }
 
     /// The three assertions below must hold *together*: two earlier fixes for
@@ -1755,16 +1747,20 @@ mod tests {
     /// emitted.
     ///
     /// 20x10 terminal, so `large_buffer` turns on past ~200 columns of content.
-    /// `"> "` is 2 columns, making `n == 218` and `n == 238` exact multiples.
+    /// The bulk has to sit *after* the cursor: content before it would push the
+    /// cursor to the bottom of the screen, where the margin is unreachable (see
+    /// [`a_paint_that_fills_the_screen_does_not_move_off_it`]) and this fix does
+    /// not apply. `"> "` is 2 columns, so `n == 38`, `58` and `78` are exact
+    /// multiples and `n == 37` is the off-margin control.
     #[rstest]
-    #[case(218, "")]
-    #[case(238, "")]
-    #[case(217, "XYZ")]
-    #[case(218, "XYZ")]
-    #[case(238, "XYZ")]
-    fn a_large_buffer_paint_pins_the_cursor_too(#[case] n: usize, #[case] after: &str) {
+    #[case(38)]
+    #[case(58)]
+    #[case(78)]
+    #[case(37)]
+    fn a_large_buffer_paint_pins_the_cursor_too(#[case] n: usize) {
         let before = "a".repeat(n);
-        let lines = make_lines("> ", "", "", &before, after);
+        let after = "y".repeat(220);
+        let lines = make_lines("> ", "", "", &before, &after);
         let (out, _reserved, large) = capture_with_mode(&lines);
         assert!(large, "n={n}: meant to exercise the large-buffer path");
 
@@ -1773,8 +1769,8 @@ mod tests {
         assert_eq!(
             (r1, c1, p1),
             (r2, c2, p2),
-            "n={n} after={after:?}: cursor depends on how DECSC treats the \
-             pending-wrap flag; emitted {out:?}"
+            "n={n}: cursor depends on how DECSC treats the pending-wrap flag; \
+             emitted {out:?}"
         );
     }
 
@@ -1848,6 +1844,33 @@ mod tests {
         // Asserted against each other rather than a literal: what a large buffer
         // puts on screen is a trimmed window, but it must not differ by terminal.
         assert_eq!(screen1, screen2, "screen depends on the DECSC convention");
+    }
+
+    /// Content that fills the screen exactly puts the deferred wrap on a row the
+    /// terminal has not scrolled into existence, so there is no row to move to.
+    /// Emitting the move anyway gets it clamped to the bottom row's first
+    /// column, which is further from the text than the save already was.
+    ///
+    /// 20x10 terminal, `"> "` is 2 columns, so `n == 198` fills all ten rows.
+    #[rstest]
+    #[case(198)]
+    #[case(218)]
+    #[case(238)]
+    fn a_paint_that_fills_the_screen_does_not_move_off_it(#[case] n: usize) {
+        let before = "a".repeat(n);
+        let lines = make_lines("> ", "", "", &before, "");
+        let (out, ..) = capture_with_mode(&lines);
+
+        // crossterm encodes MoveTo(0, row) as "\x1b[{row+1};1H"; rows 10 and up
+        // are off a ten-row screen.
+        for row in 10..=40u16 {
+            let escape = format!("\x1b[{};1H", row + 1);
+            assert!(
+                !out.contains(&escape),
+                "n={n}: moved the cursor to row {row} on a ten-row screen; \
+                 emitted {out:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -850,7 +850,12 @@ impl Painter {
         None
     }
 
-    fn print_right_prompt(&mut self, lines: &PromptLines, layout: &PromptLayout) -> Result<()> {
+    fn print_right_prompt(
+        &mut self,
+        lines: &PromptLines,
+        layout: &PromptLayout,
+        margin_row: Option<u16>,
+    ) -> Result<()> {
         let Some(rp) = &layout.right_prompt else {
             return Ok(());
         };
@@ -866,8 +871,12 @@ impl Painter {
         }
 
         self.stdout
-            .queue(Print(&coerce_crlf(&lines.prompt_str_right)))?
-            .queue(RestorePosition)?;
+            .queue(Print(&coerce_crlf(&lines.prompt_str_right)))?;
+
+        match margin_row {
+            Some(row) => self.stdout.queue(MoveTo(0, row))?,
+            None => self.stdout.queue(RestorePosition)?,
+        };
 
         Ok(())
     }
@@ -962,7 +971,14 @@ impl Painter {
                 .queue(SetForegroundColor(prompt.get_prompt_right_color()))?;
         }
 
-        self.print_right_prompt(lines, layout)?;
+        // Only a *placed* right prompt saves and restores, so skip building the
+        // prefix when there is none: this runs on every paint.
+        let margin_row = if layout.right_prompt.is_some() {
+            self.margin_cursor_row(&(lines.prompt_str_left.to_string() + &lines.prompt_indicator))
+        } else {
+            None
+        };
+        self.print_right_prompt(lines, layout, margin_row)?;
 
         // Emit command input start marker (OSC 133;B) after prompt (including right prompt)
         if let Some(markers) = &self.semantic_markers {
@@ -1034,7 +1050,13 @@ impl Painter {
                     .queue(SetForegroundColor(prompt.get_prompt_right_color()))?;
             }
 
-            self.print_right_prompt(lines, layout)?;
+            // Judged from the *skipped* prompt, which is what reached the screen.
+            let margin_row = if layout.right_prompt.is_some() {
+                self.margin_cursor_row(prompt_skipped)
+            } else {
+                None
+            };
+            self.print_right_prompt(lines, layout, margin_row)?;
         }
 
         if use_ansi_coloring {
@@ -1248,6 +1270,7 @@ impl Painter {
         }
         Ok(())
     }
+
     #[cfg(test)]
     pub(crate) fn force_prompt_anchored_for_test(&mut self, row: u16) {
         self.prompt_start_row = PromptStartRow::Verified(row);
@@ -1753,6 +1776,78 @@ mod tests {
             "n={n} after={after:?}: cursor depends on how DECSC treats the \
              pending-wrap flag; emitted {out:?}"
         );
+    }
+
+    /// The right prompt saves and restores around its own `MoveTo`, and that
+    /// save is a second place a deferred wrap can be recorded ambiguously.
+    ///
+    /// Reaching it needs a *multi-line* left prompt. Placement is judged by
+    /// `estimate_right_prompt_line_width`, which for a one-row prompt adds the
+    /// indicator and input width and so overflows the margin case out of
+    /// existence; past one row it counts only the first line. A short first line
+    /// therefore leaves room for the right prompt while the last line still
+    /// fills the width, which is exactly when the save happens on the margin.
+    #[test]
+    fn a_right_prompt_paint_pins_the_cursor_too() {
+        // 20-column terminal. First line is 2 columns so the right prompt is
+        // placed; the second is 20, landing the cursor on the margin.
+        let left = format!("ab\n{}", "x".repeat(20));
+        let lines = make_lines(&left, "", "R", "Z", "");
+        let (out, reserved, large) = capture_with_mode(&lines);
+        assert!(!large, "meant to exercise the small-buffer path");
+
+        let (r1, c1, p1, rows1, screen1) = replay(&out, 20, true);
+        let (r2, c2, p2, rows2, screen2) = replay(&out, 20, false);
+
+        assert_eq!(
+            (r1, c1, p1),
+            (r2, c2, p2),
+            "cursor depends on how DECSC treats the pending-wrap flag across the \
+             right prompt's save/restore; emitted {out:?}"
+        );
+        let written = rows1.max(rows2);
+        assert!(
+            written < reserved,
+            "wrote to row {written} with only {reserved} row(s) reserved"
+        );
+        // Row 0 is the prompt's first line with `R` in the last cell, row 1 the
+        // filled line, row 2 the input. `replay` concatenates right-trimmed rows.
+        let expected = format!("ab{}R{}Z", " ".repeat(17), "x".repeat(20));
+        assert_eq!(screen1, expected, "screen was corrupted");
+        assert_eq!(screen2, expected, "screen was corrupted");
+    }
+
+    /// The same save, on the large-buffer path, which prints a *skipped* prompt
+    /// and so has to judge the margin from that rather than from `lines`.
+    ///
+    /// The two flags look mutually exclusive and are not: `large_buffer` is
+    /// `required_lines >= screen_height` over the whole content, while
+    /// `extra_rows` counts only what precedes the cursor. Content after the
+    /// cursor therefore turns the large-buffer path on while leaving the prompt
+    /// unscrolled, which is the one combination that still paints a right
+    /// prompt (`extra_rows > 0` suppresses it).
+    #[test]
+    fn a_large_buffer_right_prompt_paint_pins_the_cursor_too() {
+        let left = format!("ab\n{}", "x".repeat(20));
+        // 20x10 terminal: the trailing content pushes `required_lines` past the
+        // height without adding rows before the cursor.
+        let after = "y".repeat(200);
+        let lines = make_lines(&left, "", "R", "Z", &after);
+        let (out, _reserved, large) = capture_with_mode(&lines);
+        assert!(large, "meant to exercise the large-buffer path");
+
+        let (r1, c1, p1, _, screen1) = replay(&out, 20, true);
+        let (r2, c2, p2, _, screen2) = replay(&out, 20, false);
+
+        assert_eq!(
+            (r1, c1, p1),
+            (r2, c2, p2),
+            "cursor depends on how DECSC treats the pending-wrap flag across the \
+             right prompt's save/restore; emitted {out:?}"
+        );
+        // Asserted against each other rather than a literal: what a large buffer
+        // puts on screen is a trimmed window, but it must not differ by terminal.
+        assert_eq!(screen1, screen2, "screen depends on the DECSC convention");
     }
 
     #[test]

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -843,10 +843,10 @@ impl Painter {
         None
     }
 
-    /// `printed_before` is the text this paint put on screen ahead of the save
-    /// below, which is what decides whether that save landed on the margin. It
-    /// arrives unjoined and is only walked past the early return, so a paint
-    /// with no right prompt pays nothing for it.
+    /// `printed_before` is what this paint put on screen ahead of the save
+    /// below, which decides whether that save landed on the margin. It is only
+    /// walked past the early return, so a paint with no right prompt pays
+    /// nothing for it.
     fn print_right_prompt<'a>(
         &mut self,
         lines: &PromptLines,
@@ -876,12 +876,8 @@ impl Painter {
         self.queue_cursor_placement(margin_row)
     }
 
-    /// Put the cursor back where the paint left it, given the row
-    /// [`Self::margin_cursor_row`] decided on.
-    ///
-    /// `SavePosition` may have recorded a deferred wrap, which restores to
-    /// either side of the margin depending on the terminal, so on the margin the
-    /// cursor is placed absolutely instead of restored.
+    /// Put the cursor back where the paint left it: absolutely on the margin,
+    /// where the save is ambiguous, and by restoring it everywhere else.
     fn queue_cursor_placement(&mut self, margin_row: Option<u16>) -> Result<()> {
         match margin_row {
             Some(row) => self.stdout.queue(MoveTo(0, row))?,
@@ -928,21 +924,18 @@ impl Painter {
         Ok(())
     }
 
-    /// The absolute row the cursor must be moved to, when `printed` (the text
-    /// this paint actually emitted before the cursor, in the order it was
-    /// emitted) ends at the right margin.
+    /// The absolute row the cursor must be moved to, when `printed` (what this
+    /// paint emitted before the cursor, in order) ends at the right margin.
     ///
     /// `None` off the margin, where `RestorePosition` is unambiguous. Each print
     /// path answers for its own output rather than the caller reconstructing it:
     /// a large buffer prints line-skipped text, so the rows it occupies are not
     /// the rows the untrimmed buffer would.
     ///
-    /// Also `None` when the row the cursor belongs on is past the bottom of the
-    /// screen. Text that fills the screen exactly leaves the deferred wrap
-    /// pointing at a row the terminal has not scrolled into existence yet, so
-    /// there is no position to move to: the terminal would clamp the move to the
-    /// first column of the bottom row, which is a whole row's travel from the
-    /// text. `RestorePosition` at least lands next to it.
+    /// Also `None` past the bottom of the screen: text filling it exactly points
+    /// the deferred wrap at a row the terminal has not scrolled into existence,
+    /// and a move there gets clamped to the bottom row's first column, a whole
+    /// row from the text. Restoring at least lands next to it.
     fn margin_cursor_row<'a>(&self, printed: impl IntoIterator<Item = &'a str>) -> Option<u16> {
         let rows = deferred_wrap_row(printed, self.screen_width())?;
         let row = self.prompt_start_row.last_known_row().saturating_add(rows);
@@ -1553,15 +1546,13 @@ mod tests {
         }
     }
 
-    /// Paint once into a capture buffer, returning the exact bytes emitted, the
-    /// rows the paint reserved, and whether it took the large-buffer path.
+    /// Paint once into a capture buffer, returning the bytes emitted, the rows
+    /// the paint reserved, and whether it took the large-buffer path.
     ///
-    /// `anchor_row` is the cached prompt-start row; it is marked verified so the
-    /// painter takes the no-drift path and never queries the real terminal.
-    ///
-    /// `large_buffer` comes back so a case can assert it exercised the path it
-    /// meant to: it turns on at `required_lines >= screen_height`, which is a
-    /// buffer length rather than anything the caller states directly.
+    /// `anchor_row` is marked verified so the painter takes the no-drift path
+    /// and never queries the real terminal. `large_buffer` comes back so a case
+    /// can assert it exercised the path it meant to, since it turns on at
+    /// `required_lines >= screen_height` rather than at anything stated here.
     fn capture_repaint(lines: &PromptLines, anchor_row: u16) -> (String, u16, bool) {
         let mut p = Painter::new(W::capture());
         p.terminal_size = (20, 10);
@@ -1589,13 +1580,10 @@ mod tests {
         /// Row, column, and whether a wrap is deferred. Compared as a unit,
         /// since a cursor that agrees on two of the three is still ambiguous.
         cursor: (u16, u16, bool),
-        /// The highest row a glyph actually reached, to check against the rows
-        /// the paint reserved.
+        /// The highest row a glyph reached, to check against the rows reserved.
         max_written: u16,
-        /// The rendered screen: rows right-trimmed and concatenated, with no
-        /// separator, so a case can state the text it expects without also
-        /// stating where it wrapped. Row structure is covered by `cursor` and
-        /// `max_written` rather than here.
+        /// Rows right-trimmed and concatenated with no separator, so a case can
+        /// state the text it expects without also stating where it wrapped.
         screen: String,
     }
 
@@ -1741,17 +1729,14 @@ mod tests {
         );
     }
 
-    /// The same three invariants on the large-buffer path, which prints
-    /// line-skipped text: the rows it puts on screen are not the rows the whole
-    /// buffer would need, so the margin has to be judged from what was actually
-    /// emitted.
+    /// The large-buffer path prints line-skipped text, so the margin has to be
+    /// judged from what was emitted rather than from the whole buffer.
     ///
-    /// 20x10 terminal, so `large_buffer` turns on past ~200 columns of content.
-    /// The bulk has to sit *after* the cursor: content before it would push the
-    /// cursor to the bottom of the screen, where the margin is unreachable (see
-    /// [`a_paint_that_fills_the_screen_does_not_move_off_it`]) and this fix does
-    /// not apply. `"> "` is 2 columns, so `n == 38`, `58` and `78` are exact
-    /// multiples and `n == 37` is the off-margin control.
+    /// The bulk sits *after* the cursor deliberately: on this 20x10 terminal the
+    /// ~200 columns that turn `large_buffer` on would, placed before the cursor,
+    /// also fill the screen and put the margin out of reach (see
+    /// [`a_paint_that_fills_the_screen_does_not_move_off_it`]). `n == 37` is the
+    /// off-margin control.
     #[rstest]
     #[case(38)]
     #[case(58)]
@@ -1783,8 +1768,7 @@ mod tests {
     /// fills the width, which is exactly when the save happens on the margin.
     #[test]
     fn a_right_prompt_paint_pins_the_cursor_too() {
-        // 20-column terminal. First line is 2 columns so the right prompt is
-        // placed; the second is 20, landing the cursor on the margin.
+        // 20 columns: a 2-column first line, a second that fills the width.
         let left = format!("ab\n{}", "x".repeat(20));
         let lines = make_lines(&left, "", "R", "Z", "");
         let (out, reserved, large) = capture_repaint(&lines, 0);

--- a/src/painting/utils.rs
+++ b/src/painting/utils.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 /// Ensures input uses CRLF line endings.
@@ -89,22 +90,58 @@ pub(crate) fn line_width(line: &str) -> usize {
     strip_ansi(line).width()
 }
 
-/// Whether printing `printed` leaves the cursor at the terminal's right margin,
-/// in the *deferred wrap* state.
+/// Where printing `printed` leaves the cursor, when it lands on the terminal's
+/// right margin in the *deferred wrap* state.
 ///
 /// A terminal does not move to the next row when a glyph lands in the final
 /// column; it flags the cursor pending and only wraps once the next glyph
 /// arrives. Saving and restoring that state is ambiguous, since terminals
-/// disagree about whether DECSC/DECRC carry the flag.
-pub(crate) fn ends_at_right_margin(printed: &str, terminal_columns: u16) -> bool {
-    let terminal_columns: usize = terminal_columns.into();
-    if terminal_columns == 0 {
-        return false;
+/// disagree about whether DECSC/DECRC carry the flag, so the caller has to
+/// place the cursor absolutely instead. Returns how many rows past the start of
+/// `printed` that row is, or `None` when the run ends off the margin and
+/// `RestorePosition` is already unambiguous.
+///
+/// Laid out one grapheme at a time rather than by dividing the run's width,
+/// because the two disagree: a double-width grapheme with a single column left
+/// cannot be split, so the terminal leaves that column blank and wraps early.
+/// Division would report a 42-column run on a 21-column terminal as two exact
+/// rows ending on the margin, when the terminal has actually wrapped twice and
+/// left the cursor mid-row. That is the difference between restoring the cursor
+/// and moving it somewhere it never was.
+///
+/// Note this is the *only* place in the painter that models wrapping this
+/// precisely; [`estimate_required_lines`] and friends still divide, so row
+/// reservations remain approximate for wide graphemes. Placing the cursor is
+/// worth the extra pass because the error is directly visible.
+pub(crate) fn deferred_wrap_row(printed: &str, terminal_columns: u16) -> Option<u16> {
+    let columns: usize = terminal_columns.into();
+    if columns == 0 {
+        return None;
     }
-    // Only the text since the last hard line break sits on the cursor's row.
-    let last_row = printed.rsplit('\n').next().unwrap_or(printed);
-    let width = line_width(last_row);
-    width > 0 && width % terminal_columns == 0
+
+    let (mut row, mut col, mut pending) = (0u16, 0usize, false);
+    for grapheme in strip_ansi(printed).graphemes(true) {
+        match grapheme {
+            "\n" => (row, col, pending) = (row.saturating_add(1), 0, false),
+            "\r" => (col, pending) = (0, false),
+            _ => {
+                let width = grapheme.width();
+                // The wrap this grapheme's arrival was deferred until.
+                if pending {
+                    (row, col) = (row.saturating_add(1), 0);
+                }
+                // No room for the whole grapheme: the trailing column stays
+                // blank and the terminal wraps before drawing it.
+                if col + width > columns {
+                    (row, col) = (row.saturating_add(1), 0);
+                }
+                col += width;
+                pending = col >= columns;
+            }
+        }
+    }
+
+    pending.then(|| row.saturating_add(1))
 }
 
 #[cfg(test)]
@@ -130,6 +167,78 @@ mod test {
             input != expected || matches!(result, Cow::Borrowed(_)),
             "Unnecessary allocation"
         )
+    }
+
+    /// Narrow graphemes pack a row exactly, so the margin falls on every whole
+    /// multiple of the width and the row is that multiple.
+    #[rstest]
+    #[case("", 20, None)]
+    #[case("a", 20, None)]
+    #[case(&"a".repeat(19), 20, None)]
+    #[case(&"a".repeat(20), 20, Some(1))]
+    #[case(&"a".repeat(21), 20, None)]
+    #[case(&"a".repeat(40), 20, Some(2))]
+    #[case(&"a".repeat(60), 20, Some(3))]
+    // A hard break resets the column, so the rows before it still count.
+    #[case("ab\naaaaaaaaaaaaaaaaaaaa", 20, Some(2))]
+    #[case("ab\n", 20, None)]
+    // Zero columns is reported by terminals mid-resize; nothing to divide by.
+    #[case(&"a".repeat(20), 0, None)]
+    fn deferred_wrap_row_on_narrow_graphemes(
+        #[case] printed: &str,
+        #[case] columns: u16,
+        #[case] expected: Option<u16>,
+    ) {
+        assert_eq!(deferred_wrap_row(printed, columns), expected);
+    }
+
+    /// A double-width grapheme cannot straddle the margin: with one column left
+    /// the terminal blanks it and wraps early, so the run occupies more rows
+    /// than its width divided by the terminal's, and lands off the margin where
+    /// division says it lands on one.
+    ///
+    /// On 21 columns each row fits ten `あ` with a column to spare, so the
+    /// eleventh starts a row and only a multiple of ten ever reaches a margin
+    /// (at column 20 of 21 — never, since 20 < 21).
+    #[rstest]
+    // 42 columns of text on a 21-column terminal: division says two exact rows
+    // ending on the margin, the terminal says three rows ending at column 2.
+    #[case(&"あ".repeat(21), 21, None)]
+    #[case(&"あ".repeat(10), 21, None)]
+    // An even width divides evenly, so wide graphemes do reach the margin.
+    #[case(&"あ".repeat(10), 20, Some(1))]
+    #[case(&"あ".repeat(20), 20, Some(2))]
+    #[case(&"あ".repeat(9), 20, None)]
+    // A narrow lead-in leaves an odd column, pushing every wide grapheme over.
+    #[case(&format!("> {}", "あ".repeat(9)), 20, Some(1))]
+    #[case(&format!("> {}", "あ".repeat(10)), 20, None)]
+    // Narrow terminals make the blanked columns add up fast: 10 columns of text
+    // across 5 columns is two exact rows by division and three by layout.
+    #[case(&"あ".repeat(5), 5, None)]
+    #[case(&"あ".repeat(3), 3, None)]
+    // And the reverse, where the blanked columns are what carry the run *onto*
+    // a margin: 9 columns of text is no multiple of 5, but the early wrap after
+    // the second `あ` pushes the tail out to the end of the next row.
+    #[case("あああaaa", 5, Some(2))]
+    fn deferred_wrap_row_on_wide_graphemes(
+        #[case] printed: &str,
+        #[case] columns: u16,
+        #[case] expected: Option<u16>,
+    ) {
+        assert_eq!(deferred_wrap_row(printed, columns), expected);
+    }
+
+    /// ANSI is stripped before layout, and a combining mark joins the grapheme
+    /// it modifies rather than claiming a column of its own.
+    #[rstest]
+    #[case(&format!("\x1b[31m{}\x1b[0m", "a".repeat(20)), 20, Some(1))]
+    #[case(&"e\u{301}".repeat(20), 20, Some(1))]
+    fn deferred_wrap_row_ignores_zero_width_input(
+        #[case] printed: &str,
+        #[case] columns: u16,
+        #[case] expected: Option<u16>,
+    ) {
+        assert_eq!(deferred_wrap_row(printed, columns), expected);
     }
 
     /// Regression: no-color rendering strips ANSI bytes before CRLF coercion,

--- a/src/painting/utils.rs
+++ b/src/painting/utils.rs
@@ -62,11 +62,10 @@ pub(crate) fn estimate_required_lines(input: &str, screen_width: u16) -> usize {
 /// the size is unknown; return 0 in that case rather than dividing by
 /// zero (see #842).
 ///
-/// Dividing the width assumes glyphs pack a row exactly, which a
-/// double-width grapheme at the margin does not: see
-/// [`deferred_wrap_row`], which lays the same text out one grapheme at a
-/// time. Reserving a row too few or too many is recoverable, so the cheap
-/// model stays here; placing the cursor is not, so it uses the other one.
+/// Dividing assumes glyphs pack a row exactly, which a double-width
+/// grapheme at the margin does not. A reserved row too few or too many is
+/// recoverable, so the cheap model stays here; [`deferred_wrap_row`] pays
+/// for an exact one where the error would land on screen.
 ///
 /// FIXME: The zero-column guard below papers over a caller bug, it
 /// doesn't solve it. `menu::list_menu::ListMenu::menu_required_lines`
@@ -101,28 +100,20 @@ pub(crate) fn line_width(line: &str) -> usize {
 ///
 /// A terminal does not move to the next row when a glyph lands in the final
 /// column; it flags the cursor pending and only wraps once the next glyph
-/// arrives. Saving and restoring that state is ambiguous, since terminals
-/// disagree about whether DECSC/DECRC carry the flag, so the caller has to
+/// arrives. Terminals disagree about whether DECSC/DECRC carry that flag, so a
+/// save taken there restores to either side of the margin and the caller has to
 /// place the cursor absolutely instead. Returns how many rows past the start of
-/// the run that row is, or `None` when the run ends off the margin and
-/// `RestorePosition` is already unambiguous.
+/// the run that row is, or `None` off the margin, where restoring is already
+/// unambiguous. `pieces` are laid out end to end, since the walk is a fold and
+/// never looks backwards.
 ///
-/// `pieces` are laid out end to end, so a caller can hand over the parts it
-/// printed without joining them: the walk is a fold and never looks backwards.
-///
-/// Laid out one grapheme at a time rather than by dividing the run's width,
-/// because the two disagree: a double-width grapheme with a single column left
-/// cannot be split, so the terminal leaves that column blank and wraps early.
-/// Division would report a 42-column run on a 21-column terminal as two exact
-/// rows ending on the margin, when the terminal has actually wrapped twice and
-/// left the cursor mid-row. That is the difference between restoring the cursor
-/// and moving it somewhere it never was.
-///
-/// [`estimate_required_lines`] and friends still divide, and deliberately: they
-/// answer how many rows to reserve, where being off by one costs a wasted row
-/// or an extra erase, while this answers which cell the cursor occupies, where
-/// being off by one is on screen. The two only disagree on wide graphemes, so
-/// the cheap model stays where its error is recoverable.
+/// Counted a grapheme at a time rather than by dividing the run's width, which
+/// [`estimate_required_lines`] and friends still do. A double-width grapheme
+/// with one column left cannot be split, so the terminal blanks that column and
+/// wraps early: division reads a 42-column run on a 21-column terminal as two
+/// exact rows ending on the margin, when the terminal needs three and leaves
+/// the cursor mid-row. That is the difference between restoring the cursor and
+/// moving it somewhere it never was.
 pub(crate) fn deferred_wrap_row<'a>(
     pieces: impl IntoIterator<Item = &'a str>,
     terminal_columns: u16,
@@ -208,17 +199,12 @@ mod test {
         assert_eq!(deferred_wrap_row([printed], columns), expected);
     }
 
-    /// A double-width grapheme cannot straddle the margin: with one column left
-    /// the terminal blanks it and wraps early, so the run occupies more rows
-    /// than its width divided by the terminal's, and lands off the margin where
-    /// division says it lands on one.
-    ///
-    /// On 21 columns each row fits ten `あ` with a column to spare, so the
-    /// eleventh starts a row and only a multiple of ten ever reaches a margin
-    /// (at column 20 of 21 — never, since 20 < 21).
+    /// Wide graphemes only diverge from division when the width leaves an odd
+    /// column for one to straddle. The even-width cases pin down the agreement,
+    /// the rest are what a revert to division would break.
     #[rstest]
-    // 42 columns of text on a 21-column terminal: division says two exact rows
-    // ending on the margin, the terminal says three rows ending at column 2.
+    // 42 columns on a 21-column terminal: division reads two exact rows ending
+    // on the margin, the terminal needs three and ends at column 2.
     #[case(&"あ".repeat(21), 21, None)]
     #[case(&"あ".repeat(10), 21, None)]
     // An even width divides evenly, so wide graphemes do reach the margin.

--- a/src/painting/utils.rs
+++ b/src/painting/utils.rs
@@ -89,6 +89,24 @@ pub(crate) fn line_width(line: &str) -> usize {
     strip_ansi(line).width()
 }
 
+/// Whether printing `printed` leaves the cursor at the terminal's right margin,
+/// in the *deferred wrap* state.
+///
+/// A terminal does not move to the next row when a glyph lands in the final
+/// column; it flags the cursor pending and only wraps once the next glyph
+/// arrives. Saving and restoring that state is ambiguous, since terminals
+/// disagree about whether DECSC/DECRC carry the flag.
+pub(crate) fn ends_at_right_margin(printed: &str, terminal_columns: u16) -> bool {
+    let terminal_columns: usize = terminal_columns.into();
+    if terminal_columns == 0 {
+        return false;
+    }
+    // Only the text since the last hard line break sits on the cursor's row.
+    let last_row = printed.rsplit('\n').next().unwrap_or(printed);
+    let width = line_width(last_row);
+    width > 0 && width % terminal_columns == 0
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/painting/utils.rs
+++ b/src/painting/utils.rs
@@ -62,6 +62,12 @@ pub(crate) fn estimate_required_lines(input: &str, screen_width: u16) -> usize {
 /// the size is unknown; return 0 in that case rather than dividing by
 /// zero (see #842).
 ///
+/// Dividing the width assumes glyphs pack a row exactly, which a
+/// double-width grapheme at the margin does not: see
+/// [`deferred_wrap_row`], which lays the same text out one grapheme at a
+/// time. Reserving a row too few or too many is recoverable, so the cheap
+/// model stays here; placing the cursor is not, so it uses the other one.
+///
 /// FIXME: The zero-column guard below papers over a caller bug, it
 /// doesn't solve it. `menu::list_menu::ListMenu::menu_required_lines`
 /// passes `terminal_columns.saturating_sub(indicator_width + count_digits)`,
@@ -90,7 +96,7 @@ pub(crate) fn line_width(line: &str) -> usize {
     strip_ansi(line).width()
 }
 
-/// Where printing `printed` leaves the cursor, when it lands on the terminal's
+/// Where printing `pieces` leaves the cursor, when it lands on the terminal's
 /// right margin in the *deferred wrap* state.
 ///
 /// A terminal does not move to the next row when a glyph lands in the final
@@ -98,8 +104,11 @@ pub(crate) fn line_width(line: &str) -> usize {
 /// arrives. Saving and restoring that state is ambiguous, since terminals
 /// disagree about whether DECSC/DECRC carry the flag, so the caller has to
 /// place the cursor absolutely instead. Returns how many rows past the start of
-/// `printed` that row is, or `None` when the run ends off the margin and
+/// the run that row is, or `None` when the run ends off the margin and
 /// `RestorePosition` is already unambiguous.
+///
+/// `pieces` are laid out end to end, so a caller can hand over the parts it
+/// printed without joining them: the walk is a fold and never looks backwards.
 ///
 /// Laid out one grapheme at a time rather than by dividing the run's width,
 /// because the two disagree: a double-width grapheme with a single column left
@@ -109,39 +118,46 @@ pub(crate) fn line_width(line: &str) -> usize {
 /// left the cursor mid-row. That is the difference between restoring the cursor
 /// and moving it somewhere it never was.
 ///
-/// Note this is the *only* place in the painter that models wrapping this
-/// precisely; [`estimate_required_lines`] and friends still divide, so row
-/// reservations remain approximate for wide graphemes. Placing the cursor is
-/// worth the extra pass because the error is directly visible.
-pub(crate) fn deferred_wrap_row(printed: &str, terminal_columns: u16) -> Option<u16> {
+/// [`estimate_required_lines`] and friends still divide, and deliberately: they
+/// answer how many rows to reserve, where being off by one costs a wasted row
+/// or an extra erase, while this answers which cell the cursor occupies, where
+/// being off by one is on screen. The two only disagree on wide graphemes, so
+/// the cheap model stays where its error is recoverable.
+pub(crate) fn deferred_wrap_row<'a>(
+    pieces: impl IntoIterator<Item = &'a str>,
+    terminal_columns: u16,
+) -> Option<u16> {
     let columns: usize = terminal_columns.into();
     if columns == 0 {
         return None;
     }
 
-    let (mut row, mut col, mut pending) = (0u16, 0usize, false);
-    for grapheme in strip_ansi(printed).graphemes(true) {
-        match grapheme {
-            "\n" => (row, col, pending) = (row.saturating_add(1), 0, false),
-            "\r" => (col, pending) = (0, false),
-            _ => {
-                let width = grapheme.width();
-                // The wrap this grapheme's arrival was deferred until.
-                if pending {
-                    (row, col) = (row.saturating_add(1), 0);
+    // `col == columns` *is* the deferred wrap: the run has filled the row but
+    // nothing has arrived to push it over yet.
+    let (mut row, mut col) = (0u16, 0usize);
+    for piece in pieces {
+        for grapheme in strip_ansi(piece).graphemes(true) {
+            match grapheme {
+                "\n" => (row, col) = (row.saturating_add(1), 0),
+                "\r" => col = 0,
+                _ => {
+                    let width = grapheme.width();
+                    // The wrap this grapheme's arrival was deferred until.
+                    if col >= columns {
+                        (row, col) = (row.saturating_add(1), 0);
+                    }
+                    // No room for the whole grapheme: the trailing column stays
+                    // blank and the terminal wraps before drawing it.
+                    if col + width > columns {
+                        (row, col) = (row.saturating_add(1), 0);
+                    }
+                    col += width;
                 }
-                // No room for the whole grapheme: the trailing column stays
-                // blank and the terminal wraps before drawing it.
-                if col + width > columns {
-                    (row, col) = (row.saturating_add(1), 0);
-                }
-                col += width;
-                pending = col >= columns;
             }
         }
     }
 
-    pending.then(|| row.saturating_add(1))
+    (col >= columns).then(|| row.saturating_add(1))
 }
 
 #[cfg(test)]
@@ -189,7 +205,7 @@ mod test {
         #[case] columns: u16,
         #[case] expected: Option<u16>,
     ) {
-        assert_eq!(deferred_wrap_row(printed, columns), expected);
+        assert_eq!(deferred_wrap_row([printed], columns), expected);
     }
 
     /// A double-width grapheme cannot straddle the margin: with one column left
@@ -225,7 +241,7 @@ mod test {
         #[case] columns: u16,
         #[case] expected: Option<u16>,
     ) {
-        assert_eq!(deferred_wrap_row(printed, columns), expected);
+        assert_eq!(deferred_wrap_row([printed], columns), expected);
     }
 
     /// ANSI is stripped before layout, and a combining mark joins the grapheme
@@ -238,7 +254,7 @@ mod test {
         #[case] columns: u16,
         #[case] expected: Option<u16>,
     ) {
-        assert_eq!(deferred_wrap_row(printed, columns), expected);
+        assert_eq!(deferred_wrap_row([printed], columns), expected);
     }
 
     /// Regression: no-color rendering strips ANSI bytes before CRLF coercion,


### PR DESCRIPTION
<!-- Thanks for contributing to Reedline! -->

## Summary <!-- Must Have -->
<!--
Motivate this PR: why did you open it, how did you arrive at this solution?
Mention any changes to Reedline's public API or observable behavior, or mention that there are none.
-->
A line filling the width exactly was leaving the cursor in the deferred-wrap state, and terminals disagree about whether DECRC restores that flag, thus the cursor rendered either in the last cell of the row or the first of the next.
Every edit mode where affected.

Both save sites are fixed: the one bracketing the text after the cursor, and the right prompt's own.
Each replaces the ambiguous restore with an absolute MoveTo.

The new tests replay the emitted stream under both DECSC conventions, so one machine checks both kinds of terminal.

No public API change.