### PR TITLE
fix(engine): decide menu completions once the completer answers

### DIFF
--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -49,6 +49,14 @@ impl CompletionOrigin {
             insertion_point,
         }
     }
+
+    /// Whether `buffer` and `insertion_point` are still exactly what this was
+    /// stamped for. Anything else means the line moved on and results computed
+    /// against this origin no longer describe it.
+    pub fn matches(&self, buffer: &str, insertion_point: usize) -> bool {
+        // Cursor first: it rules out most drift without comparing the line.
+        self.insertion_point == insertion_point && self.buffer == buffer
+    }
 }
 
 /// Longest common prefix extension computed by the completer.

--- a/src/completion/base.rs
+++ b/src/completion/base.rs
@@ -152,6 +152,12 @@ impl CompletionResult {
     pub fn is_pending(&self) -> bool {
         matches!(self, CompletionResult::Pending)
     }
+
+    /// Whether a later result may still supersede this one: either nothing has
+    /// arrived yet, or what arrived was computed against a different line.
+    pub fn is_provisional(&self) -> bool {
+        !matches!(self, CompletionResult::Fresh { .. })
+    }
 }
 
 /// Vitality of a completer's background work, grabbed by the engine once per

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1102,6 +1102,13 @@ impl Reedline {
             return Ok(());
         };
 
+        // The request that just finished was host code, which may have scrolled the
+        // terminal while it ran in the background — after the keystroke that
+        // dispatched it had already re-verified the anchor. `update_values` below
+        // can also dispatch another request for a line that moved on. Either way
+        // the repaint at the end of this settle must not trust the cached row.
+        invalidate_anchor_if_host_completer_runs(&self.menus[menu_index], &mut self.painter);
+
         let menu = &mut self.menus[menu_index];
         // The request this menu was waiting on finished, so repopulate it.
         menu.update_values(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2438,7 +2438,11 @@ impl Reedline {
         // Updating the working details of the active menu
         for menu in self.menus.iter_mut() {
             if menu.is_active() {
-                lines.prompt_indicator = menu.indicator().to_owned().into();
+                // A menu still waiting on its first answer stays off screen, so a Tab
+                // resolving to one suggestion never draws a menu it takes away again.
+                if !menu.is_awaiting_first_answer() {
+                    lines.prompt_indicator = menu.indicator().to_owned().into();
+                }
                 // If the menu requires the cursor position, update it (ide menu)
                 let cursor_pos = lines.cursor_pos(self.painter.screen_width());
                 menu.set_cursor_pos(cursor_pos);
@@ -2452,7 +2456,10 @@ impl Reedline {
             }
         }
 
-        let menu = self.menus.iter().find(|menu| menu.is_active());
+        let menu = self
+            .menus
+            .iter()
+            .find(|menu| menu.is_active() && !menu.is_awaiting_first_answer());
 
         self.painter.repaint_buffer(
             prompt,
@@ -3834,6 +3841,28 @@ mod tests {
             reedline.current_buffer_contents(),
             "crates",
             "the fresh result was dropped because the stale one closed the menu first"
+        );
+    }
+
+    /// The flicker: a menu opened over an answer that is not about this line stays off
+    /// screen, so a Tab that resolves to one suggestion never draws a menu at all.
+    #[test]
+    fn an_opening_menu_is_not_visible_until_answered() {
+        let (reedline, _) = activate_menu_over(
+            Box::new(StaleThenFreshCompleter::new("console", "co", &["crates"])),
+            "cr",
+            true,
+            false,
+        );
+
+        let menu = reedline
+            .menus
+            .iter()
+            .find(|menu| menu.is_active())
+            .expect("the menu is open");
+        assert!(
+            menu.is_awaiting_first_answer(),
+            "it would only be taken away again once the real answer lands"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1428,7 +1428,15 @@ impl Reedline {
             }
             ReedlineEvent::MenuNext => {
                 if let Some(menu) = self.menus.iter_mut().find(|menu| menu.is_active()) {
-                    if menu.get_values().len() == 1 && menu.can_quick_complete() {
+                    // The second route to the lone-value accept, so it carries the same
+                    // provisional guard as `decide_menu_completion`: accepting a lone
+                    // *stale* value is refused downstream, but the `Enter` would still
+                    // deactivate the menu, closing it over a completion that never
+                    // happened.
+                    if menu.get_values().len() == 1
+                        && menu.can_quick_complete()
+                        && !menu.results_are_provisional()
+                    {
                         self.handle_editor_event(prompt, ReedlineEvent::Enter)
                     } else {
                         if self.partial_completions {
@@ -3823,6 +3831,35 @@ mod tests {
             "crates",
             "the fresh result was dropped because the stale one closed the menu first"
         );
+    }
+
+    /// The same lone stale value through the second route: `MenuNext` with the menu
+    /// already open. The accept is refused downstream either way, but the `Enter` it
+    /// rode on would still deactivate the menu, so the pending completion had nothing
+    /// left to land in.
+    #[test]
+    fn menu_next_does_not_close_the_menu_over_a_lone_stale_value() {
+        let (mut reedline, _) = activate_menu_over(
+            Box::new(DeferredCompleter::stale("console", "co", &["crates"])),
+            "cr",
+            true,
+            false,
+        );
+        assert!(menu_is_active(&reedline), "setup");
+
+        reedline
+            .handle_event(&DefaultPrompt::default(), ReedlineEvent::MenuNext)
+            .unwrap();
+
+        assert!(
+            menu_is_active(&reedline),
+            "MenuNext accepted a provisional lone value and closed the menu"
+        );
+        assert_eq!(reedline.current_buffer_contents(), "cr");
+
+        // With the menu still open, the arm from the activation is still owed.
+        settle(&mut reedline);
+        assert_eq!(reedline.current_buffer_contents(), "crates");
     }
 
     /// The flicker: a menu opened over an answer that is not about this line stays off

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3565,17 +3565,43 @@ mod tests {
         assert_eq!(reedline.current_buffer_contents(), "67x");
     }
 
-    /// A completer that computes in the background: the first request is answered with
-    /// `Pending` and only later requests carry values. This is what a cold cache looks
-    /// like from the engine's side (nushell/reedline#1142).
+    /// A completer that computes in the background: the first request cannot be answered
+    /// for the line on screen, and only later ones carry its values. This is what a cold
+    /// cache looks like from the engine's side (nushell/reedline#1142).
     struct DeferredCompleter {
+        first_answer: CompletionResult,
         values: Vec<String>,
         dispatched: bool,
     }
 
     impl DeferredCompleter {
-        fn new(values: &[&str]) -> Self {
+        /// A cold cache: nothing to show at all until the background work lands.
+        fn pending(values: &[&str]) -> Self {
+            Self::new(CompletionResult::Pending, values)
+        }
+
+        /// A warm-but-wrong cache: `stale` is answered from a neighbouring entry, so the
+        /// value is real but its span belongs to `origin_buffer` rather than the line.
+        fn stale(stale: &str, origin_buffer: &str, values: &[&str]) -> Self {
+            let first_answer = CompletionResult::Stale {
+                suggestions: vec![Suggestion {
+                    value: stale.to_string(),
+                    span: Span {
+                        start: 0,
+                        end: origin_buffer.len(),
+                    },
+                    ..Default::default()
+                }]
+                .into(),
+                origin: CompletionOrigin::new(origin_buffer, origin_buffer.len()),
+                partial: None,
+            };
+            Self::new(first_answer, values)
+        }
+
+        fn new(first_answer: CompletionResult, values: &[&str]) -> Self {
             Self {
+                first_answer,
                 values: values.iter().map(|value| value.to_string()).collect(),
                 dispatched: false,
             }
@@ -3586,7 +3612,7 @@ mod tests {
         fn complete(&mut self, _line: &str, pos: usize) -> CompletionResult {
             if !self.dispatched {
                 self.dispatched = true;
-                return CompletionResult::Pending;
+                return self.first_answer.clone();
             }
             CompletionResult::fresh(
                 self.values
@@ -3609,16 +3635,17 @@ mod tests {
         }
     }
 
-    /// Engine with `quick` completions and a background completer over `values`, with
-    /// `buffer` typed and the completion menu activated — the state right after Tab, while
-    /// the completer is still working.
+    /// [`engine_awaiting`] with partial completions off.
     fn engine_awaiting_completions(values: &[&str], buffer: &str, quick: bool) -> Reedline {
         engine_awaiting(values, buffer, quick, false)
     }
 
+    /// Engine with `quick` and `partial` completions and a background completer over
+    /// `values`, with `buffer` typed and the completion menu activated — the state right
+    /// after Tab, while the completer is still working.
     fn engine_awaiting(values: &[&str], buffer: &str, quick: bool, partial: bool) -> Reedline {
         let (reedline, _) = activate_menu_over(
-            Box::new(DeferredCompleter::new(values)),
+            Box::new(DeferredCompleter::pending(values)),
             buffer,
             quick,
             partial,
@@ -3647,8 +3674,9 @@ mod tests {
             .with_partial_completions(partial);
 
         // Settling repaints, which needs a painter that believes it is on a terminal.
+        // Size first: `handle_resize` invalidates the anchor the next line pins.
+        reedline.painter.handle_resize(80, 24);
         reedline.painter.force_prompt_anchored_for_test(0);
-        reedline.painter.force_terminal_size_for_test(80, 24);
 
         reedline.run_edit_commands(&[EditCommand::InsertString(buffer.to_string())]);
         let status = reedline
@@ -3712,7 +3740,7 @@ mod tests {
         assert!(reedline.deferred_menu_completion.is_none(), "arm is spent");
 
         // A second round of results, now down to one value, with no Tab in between.
-        reedline.completer = Box::new(DeferredCompleter::new(&["test"]));
+        reedline.completer = Box::new(DeferredCompleter::pending(&["test"]));
         reedline.completer.complete("t", 1);
         settle(&mut reedline);
 
@@ -3773,73 +3801,13 @@ mod tests {
         assert!(menu_is_active(&reedline));
     }
 
-    /// A warm-but-wrong cache: the first request is answered from a neighbouring entry,
-    /// so the values are real but belong to another line. Only the second carries the
-    /// answer for the line on screen.
-    struct StaleThenFreshCompleter {
-        stale: String,
-        origin: CompletionOrigin,
-        values: Vec<String>,
-        dispatched: bool,
-    }
-
-    impl StaleThenFreshCompleter {
-        fn new(stale: &str, origin_buffer: &str, values: &[&str]) -> Self {
-            Self {
-                stale: stale.to_string(),
-                origin: CompletionOrigin::new(origin_buffer, origin_buffer.len()),
-                values: values.iter().map(|value| value.to_string()).collect(),
-                dispatched: false,
-            }
-        }
-    }
-
-    impl Completer for StaleThenFreshCompleter {
-        fn complete(&mut self, _line: &str, pos: usize) -> CompletionResult {
-            if !self.dispatched {
-                self.dispatched = true;
-                return CompletionResult::Stale {
-                    suggestions: vec![Suggestion {
-                        value: self.stale.clone(),
-                        span: Span {
-                            start: 0,
-                            end: self.origin.buffer.len(),
-                        },
-                        ..Default::default()
-                    }]
-                    .into(),
-                    origin: self.origin.clone(),
-                    partial: None,
-                };
-            }
-            CompletionResult::fresh(
-                self.values
-                    .iter()
-                    .map(|value| Suggestion {
-                        value: value.clone(),
-                        span: Span { start: 0, end: pos },
-                        ..Default::default()
-                    })
-                    .collect::<Vec<_>>(),
-            )
-        }
-
-        fn poll_completion(&mut self) -> CompletionStatus {
-            if self.dispatched {
-                CompletionStatus::Ready
-            } else {
-                CompletionStatus::Idle
-            }
-        }
-    }
-
     /// A lone *stale* suggestion looks like a lone fresh one to the quick completion
     /// check, but accepting it is a no-op. The Tab must still be honoured once the real
     /// answer lands.
     #[test]
     fn a_lone_stale_suggestion_does_not_swallow_the_completion() {
         let (mut reedline, _) = activate_menu_over(
-            Box::new(StaleThenFreshCompleter::new("console", "co", &["crates"])),
+            Box::new(DeferredCompleter::stale("console", "co", &["crates"])),
             "cr",
             true,
             false,
@@ -3862,7 +3830,7 @@ mod tests {
     #[test]
     fn an_opening_menu_is_not_visible_until_answered() {
         let (reedline, _) = activate_menu_over(
-            Box::new(StaleThenFreshCompleter::new("console", "co", &["crates"])),
+            Box::new(DeferredCompleter::stale("console", "co", &["crates"])),
             "cr",
             true,
             false,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1096,43 +1096,29 @@ impl Reedline {
     /// Called when the completer reports [`CompletionStatus::Ready`]. Kept out of the
     /// input loop so it is reachable from tests, which cannot drive the loop itself.
     fn settle_completions(&mut self, prompt: &dyn Prompt) -> Result<()> {
-        let mut repopulated = false;
-        let mut accept_lone_value = false;
-        let mut still_provisional = false;
+        let Some(menu_index) = self.menus.iter().position(|menu| menu.is_active()) else {
+            // No menu to answer to, so nothing can still be owed.
+            self.deferred_menu_completion = None;
+            return Ok(());
+        };
 
-        if let Some(menu) = self.menus.iter_mut().find(|menu| menu.is_active()) {
-            // The request this menu was waiting on finished, so repopulate it.
-            menu.update_values(
-                &mut self.editor,
-                self.completer.as_mut(),
-                self.history.as_ref(),
-            );
-            repopulated = true;
-            still_provisional = menu.results_are_provisional();
+        let menu = &mut self.menus[menu_index];
+        // The request this menu was waiting on finished, so repopulate it.
+        menu.update_values(
+            &mut self.editor,
+            self.completer.as_mut(),
+            self.history.as_ref(),
+        );
+        let still_provisional = menu.results_are_provisional();
 
-            let owed = self
-                .deferred_menu_completion
-                .as_ref()
-                .map_or(false, |deferred| deferred.still_applies(menu, &self.editor));
+        let owed = self
+            .deferred_menu_completion
+            .as_ref()
+            .map_or(false, |deferred| deferred.still_applies(menu, &self.editor));
 
-            if owed && !still_provisional {
-                // Replay what activating the menu would have done, in the same order: a
-                // lone value is accepted outright, otherwise a shared prefix is spliced in.
-                accept_lone_value = self.quick_completions
-                    && menu.can_quick_complete()
-                    && menu.get_values().len() == 1;
-
-                if !accept_lone_value && self.partial_completions {
-                    // Values were just refreshed above, so the menu must not re-fetch them.
-                    menu.can_partially_complete(
-                        true,
-                        &mut self.editor,
-                        self.completer.as_mut(),
-                        self.history.as_ref(),
-                    );
-                }
-            }
-        }
+        // Values were just refreshed above, so the menu must not re-fetch them.
+        let accept_lone_value =
+            owed && !still_provisional && self.decide_menu_completion(menu_index, true);
 
         // Spent once a final answer had its say, so it cannot act on a later one.
         // Provisional results decided nothing, so the arm outlives them.
@@ -1148,11 +1134,46 @@ impl Reedline {
 
         // One paint for every outcome, since painting the menu and then the accepted or
         // extended line would flicker on each completion.
-        if repopulated {
-            self.repaint(prompt)?;
+        self.repaint(prompt)
+    }
+
+    /// The completion an opening menu applies to the line: a lone suggestion is accepted
+    /// outright, otherwise the prefix the suggestions share is spliced in. Returns whether
+    /// the caller should accept that lone suggestion.
+    ///
+    /// Both the [`Menu`](ReedlineEvent::Menu) event and the deferred replay in
+    /// [`settle_completions`](Self::settle_completions) decide this, and they have to
+    /// decide it identically. `values_updated` says whether the caller already refreshed
+    /// the menu's values, so they are not fetched twice.
+    fn decide_menu_completion(&mut self, menu_index: usize, values_updated: bool) -> bool {
+        let menu = &mut self.menus[menu_index];
+
+        let accept_lone_value = if self.quick_completions && menu.can_quick_complete() {
+            if !values_updated {
+                menu.update_values(
+                    &mut self.editor,
+                    self.completer.as_mut(),
+                    self.history.as_ref(),
+                );
+            }
+            // Accepting a lone *stale* value is refused downstream, since its span
+            // belongs to another line, so the menu would close over a completion that
+            // never happened.
+            menu.get_values().len() == 1 && !menu.results_are_provisional()
+        } else {
+            false
+        };
+
+        if !accept_lone_value && self.partial_completions {
+            menu.can_partially_complete(
+                values_updated || self.quick_completions,
+                &mut self.editor,
+                self.completer.as_mut(),
+                self.history.as_ref(),
+            );
         }
 
-        Ok(())
+        accept_lone_value
     }
 
     fn process_input_batch(
@@ -1378,44 +1399,27 @@ impl Reedline {
         match event {
             ReedlineEvent::Menu(name) => {
                 if self.active_menu().is_none() {
-                    if let Some(menu) = self.menus.iter_mut().find(|menu| menu.name() == name) {
-                        menu.menu_event(MenuEvent::Activate(self.quick_completions));
-                        invalidate_anchor_if_host_completer_runs(menu, &mut self.painter);
+                    if let Some(index) = self.menus.iter().position(|menu| menu.name() == name) {
+                        self.menus[index].menu_event(MenuEvent::Activate(self.quick_completions));
+                        invalidate_anchor_if_host_completer_runs(
+                            &self.menus[index],
+                            &mut self.painter,
+                        );
 
-                        if self.quick_completions && menu.can_quick_complete() {
-                            menu.update_values(
-                                &mut self.editor,
-                                self.completer.as_mut(),
-                                self.history.as_ref(),
-                            );
-
-                            // Accepting a lone *stale* value is refused downstream,
-                            // since its span belongs to another line, so the menu
-                            // would close over a completion that never happened.
-                            if menu.get_values().len() == 1 && !menu.results_are_provisional() {
-                                return self.handle_editor_event(prompt, ReedlineEvent::Enter);
-                            }
-                        }
-
-                        if self.partial_completions {
-                            menu.can_partially_complete(
-                                self.quick_completions,
-                                &mut self.editor,
-                                self.completer.as_mut(),
-                                self.history.as_ref(),
-                            );
+                        if self.decide_menu_completion(index, false) {
+                            return self.handle_editor_event(prompt, ReedlineEvent::Enter);
                         }
 
                         // A final answer already had its say above, so only a
                         // provisional one leaves anything owed. With neither option set
                         // nothing queried the completer, so this reads the default
                         // `false` and the menu paints as it always has.
-                        if !menu.results_are_provisional() {
-                            return Ok(EventStatus::Handled);
+                        if self.menus[index].results_are_provisional() {
+                            self.deferred_menu_completion = Some(DeferredMenuCompletion::new(
+                                &self.menus[index],
+                                &self.editor,
+                            ));
                         }
-
-                        self.deferred_menu_completion =
-                            Some(DeferredMenuCompletion::new(menu, &self.editor));
 
                         return Ok(EventStatus::Handled);
                     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -265,7 +265,9 @@ impl DeferredMenuCompletion {
     /// Anything else means the user moved on and the decision is void.
     fn still_applies(&self, menu: &ReedlineMenu, editor: &Editor) -> bool {
         self.menu == menu.name()
-            && self.origin == CompletionOrigin::new(editor.get_buffer(), editor.insertion_point())
+            && self
+                .origin
+                .matches(editor.get_buffer(), editor.insertion_point())
     }
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -167,6 +167,8 @@ pub struct Reedline {
     quick_completions: bool,
     partial_completions: bool,
     persistent_menus: bool,
+    // Completions owed to a menu activation the completer could not answer in time
+    deferred_menu_completion: Option<DeferredMenuCompletion>,
 
     // Highlight the edit buffer
     highlighter: Box<dyn Highlighter>,
@@ -233,6 +235,41 @@ pub struct Reedline {
 struct BufferEditor {
     command: Command,
     temp_file: PathBuf,
+}
+
+/// The completions the [`Menu`](ReedlineEvent::Menu) event could not decide, because the
+/// completer had not answered yet.
+///
+/// Activating a menu immediately inspects its values twice: quick completions accept a
+/// lone suggestion, and partial completions splice in the prefix the suggestions share. A
+/// completer that computes in the background answers that first request with
+/// [`Pending`](crate::CompletionResult::Pending), so both read an empty menu.
+///
+/// The snapshot pins the editor state as of the keystroke this was armed on: a result
+/// landing after the user has typed on is discarded rather than rewriting the line
+/// underneath them.
+struct DeferredMenuCompletion {
+    menu: String,
+    buffer: String,
+    insertion_point: usize,
+}
+
+impl DeferredMenuCompletion {
+    fn new(menu: &ReedlineMenu, editor: &Editor) -> Self {
+        Self {
+            menu: menu.name().to_string(),
+            buffer: editor.get_buffer().to_string(),
+            insertion_point: editor.insertion_point(),
+        }
+    }
+
+    /// Whether the line is still exactly as it was when this was armed, on the same menu.
+    /// Anything else means the user moved on and the decision is void.
+    fn still_applies(&self, menu: &ReedlineMenu, editor: &Editor) -> bool {
+        self.menu == menu.name()
+            && self.buffer == editor.get_buffer()
+            && self.insertion_point == editor.insertion_point()
+    }
 }
 
 /// Call [`request_repaint`](RepaintSignal::request_repaint) once
@@ -329,6 +366,7 @@ impl Reedline {
             quick_completions: false,
             partial_completions: false,
             persistent_menus: false,
+            deferred_menu_completion: None,
             highlighter: buffer_highlighter,
             visual_selection_style,
             hinter,
@@ -993,17 +1031,8 @@ impl Reedline {
             // Anything BUT idle means work is in flight. We need to keep polling.
             let completer_pending = status != CompletionStatus::Idle;
 
-            if let Some(menu) = (status == CompletionStatus::Ready)
-                .then(|| self.menus.iter_mut().find(|m| m.is_active()))
-                .flatten()
-            {
-                // latest request finished, so repopulate
-                menu.update_values(
-                    &mut self.editor,
-                    self.completer.as_mut(),
-                    self.history.as_ref(),
-                );
-                self.repaint(prompt)?;
+            if status == CompletionStatus::Ready {
+                self.settle_completions(prompt)?;
             }
 
             // Helper function that returns true if the input is complete and
@@ -1060,6 +1089,67 @@ impl Reedline {
                 return Ok(signal);
             }
         }
+    }
+
+    /// Fold a finished completion request into the active menu, and honor the completions
+    /// owed from when the request was made.
+    ///
+    /// Called when the completer reports [`CompletionStatus::Ready`]. Kept out of the
+    /// input loop so it is reachable from tests, which cannot drive the loop itself.
+    fn settle_completions(&mut self, prompt: &dyn Prompt) -> Result<()> {
+        let mut repopulated = false;
+        let mut accept_lone_value = false;
+
+        if let Some(menu) = self.menus.iter_mut().find(|menu| menu.is_active()) {
+            // The request this menu was waiting on finished, so repopulate it.
+            menu.update_values(
+                &mut self.editor,
+                self.completer.as_mut(),
+                self.history.as_ref(),
+            );
+            repopulated = true;
+
+            let owed = self
+                .deferred_menu_completion
+                .as_ref()
+                .map_or(false, |deferred| deferred.still_applies(menu, &self.editor));
+
+            if owed {
+                // Replay what activating the menu would have done, in the same order: a
+                // lone value is accepted outright, otherwise a shared prefix is spliced in.
+                accept_lone_value = self.quick_completions
+                    && menu.can_quick_complete()
+                    && menu.get_values().len() == 1;
+
+                if !accept_lone_value && self.partial_completions {
+                    // Values were just refreshed above, so the menu must not re-fetch them.
+                    menu.can_partially_complete(
+                        true,
+                        &mut self.editor,
+                        self.completer.as_mut(),
+                        self.history.as_ref(),
+                    );
+                }
+            }
+        }
+
+        // Spent either way: a deferral these results did not satisfy must not act on a
+        // later one.
+        self.deferred_menu_completion = None;
+
+        if accept_lone_value {
+            // With a menu active this replaces in the buffer and deactivates, rather than
+            // submitting the line.
+            self.handle_editor_event(prompt, ReedlineEvent::Enter)?;
+        }
+
+        // One paint for every outcome, since painting the menu and then the accepted or
+        // extended line would flicker on each completion.
+        if repopulated {
+            self.repaint(prompt)?;
+        }
+
+        Ok(())
     }
 
     fn process_input_batch(
@@ -1301,15 +1391,21 @@ impl Reedline {
                             }
                         }
 
-                        if self.partial_completions
-                            && menu.can_partially_complete(
+                        if self.partial_completions {
+                            menu.can_partially_complete(
                                 self.quick_completions,
                                 &mut self.editor,
                                 self.completer.as_mut(),
                                 self.history.as_ref(),
-                            )
-                        {
-                            return Ok(EventStatus::Handled);
+                            );
+                        }
+
+                        // Armed even when values did come back, since settling re-checks
+                        // them and a result that was already final never lands a second
+                        // time.
+                        if self.quick_completions || self.partial_completions {
+                            self.deferred_menu_completion =
+                                Some(DeferredMenuCompletion::new(menu, &self.editor));
                         }
 
                         return Ok(EventStatus::Handled);
@@ -1683,6 +1779,8 @@ impl Reedline {
     }
 
     fn deactivate_menus(&mut self) {
+        // Nothing is left to complete into.
+        self.deferred_menu_completion = None;
         self.menus
             .iter_mut()
             .for_each(|menu| menu.menu_event(MenuEvent::Deactivate));
@@ -2501,7 +2599,9 @@ impl Reedline {
 mod tests {
     use super::*;
     use crate::terminal_extensions::semantic_prompt::PromptKind;
-    use crate::{ColumnarMenu, DefaultPrompt, MenuBuilder, PromptViMode};
+    use crate::{
+        ColumnarMenu, CompletionResult, DefaultPrompt, MenuBuilder, PromptViMode, Span, Suggestion,
+    };
     use rstest::rstest;
 
     fn seam_engine(edit_mode: Box<dyn EditMode>) -> Reedline {
@@ -3435,6 +3535,196 @@ mod tests {
         let insertion = EditCommand::InsertString(String::from("x"));
         reedline.run_edit_commands(&[insertion]);
         assert_eq!(reedline.current_buffer_contents(), "67x");
+    }
+
+    /// A completer that computes in the background: the first request is answered with
+    /// `Pending` and only later requests carry values. This is what a cold cache looks
+    /// like from the engine's side (nushell/reedline#1142).
+    struct DeferredCompleter {
+        values: Vec<String>,
+        dispatched: bool,
+    }
+
+    impl DeferredCompleter {
+        fn new(values: &[&str]) -> Self {
+            Self {
+                values: values.iter().map(|value| value.to_string()).collect(),
+                dispatched: false,
+            }
+        }
+    }
+
+    impl Completer for DeferredCompleter {
+        fn complete(&mut self, _line: &str, pos: usize) -> CompletionResult {
+            if !self.dispatched {
+                self.dispatched = true;
+                return CompletionResult::Pending;
+            }
+            CompletionResult::fresh(
+                self.values
+                    .iter()
+                    .map(|value| Suggestion {
+                        value: value.clone(),
+                        span: Span { start: 0, end: pos },
+                        ..Default::default()
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }
+
+        fn poll_completion(&mut self) -> CompletionStatus {
+            if self.dispatched {
+                CompletionStatus::Ready
+            } else {
+                CompletionStatus::Idle
+            }
+        }
+    }
+
+    /// Engine with `quick` completions and a background completer over `values`, with
+    /// `buffer` typed and the completion menu activated — the state right after Tab, while
+    /// the completer is still working.
+    fn engine_awaiting_completions(values: &[&str], buffer: &str, quick: bool) -> Reedline {
+        engine_awaiting(values, buffer, quick, false)
+    }
+
+    fn engine_awaiting(values: &[&str], buffer: &str, quick: bool, partial: bool) -> Reedline {
+        let completion_menu = ReedlineMenu::EngineCompleter(Box::new(
+            ColumnarMenu::default().with_name("completion_menu"),
+        ));
+        let mut reedline = Reedline::create()
+            .with_completer(Box::new(DeferredCompleter::new(values)))
+            .with_menu(completion_menu)
+            .with_quick_completions(quick)
+            .with_partial_completions(partial);
+
+        // Settling repaints, which needs a painter that believes it is on a terminal.
+        reedline.painter.force_prompt_anchored_for_test(0);
+        reedline.painter.force_terminal_size_for_test(80, 24);
+
+        reedline.run_edit_commands(&[EditCommand::InsertString(buffer.to_string())]);
+        reedline
+            .handle_event(
+                &DefaultPrompt::default(),
+                ReedlineEvent::Menu(String::from("completion_menu")),
+            )
+            .unwrap();
+
+        // Nothing could be decided yet — that is the premise of every test below.
+        assert_eq!(reedline.current_buffer_contents(), buffer);
+        reedline
+    }
+
+    fn settle(reedline: &mut Reedline) {
+        reedline
+            .settle_completions(&DefaultPrompt::default())
+            .unwrap();
+    }
+
+    /// The regression: a lone suggestion that arrives after the menu opened must still be
+    /// accepted, exactly as a synchronous completer's would have been.
+    #[test]
+    fn quick_completion_accepts_a_lone_suggestion_that_arrives_late() {
+        let mut reedline = engine_awaiting_completions(&["crates"], "cr", true);
+
+        settle(&mut reedline);
+
+        assert_eq!(reedline.current_buffer_contents(), "crates");
+        assert!(!menu_is_active(&reedline), "accepting closes the menu");
+    }
+
+    /// The decision belongs to the keystroke that asked for it. Once the user has typed
+    /// on, a late result must not rewrite the line underneath them.
+    #[test]
+    fn a_late_lone_suggestion_is_dropped_once_the_line_moved_on() {
+        let mut reedline = engine_awaiting_completions(&["crates"], "cr", true);
+
+        send_edit(&mut reedline, EditCommand::InsertChar('a'));
+        settle(&mut reedline);
+
+        assert_eq!(reedline.current_buffer_contents(), "cra");
+    }
+
+    /// Arming happens before the count is final, so settling has to re-check it: several
+    /// suggestions mean a menu, not an acceptance.
+    #[test]
+    fn late_results_with_several_suggestions_only_populate_the_menu() {
+        let mut reedline = engine_awaiting_completions(&["test", "this", "that"], "t", true);
+
+        settle(&mut reedline);
+
+        assert_eq!(reedline.current_buffer_contents(), "t");
+        assert!(menu_is_active(&reedline));
+    }
+
+    /// An arm is spent by the result that settles it, so a later request cannot inherit it.
+    #[test]
+    fn an_unsatisfied_arm_does_not_fire_on_a_later_result() {
+        let mut reedline = engine_awaiting_completions(&["test", "this", "that"], "t", true);
+
+        settle(&mut reedline);
+        assert!(reedline.deferred_menu_completion.is_none(), "arm is spent");
+
+        // A second round of results, now down to one value, with no Tab in between.
+        reedline.completer = Box::new(DeferredCompleter::new(&["test"]));
+        reedline.completer.complete("t", 1);
+        settle(&mut reedline);
+
+        assert_eq!(reedline.current_buffer_contents(), "t");
+    }
+
+    /// The other half of the same Tab: partial completions read the same empty menu the
+    /// quick check did, so a shared prefix must be spliced in when the values land.
+    #[test]
+    fn late_results_splice_the_shared_prefix() {
+        let mut reedline = engine_awaiting(&["nu-cmd-base", "nu-cmd-lang"], "nu-cm", true, true);
+
+        settle(&mut reedline);
+
+        assert_eq!(reedline.current_buffer_contents(), "nu-cmd-");
+    }
+
+    /// A shared prefix is spliced under `partial` alone, with no quick completions.
+    #[test]
+    fn late_results_splice_the_shared_prefix_without_quick_completions() {
+        let mut reedline = engine_awaiting(&["nu-cmd-base", "nu-cmd-lang"], "nu-cm", false, true);
+
+        settle(&mut reedline);
+
+        assert_eq!(reedline.current_buffer_contents(), "nu-cmd-");
+    }
+
+    /// Accepting a lone value wins over splicing, as it does on activation.
+    #[test]
+    fn a_lone_late_suggestion_is_accepted_rather_than_spliced() {
+        let mut reedline = engine_awaiting(&["crates"], "cr", true, true);
+
+        settle(&mut reedline);
+
+        assert_eq!(reedline.current_buffer_contents(), "crates");
+        assert!(!menu_is_active(&reedline));
+    }
+
+    /// Splicing is owed to a keystroke too, and is void once the line moved on.
+    #[test]
+    fn a_late_shared_prefix_is_dropped_once_the_line_moved_on() {
+        let mut reedline = engine_awaiting(&["nu-cmd-base", "nu-cmd-lang"], "nu-cm", true, true);
+
+        send_edit(&mut reedline, EditCommand::InsertChar('d'));
+        settle(&mut reedline);
+
+        assert_eq!(reedline.current_buffer_contents(), "nu-cmd");
+    }
+
+    /// With quick completions off, late results populate the menu and nothing else.
+    #[test]
+    fn late_results_never_auto_accept_without_quick_completions() {
+        let mut reedline = engine_awaiting_completions(&["crates"], "cr", false);
+
+        settle(&mut reedline);
+
+        assert_eq!(reedline.current_buffer_contents(), "cr");
+        assert!(menu_is_active(&reedline));
     }
 
     fn menu_is_active(reedline: &Reedline) -> bool {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -17,7 +17,7 @@ use {
 };
 use {
     crate::{
-        completion::{Completer, CompletionStatus, DefaultCompleter},
+        completion::{Completer, CompletionOrigin, CompletionStatus, DefaultCompleter},
         core_editor::Editor,
         edit_mode::{EditMode, Emacs},
         enums::{EventStatus, ReedlineEvent},
@@ -241,25 +241,23 @@ struct BufferEditor {
 /// completer had not answered yet.
 ///
 /// Activating a menu immediately inspects its values twice: quick completions accept a
-/// lone suggestion, and partial completions splice in the prefix the suggestions share. A
-/// completer that computes in the background answers that first request with
-/// [`Pending`](crate::CompletionResult::Pending), so both read an empty menu.
+/// lone suggestion, and partial completions splice in the prefix the suggestions share.
+/// A completer computing in the background can answer neither yet.
 ///
 /// The snapshot pins the editor state as of the keystroke this was armed on: a result
 /// landing after the user has typed on is discarded rather than rewriting the line
 /// underneath them.
 struct DeferredMenuCompletion {
     menu: String,
-    buffer: String,
-    insertion_point: usize,
+    /// The line this was armed on, stamped as a completer stamps its own results.
+    origin: CompletionOrigin,
 }
 
 impl DeferredMenuCompletion {
     fn new(menu: &ReedlineMenu, editor: &Editor) -> Self {
         Self {
             menu: menu.name().to_string(),
-            buffer: editor.get_buffer().to_string(),
-            insertion_point: editor.insertion_point(),
+            origin: CompletionOrigin::new(editor.get_buffer(), editor.insertion_point()),
         }
     }
 
@@ -267,8 +265,7 @@ impl DeferredMenuCompletion {
     /// Anything else means the user moved on and the decision is void.
     fn still_applies(&self, menu: &ReedlineMenu, editor: &Editor) -> bool {
         self.menu == menu.name()
-            && self.buffer == editor.get_buffer()
-            && self.insertion_point == editor.insertion_point()
+            && self.origin == CompletionOrigin::new(editor.get_buffer(), editor.insertion_point())
     }
 }
 
@@ -1099,6 +1096,7 @@ impl Reedline {
     fn settle_completions(&mut self, prompt: &dyn Prompt) -> Result<()> {
         let mut repopulated = false;
         let mut accept_lone_value = false;
+        let mut still_provisional = false;
 
         if let Some(menu) = self.menus.iter_mut().find(|menu| menu.is_active()) {
             // The request this menu was waiting on finished, so repopulate it.
@@ -1108,13 +1106,14 @@ impl Reedline {
                 self.history.as_ref(),
             );
             repopulated = true;
+            still_provisional = menu.results_are_provisional();
 
             let owed = self
                 .deferred_menu_completion
                 .as_ref()
                 .map_or(false, |deferred| deferred.still_applies(menu, &self.editor));
 
-            if owed {
+            if owed && !still_provisional {
                 // Replay what activating the menu would have done, in the same order: a
                 // lone value is accepted outright, otherwise a shared prefix is spliced in.
                 accept_lone_value = self.quick_completions
@@ -1133,9 +1132,11 @@ impl Reedline {
             }
         }
 
-        // Spent either way: a deferral these results did not satisfy must not act on a
-        // later one.
-        self.deferred_menu_completion = None;
+        // Spent once a final answer had its say, so it cannot act on a later one.
+        // Provisional results decided nothing, so the arm outlives them.
+        if !still_provisional {
+            self.deferred_menu_completion = None;
+        }
 
         if accept_lone_value {
             // With a menu active this replaces in the buffer and deactivates, rather than
@@ -1386,7 +1387,10 @@ impl Reedline {
                                 self.history.as_ref(),
                             );
 
-                            if menu.get_values().len() == 1 {
+                            // Accepting a lone *stale* value is refused downstream,
+                            // since its span belongs to another line, so the menu
+                            // would close over a completion that never happened.
+                            if menu.get_values().len() == 1 && !menu.results_are_provisional() {
                                 return self.handle_editor_event(prompt, ReedlineEvent::Enter);
                             }
                         }
@@ -1400,13 +1404,16 @@ impl Reedline {
                             );
                         }
 
-                        // Armed even when values did come back, since settling re-checks
-                        // them and a result that was already final never lands a second
-                        // time.
-                        if self.quick_completions || self.partial_completions {
-                            self.deferred_menu_completion =
-                                Some(DeferredMenuCompletion::new(menu, &self.editor));
+                        // A final answer already had its say above, so only a
+                        // provisional one leaves anything owed. With neither option set
+                        // nothing queried the completer, so this reads the default
+                        // `false` and the menu paints as it always has.
+                        if !menu.results_are_provisional() {
+                            return Ok(EventStatus::Handled);
                         }
+
+                        self.deferred_menu_completion =
+                            Some(DeferredMenuCompletion::new(menu, &self.editor));
 
                         return Ok(EventStatus::Handled);
                     }
@@ -2600,7 +2607,8 @@ mod tests {
     use super::*;
     use crate::terminal_extensions::semantic_prompt::PromptKind;
     use crate::{
-        ColumnarMenu, CompletionResult, DefaultPrompt, MenuBuilder, PromptViMode, Span, Suggestion,
+        ColumnarMenu, CompletionOrigin, CompletionResult, DefaultPrompt, MenuBuilder, PromptViMode,
+        Span, Suggestion,
     };
     use rstest::rstest;
 
@@ -3589,11 +3597,31 @@ mod tests {
     }
 
     fn engine_awaiting(values: &[&str], buffer: &str, quick: bool, partial: bool) -> Reedline {
+        let (reedline, _) = activate_menu_over(
+            Box::new(DeferredCompleter::new(values)),
+            buffer,
+            quick,
+            partial,
+        );
+
+        // Nothing could be decided yet, the premise of every test below.
+        assert_eq!(reedline.current_buffer_contents(), buffer);
+        reedline
+    }
+
+    /// Type `buffer` and press Tab, against a completer that answers however the test
+    /// needs it to. Returns the engine and how the menu activation was handled.
+    fn activate_menu_over(
+        completer: Box<dyn Completer + Send>,
+        buffer: &str,
+        quick: bool,
+        partial: bool,
+    ) -> (Reedline, EventStatus) {
         let completion_menu = ReedlineMenu::EngineCompleter(Box::new(
             ColumnarMenu::default().with_name("completion_menu"),
         ));
         let mut reedline = Reedline::create()
-            .with_completer(Box::new(DeferredCompleter::new(values)))
+            .with_completer(completer)
             .with_menu(completion_menu)
             .with_quick_completions(quick)
             .with_partial_completions(partial);
@@ -3603,16 +3631,14 @@ mod tests {
         reedline.painter.force_terminal_size_for_test(80, 24);
 
         reedline.run_edit_commands(&[EditCommand::InsertString(buffer.to_string())]);
-        reedline
+        let status = reedline
             .handle_event(
                 &DefaultPrompt::default(),
                 ReedlineEvent::Menu(String::from("completion_menu")),
             )
             .unwrap();
 
-        // Nothing could be decided yet — that is the premise of every test below.
-        assert_eq!(reedline.current_buffer_contents(), buffer);
-        reedline
+        (reedline, status)
     }
 
     fn settle(reedline: &mut Reedline) {
@@ -3725,6 +3751,90 @@ mod tests {
 
         assert_eq!(reedline.current_buffer_contents(), "cr");
         assert!(menu_is_active(&reedline));
+    }
+
+    /// A warm-but-wrong cache: the first request is answered from a neighbouring entry,
+    /// so the values are real but belong to another line. Only the second carries the
+    /// answer for the line on screen.
+    struct StaleThenFreshCompleter {
+        stale: String,
+        origin: CompletionOrigin,
+        values: Vec<String>,
+        dispatched: bool,
+    }
+
+    impl StaleThenFreshCompleter {
+        fn new(stale: &str, origin_buffer: &str, values: &[&str]) -> Self {
+            Self {
+                stale: stale.to_string(),
+                origin: CompletionOrigin::new(origin_buffer, origin_buffer.len()),
+                values: values.iter().map(|value| value.to_string()).collect(),
+                dispatched: false,
+            }
+        }
+    }
+
+    impl Completer for StaleThenFreshCompleter {
+        fn complete(&mut self, _line: &str, pos: usize) -> CompletionResult {
+            if !self.dispatched {
+                self.dispatched = true;
+                return CompletionResult::Stale {
+                    suggestions: vec![Suggestion {
+                        value: self.stale.clone(),
+                        span: Span {
+                            start: 0,
+                            end: self.origin.buffer.len(),
+                        },
+                        ..Default::default()
+                    }]
+                    .into(),
+                    origin: self.origin.clone(),
+                    partial: None,
+                };
+            }
+            CompletionResult::fresh(
+                self.values
+                    .iter()
+                    .map(|value| Suggestion {
+                        value: value.clone(),
+                        span: Span { start: 0, end: pos },
+                        ..Default::default()
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }
+
+        fn poll_completion(&mut self) -> CompletionStatus {
+            if self.dispatched {
+                CompletionStatus::Ready
+            } else {
+                CompletionStatus::Idle
+            }
+        }
+    }
+
+    /// A lone *stale* suggestion looks like a lone fresh one to the quick completion
+    /// check, but accepting it is a no-op. The Tab must still be honoured once the real
+    /// answer lands.
+    #[test]
+    fn a_lone_stale_suggestion_does_not_swallow_the_completion() {
+        let (mut reedline, _) = activate_menu_over(
+            Box::new(StaleThenFreshCompleter::new("console", "co", &["crates"])),
+            "cr",
+            true,
+            false,
+        );
+
+        // The stale span is refused, so the buffer is untouched.
+        assert_eq!(reedline.current_buffer_contents(), "cr");
+
+        settle(&mut reedline);
+
+        assert_eq!(
+            reedline.current_buffer_contents(),
+            "crates",
+            "the fresh result was dropped because the stale one closed the menu first"
+        );
     }
 
     fn menu_is_active(reedline: &Reedline) -> bool {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2446,7 +2446,7 @@ impl Reedline {
             if menu.is_active() {
                 // A menu still waiting on its first answer stays off screen, so a Tab
                 // resolving to one suggestion never draws a menu it takes away again.
-                if !menu.is_awaiting_first_answer() {
+                if menu.is_visible() {
                     lines.prompt_indicator = menu.indicator().to_owned().into();
                 }
                 // If the menu requires the cursor position, update it (ide menu)
@@ -2459,13 +2459,20 @@ impl Reedline {
                     self.history.as_ref(),
                     &self.painter,
                 );
+
+                // That update is where a first answer lands and ends the opening phase,
+                // so ask again: the painter picks the menu to draw below, and an
+                // indicator saying otherwise would draw its rows under the ordinary
+                // prompt. Reading it twice is the price of the loop: the indicator sets
+                // the prompt width that positions the cursor, which the update consumes,
+                // so on the frame a menu opens that width lags by one paint.
+                if menu.is_visible() {
+                    lines.prompt_indicator = menu.indicator().to_owned().into();
+                }
             }
         }
 
-        let menu = self
-            .menus
-            .iter()
-            .find(|menu| menu.is_active() && !menu.is_awaiting_first_answer());
+        let menu = self.menus.iter().find(|menu| menu.is_visible());
 
         self.painter.repaint_buffer(
             prompt,

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -627,6 +627,10 @@ impl Menu for ColumnarMenu {
         // Reset completions on activation
         self.completions = CompletionDisplay::default();
         self.opening = true;
+        // Nothing has been asked about this line yet, so no answer is outstanding and
+        // none is provisional. Left alone, both would describe the previous activation.
+        self.awaiting_results = false;
+        self.provisional_results = false;
     }
 
     /// Queue menu event
@@ -1127,6 +1131,32 @@ mod tests {
         assert!(
             !menu.is_awaiting_first_answer(),
             "the first real answer makes it visible"
+        );
+    }
+
+    /// Freshness describes the line the menu is open over, so re-opening it must not
+    /// inherit the last line's answer. The engine reads this to decide whether anything
+    /// is still owed, and with quick and partial completions both off nothing queries
+    /// the completer, so a leftover `true` would arm a replay that can never come.
+    #[test]
+    fn re_activating_forgets_the_previous_lines_answer() {
+        let mut menu = ColumnarMenu::default();
+        let mut editor = Editor::default();
+        editor.set_buffer("cr".to_string(), UndoBehavior::CreateUndoPoint);
+
+        menu.menu_event(MenuEvent::Activate(true));
+        menu.update_values(
+            &mut editor,
+            &mut StaleSpanCompleter::new("console", Span::new(0, 2), "co", 2),
+        );
+        assert!(menu.results_are_provisional());
+
+        menu.menu_event(MenuEvent::Deactivate);
+        menu.menu_event(MenuEvent::Activate(true));
+
+        assert!(
+            !menu.results_are_provisional(),
+            "nothing has been asked about the new line yet"
         );
     }
 

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -75,6 +75,9 @@ pub struct ColumnarMenu {
     /// yet. While set, the menu draws nothing rather than a premature
     /// "NO RECORDS FOUND" (which is reserved for a settled, genuinely empty result).
     awaiting_results: bool,
+    /// Whether the displayed values may still be superseded. Implied by
+    /// `awaiting_results`, but also set when stale values *are* on screen.
+    provisional_results: bool,
     /// Column position
     col_pos: u16,
     /// row position in the menu. Starts from 0
@@ -98,6 +101,7 @@ impl Default for ColumnarMenu {
             working_details: ColumnDetails::default(),
             completions: CompletionDisplay::default(),
             awaiting_results: false,
+            provisional_results: false,
             col_pos: 0,
             row_pos: 0,
             skip_rows: 0,
@@ -637,6 +641,7 @@ impl Menu for ColumnarMenu {
 
         let (result, base_ranges) = completer.complete_with_base_ranges(&input, pos);
         self.awaiting_results = result.is_pending();
+        self.provisional_results = result.is_provisional();
         if let Some(completions) = CompletionDisplay::from_result(result, &base_ranges, editor) {
             self.completions = completions;
             self.reset_position();
@@ -672,6 +677,10 @@ impl Menu for ColumnarMenu {
     /// Gets values from filler that will be displayed in the menu
     fn get_values(&self) -> &[Suggestion] {
         self.completions.suggestions()
+    }
+
+    fn results_are_provisional(&self) -> bool {
+        self.provisional_results
     }
 
     fn menu_required_lines(&self, _terminal_columns: u16) -> u16 {

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -3,7 +3,7 @@ use crate::{
     core_editor::Editor,
     menu_functions::{
         available_lines, get_match_indices, resolve_completer_input, scroll_offset,
-        style_suggestion, truncate_with_ansi, CompletionDisplay,
+        style_suggestion, truncate_with_ansi, CompletionDisplay, CompletionPhase,
     },
     painting::Painter,
     Completer, Suggestion,
@@ -71,16 +71,10 @@ pub struct ColumnarMenu {
     working_details: ColumnDetails,
     /// Suggestions currently displayed and their derived display metrics
     completions: CompletionDisplay,
-    /// Whether a background completion is still in flight with nothing to show
-    /// yet. While set, the menu draws nothing rather than a premature
-    /// "NO RECORDS FOUND" (which is reserved for a settled, genuinely empty result).
-    awaiting_results: bool,
-    /// Whether the displayed values may still be superseded. Implied by
-    /// `awaiting_results`, but also set when stale values *are* on screen.
-    provisional_results: bool,
-    /// Whether the menu is activated but not yet drawn. Cleared by the first
-    /// answer about the line on screen.
-    opening: bool,
+    /// Where the menu stands between activation and a final answer about the
+    /// line on screen: visibility, what may be decided from the values, and
+    /// whether an empty menu means "still computing" or "no records".
+    phase: CompletionPhase,
     /// Column position
     col_pos: u16,
     /// row position in the menu. Starts from 0
@@ -103,9 +97,7 @@ impl Default for ColumnarMenu {
             min_rows: 3,
             working_details: ColumnDetails::default(),
             completions: CompletionDisplay::default(),
-            awaiting_results: false,
-            provisional_results: false,
-            opening: false,
+            phase: CompletionPhase::Unasked,
             col_pos: 0,
             row_pos: 0,
             skip_rows: 0,
@@ -310,7 +302,7 @@ impl ColumnarMenu {
     fn get_rows(&self) -> u16 {
         match self.get_values().len() as u16 {
             // No reason to save space if we're waiting for results.
-            0 if self.awaiting_results => 0,
+            0 if self.phase.awaiting_results() => 0,
             // Should be one row for actual empty results
             0 => 1,
             total_values => (total_values + self.get_cols() - 1) / self.get_cols(),
@@ -626,11 +618,7 @@ impl Menu for ColumnarMenu {
     fn on_activate(&mut self) {
         // Reset completions on activation
         self.completions = CompletionDisplay::default();
-        self.opening = true;
-        // Nothing has been asked about this line yet, so no answer is outstanding and
-        // none is provisional. Left alone, both would describe the previous activation.
-        self.awaiting_results = false;
-        self.provisional_results = false;
+        self.phase.on_activate();
     }
 
     /// Queue menu event
@@ -649,11 +637,7 @@ impl Menu for ColumnarMenu {
         let (input, pos) = resolve_completer_input(editor, &mut self.input, &self.settings);
 
         let (result, base_ranges) = completer.complete_with_base_ranges(&input, pos);
-        self.provisional_results = result.is_provisional();
-        // The menu becomes visible on the first answer about the line on screen.
-        self.opening &= self.provisional_results;
-
-        self.awaiting_results = result.is_pending();
+        self.phase.note(&result);
         if let Some(completions) = CompletionDisplay::from_result(result, &base_ranges, editor) {
             self.completions = completions;
             self.reset_position();
@@ -692,11 +676,11 @@ impl Menu for ColumnarMenu {
     }
 
     fn results_are_provisional(&self) -> bool {
-        self.provisional_results
+        self.phase.provisional()
     }
 
     fn is_awaiting_first_answer(&self) -> bool {
-        self.opening
+        self.phase.awaiting_first_answer()
     }
 
     fn menu_required_lines(&self, _terminal_columns: u16) -> u16 {
@@ -705,7 +689,7 @@ impl Menu for ColumnarMenu {
 
     fn menu_string(&self, available_lines: u16, use_ansi_coloring: bool) -> String {
         if self.get_values().is_empty() {
-            if self.awaiting_results {
+            if self.phase.awaiting_results() {
                 // A background completion is still running; draw nothing rather
                 // than flashing "NO RECORDS FOUND" before the results land.
                 String::new()

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -78,6 +78,9 @@ pub struct ColumnarMenu {
     /// Whether the displayed values may still be superseded. Implied by
     /// `awaiting_results`, but also set when stale values *are* on screen.
     provisional_results: bool,
+    /// Whether the menu is activated but not yet drawn. Cleared by the first
+    /// answer about the line on screen.
+    opening: bool,
     /// Column position
     col_pos: u16,
     /// row position in the menu. Starts from 0
@@ -102,6 +105,7 @@ impl Default for ColumnarMenu {
             completions: CompletionDisplay::default(),
             awaiting_results: false,
             provisional_results: false,
+            opening: false,
             col_pos: 0,
             row_pos: 0,
             skip_rows: 0,
@@ -622,6 +626,7 @@ impl Menu for ColumnarMenu {
     fn on_activate(&mut self) {
         // Reset completions on activation
         self.completions = CompletionDisplay::default();
+        self.opening = true;
     }
 
     /// Queue menu event
@@ -640,8 +645,11 @@ impl Menu for ColumnarMenu {
         let (input, pos) = resolve_completer_input(editor, &mut self.input, &self.settings);
 
         let (result, base_ranges) = completer.complete_with_base_ranges(&input, pos);
-        self.awaiting_results = result.is_pending();
         self.provisional_results = result.is_provisional();
+        // The menu becomes visible on the first answer about the line on screen.
+        self.opening &= self.provisional_results;
+
+        self.awaiting_results = result.is_pending();
         if let Some(completions) = CompletionDisplay::from_result(result, &base_ranges, editor) {
             self.completions = completions;
             self.reset_position();
@@ -681,6 +689,10 @@ impl Menu for ColumnarMenu {
 
     fn results_are_provisional(&self) -> bool {
         self.provisional_results
+    }
+
+    fn is_awaiting_first_answer(&self) -> bool {
+        self.opening
     }
 
     fn menu_required_lines(&self, _terminal_columns: u16) -> u16 {
@@ -1085,6 +1097,62 @@ mod tests {
                 partial: None,
             }
         }
+    }
+
+    /// A menu drawn and then taken away a few frames later reads as the prompt
+    /// flickering, so it stays off screen until it hears about the line on screen.
+    #[test]
+    fn an_opening_menu_is_not_visible_until_answered() {
+        let mut menu = ColumnarMenu::default();
+        let mut editor = Editor::default();
+        editor.set_buffer("cr".to_string(), UndoBehavior::CreateUndoPoint);
+
+        menu.menu_event(MenuEvent::Activate(true));
+        menu.update_values(
+            &mut editor,
+            &mut StaleSpanCompleter::new("console", Span::new(0, 2), "co", 2),
+        );
+        assert!(
+            menu.is_awaiting_first_answer(),
+            "a cached answer about another line does not open the menu"
+        );
+
+        menu.update_values(
+            &mut editor,
+            &mut SpanCompleter {
+                value: String::from("crates"),
+                span: Span::new(0, 2),
+            },
+        );
+        assert!(
+            !menu.is_awaiting_first_answer(),
+            "the first real answer makes it visible"
+        );
+    }
+
+    /// Once open it is the other way round: stale values beat blanking the menu on
+    /// every keystroke, which is what they exist for.
+    #[test]
+    fn an_open_menu_keeps_showing_stale_values() {
+        let mut menu = ColumnarMenu::default();
+        let mut editor = Editor::default();
+        editor.set_buffer("cr".to_string(), UndoBehavior::CreateUndoPoint);
+
+        // A final answer opens the menu for real and ends the opening phase.
+        menu.menu_event(MenuEvent::Activate(true));
+        let mut fresh = SpanCompleter {
+            value: String::from("crates"),
+            span: Span::new(0, 2),
+        };
+        menu.update_values(&mut editor, &mut fresh);
+        assert_eq!(menu.get_values().len(), 1);
+
+        // A later request that can only answer with cached values still populates it.
+        let mut stale = StaleSpanCompleter::new("console", Span::new(0, 2), "co", 2);
+        menu.update_values(&mut editor, &mut stale);
+
+        assert_eq!(menu.get_values().len(), 1, "stale values are still shown");
+        assert_eq!(menu.get_values()[0].value, "console");
     }
 
     /// Stale span not spliced into changed buffer

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -150,6 +150,9 @@ pub struct IdeMenu {
     /// Whether the displayed values may still be superseded. Implied by
     /// `awaiting_results`, but also set when stale values *are* on screen.
     provisional_results: bool,
+    /// Whether the menu is activated but not yet drawn. Cleared by the first
+    /// answer about the line on screen.
+    opening: bool,
     /// Selected index
     selected: u16,
     /// Number of values that are skipped when printing,
@@ -171,6 +174,7 @@ impl Default for IdeMenu {
             completions: CompletionDisplay::default(),
             awaiting_results: false,
             provisional_results: false,
+            opening: false,
             selected: 0,
             skip_values: 0,
             event: None,
@@ -797,6 +801,7 @@ impl Menu for IdeMenu {
     fn on_activate(&mut self) {
         // Clear stale completions from previous activation
         self.completions = CompletionDisplay::default();
+        self.opening = true;
     }
 
     /// Queue menu event
@@ -813,8 +818,11 @@ impl Menu for IdeMenu {
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
         let (input, pos) = resolve_completer_input(editor, &mut self.input, &self.settings);
         let (result, base_ranges) = completer.complete_with_base_ranges(&input, pos);
-        self.awaiting_results = result.is_pending();
         self.provisional_results = result.is_provisional();
+        // The menu becomes visible on the first answer about the line on screen.
+        self.opening &= self.provisional_results;
+
+        self.awaiting_results = result.is_pending();
         if let Some(completions) = CompletionDisplay::from_result(result, &base_ranges, editor) {
             self.completions = completions;
             self.reset_position();
@@ -853,6 +861,10 @@ impl Menu for IdeMenu {
 
     fn results_are_provisional(&self) -> bool {
         self.provisional_results
+    }
+
+    fn is_awaiting_first_answer(&self) -> bool {
+        self.opening
     }
 
     fn menu_required_lines(&self, _terminal_columns: u16) -> u16 {

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -3,7 +3,7 @@ use crate::{
     core_editor::Editor,
     menu_functions::{
         available_lines, get_match_indices, resolve_completer_input, scroll_offset,
-        style_suggestion, truncate_with_ansi, CompletionDisplay,
+        style_suggestion, truncate_with_ansi, CompletionDisplay, CompletionPhase,
     },
     painting::Painter,
     Completer, Suggestion,
@@ -143,16 +143,10 @@ pub struct IdeMenu {
     working_details: IdeMenuDetails,
     /// Suggestions currently displayed and their derived display metrics
     completions: CompletionDisplay,
-    /// Whether a background completion is still in flight with nothing to show
-    /// yet. While set, the menu draws nothing rather than a premature
-    /// "NO RECORDS FOUND" (which is reserved for a settled, genuinely empty result).
-    awaiting_results: bool,
-    /// Whether the displayed values may still be superseded. Implied by
-    /// `awaiting_results`, but also set when stale values *are* on screen.
-    provisional_results: bool,
-    /// Whether the menu is activated but not yet drawn. Cleared by the first
-    /// answer about the line on screen.
-    opening: bool,
+    /// Where the menu stands between activation and a final answer about the
+    /// line on screen: visibility, what may be decided from the values, and
+    /// whether an empty menu means "still computing" or "no records".
+    phase: CompletionPhase,
     /// Selected index
     selected: u16,
     /// Number of values that are skipped when printing,
@@ -172,9 +166,7 @@ impl Default for IdeMenu {
             default_details: DefaultIdeMenuDetails::default(),
             working_details: IdeMenuDetails::default(),
             completions: CompletionDisplay::default(),
-            awaiting_results: false,
-            provisional_results: false,
-            opening: false,
+            phase: CompletionPhase::Unasked,
             selected: 0,
             skip_values: 0,
             event: None,
@@ -333,7 +325,7 @@ impl IdeMenu {
             // While a background completion is still in flight there is nothing to
             // show yet, so reserve no space; otherwise the empty menu is a settled
             // result and reserves 1 line for the no_records_msg.
-            return if self.awaiting_results { 0 } else { 1 };
+            return if self.phase.awaiting_results() { 0 } else { 1 };
         }
 
         if self.default_details.border.is_some() {
@@ -801,11 +793,7 @@ impl Menu for IdeMenu {
     fn on_activate(&mut self) {
         // Clear stale completions from previous activation
         self.completions = CompletionDisplay::default();
-        self.opening = true;
-        // Nothing has been asked about this line yet, so no answer is outstanding and
-        // none is provisional. Left alone, both would describe the previous activation.
-        self.awaiting_results = false;
-        self.provisional_results = false;
+        self.phase.on_activate();
     }
 
     /// Queue menu event
@@ -822,11 +810,7 @@ impl Menu for IdeMenu {
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
         let (input, pos) = resolve_completer_input(editor, &mut self.input, &self.settings);
         let (result, base_ranges) = completer.complete_with_base_ranges(&input, pos);
-        self.provisional_results = result.is_provisional();
-        // The menu becomes visible on the first answer about the line on screen.
-        self.opening &= self.provisional_results;
-
-        self.awaiting_results = result.is_pending();
+        self.phase.note(&result);
         if let Some(completions) = CompletionDisplay::from_result(result, &base_ranges, editor) {
             self.completions = completions;
             self.reset_position();
@@ -864,11 +848,11 @@ impl Menu for IdeMenu {
     }
 
     fn results_are_provisional(&self) -> bool {
-        self.provisional_results
+        self.phase.provisional()
     }
 
     fn is_awaiting_first_answer(&self) -> bool {
-        self.opening
+        self.phase.awaiting_first_answer()
     }
 
     fn menu_required_lines(&self, _terminal_columns: u16) -> u16 {
@@ -878,7 +862,7 @@ impl Menu for IdeMenu {
 
     fn menu_string(&self, available_lines: u16, use_ansi_coloring: bool) -> String {
         if self.get_values().is_empty() {
-            if self.awaiting_results {
+            if self.phase.awaiting_results() {
                 // A background completion is still running; draw nothing rather
                 // than flashing "NO RECORDS FOUND" before the results land.
                 String::new()

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -802,6 +802,10 @@ impl Menu for IdeMenu {
         // Clear stale completions from previous activation
         self.completions = CompletionDisplay::default();
         self.opening = true;
+        // Nothing has been asked about this line yet, so no answer is outstanding and
+        // none is provisional. Left alone, both would describe the previous activation.
+        self.awaiting_results = false;
+        self.provisional_results = false;
     }
 
     /// Queue menu event

--- a/src/menu/ide_menu.rs
+++ b/src/menu/ide_menu.rs
@@ -147,6 +147,9 @@ pub struct IdeMenu {
     /// yet. While set, the menu draws nothing rather than a premature
     /// "NO RECORDS FOUND" (which is reserved for a settled, genuinely empty result).
     awaiting_results: bool,
+    /// Whether the displayed values may still be superseded. Implied by
+    /// `awaiting_results`, but also set when stale values *are* on screen.
+    provisional_results: bool,
     /// Selected index
     selected: u16,
     /// Number of values that are skipped when printing,
@@ -167,6 +170,7 @@ impl Default for IdeMenu {
             working_details: IdeMenuDetails::default(),
             completions: CompletionDisplay::default(),
             awaiting_results: false,
+            provisional_results: false,
             selected: 0,
             skip_values: 0,
             event: None,
@@ -810,6 +814,7 @@ impl Menu for IdeMenu {
         let (input, pos) = resolve_completer_input(editor, &mut self.input, &self.settings);
         let (result, base_ranges) = completer.complete_with_base_ranges(&input, pos);
         self.awaiting_results = result.is_pending();
+        self.provisional_results = result.is_provisional();
         if let Some(completions) = CompletionDisplay::from_result(result, &base_ranges, editor) {
             self.completions = completions;
             self.reset_position();
@@ -844,6 +849,10 @@ impl Menu for IdeMenu {
 
     fn get_values(&self) -> &[Suggestion] {
         self.completions.suggestions()
+    }
+
+    fn results_are_provisional(&self) -> bool {
+        self.provisional_results
     }
 
     fn menu_required_lines(&self, _terminal_columns: u16) -> u16 {

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -418,8 +418,8 @@ impl CompletionDisplay {
 
     /// Whether spans match the current editor buffer
     fn is_current(&self, editor: &Editor) -> bool {
-        self.computed_for.buffer == editor.get_buffer()
-            && self.computed_for.insertion_point == editor.insertion_point()
+        self.computed_for
+            .matches(editor.get_buffer(), editor.insertion_point())
     }
 
     /// Accept suggestion at index (no-op if stale or out of range)

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -329,6 +329,88 @@ pub(crate) fn scroll_offset(selected: u16, current: u16, window: u16) -> u16 {
     }
 }
 
+/// Where a menu stands between its activation and a final answer about the
+/// line on screen.
+///
+/// One value instead of three flags (`awaiting_results`, `provisional_results`,
+/// `opening`), whose invariants — pending implies provisional, and only a final
+/// answer may end the opening phase — lived in the update order rather than in
+/// a type that cannot express their violation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum CompletionPhase {
+    /// Activated with nothing asked about the line yet: no answer is
+    /// outstanding and none is provisional.
+    #[default]
+    Unasked,
+    /// Only provisional answers so far. The menu stays off screen, so one
+    /// about to be closed by a lone suggestion never appears.
+    Opening(AnswerKind),
+    /// A final answer landed once. Later provisional answers keep the menu on
+    /// screen: stale values beat blanking it on every keystroke.
+    Open(AnswerKind),
+}
+
+/// How final the last answer was, as [`CompletionPhase`] remembers it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AnswerKind {
+    /// Computed for the line on screen.
+    Fresh,
+    /// Cached values for another line: shown, never decided on.
+    Stale,
+    /// Nothing yet; the background work is still running.
+    Pending,
+}
+
+impl CompletionPhase {
+    /// A new activation forgets the previous line's answer entirely.
+    pub(crate) fn on_activate(&mut self) {
+        *self = CompletionPhase::Unasked;
+    }
+
+    /// Fold the answer to an update into the phase.
+    pub(crate) fn note(&mut self, result: &CompletionResult) {
+        let kind = if result.is_pending() {
+            AnswerKind::Pending
+        } else if result.is_provisional() {
+            AnswerKind::Stale
+        } else {
+            AnswerKind::Fresh
+        };
+        *self = match (*self, kind) {
+            // Once open, no later answer can put the menu back off screen.
+            (CompletionPhase::Open(_), kind) => CompletionPhase::Open(kind),
+            // Only a final answer ends the opening phase.
+            (_, AnswerKind::Fresh) => CompletionPhase::Open(AnswerKind::Fresh),
+            (_, kind) => CompletionPhase::Opening(kind),
+        };
+    }
+
+    /// Whether the values on display may still be superseded.
+    pub(crate) fn provisional(self) -> bool {
+        match self {
+            CompletionPhase::Unasked => false,
+            CompletionPhase::Opening(kind) | CompletionPhase::Open(kind) => {
+                kind != AnswerKind::Fresh
+            }
+        }
+    }
+
+    /// Whether a background answer is still outstanding, so an empty menu
+    /// means "still computing" rather than "no records".
+    pub(crate) fn awaiting_results(self) -> bool {
+        matches!(
+            self,
+            CompletionPhase::Opening(AnswerKind::Pending)
+                | CompletionPhase::Open(AnswerKind::Pending)
+        )
+    }
+
+    /// Whether no final answer about the line on screen has landed yet.
+    pub(crate) fn awaiting_first_answer(self) -> bool {
+        !matches!(self, CompletionPhase::Open(_))
+    }
+}
+
 /// A menu's suggestions, tied to the buffer they were computed against.
 /// Spans are validated before reaching the buffer.
 #[derive(Default)]

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -199,6 +199,12 @@ pub trait Menu: Send {
         false
     }
 
+    /// Whether the menu is activated but not yet drawn, having heard no answer
+    /// about the line on screen. It claims no prompt indicator and reserves no
+    /// rows, so a menu about to be closed by a lone suggestion never appears.
+    fn is_awaiting_first_answer(&self) -> bool {
+        false
+    }
     /// Sets the position of the cursor (currently only required by the IDE menu)
     fn set_cursor_pos(&mut self, _pos: (u16, u16)) {
         // empty implementation to make it optional
@@ -624,6 +630,10 @@ impl Menu for ReedlineMenu {
 
     fn results_are_provisional(&self) -> bool {
         self.as_ref().results_are_provisional()
+    }
+
+    fn is_awaiting_first_answer(&self) -> bool {
+        self.as_ref().is_awaiting_first_answer()
     }
 
     fn set_cursor_pos(&mut self, pos: (u16, u16)) {

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -205,6 +205,13 @@ pub trait Menu: Send {
     fn is_awaiting_first_answer(&self) -> bool {
         false
     }
+
+    /// Whether the menu is on screen. An active menu still awaiting its first answer
+    /// is not: it takes input, but claims no indicator and reserves no rows.
+    fn is_visible(&self) -> bool {
+        self.is_active() && !self.is_awaiting_first_answer()
+    }
+
     /// Sets the position of the cursor (currently only required by the IDE menu)
     fn set_cursor_pos(&mut self, _pos: (u16, u16)) {
         // empty implementation to make it optional

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -187,6 +187,18 @@ pub trait Menu: Send {
 
     /// Gets cached values from menu that will be displayed
     fn get_values(&self) -> &[Suggestion];
+
+    /// Whether the values currently held may still be superseded, because the
+    /// last request came back [`Pending`](crate::CompletionResult::Pending) or
+    /// [`Stale`](crate::CompletionResult::Stale).
+    ///
+    /// Such values display and navigate normally, but nothing final may be
+    /// decided from them: a lone stale suggestion cannot be accepted, since its
+    /// span belongs to another line.
+    fn results_are_provisional(&self) -> bool {
+        false
+    }
+
     /// Sets the position of the cursor (currently only required by the IDE menu)
     fn set_cursor_pos(&mut self, _pos: (u16, u16)) {
         // empty implementation to make it optional
@@ -608,6 +620,10 @@ impl Menu for ReedlineMenu {
 
     fn get_values(&self) -> &[Suggestion] {
         self.as_ref().get_values()
+    }
+
+    fn results_are_provisional(&self) -> bool {
+        self.as_ref().results_are_provisional()
     }
 
     fn set_cursor_pos(&mut self, pos: (u16, u16)) {

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1299,13 +1299,6 @@ impl Painter {
     pub(crate) fn prompt_anchor_is_verified_for_test(&self) -> bool {
         matches!(self.prompt_start_row, PromptStartRow::Verified(_))
     }
-
-    /// Stand in for the size `initialize_prompt_position` would have queried, so a test can
-    /// paint without a terminal. The default `(0, 0)` divides by zero during layout.
-    #[cfg(test)]
-    pub(crate) fn force_terminal_size_for_test(&mut self, columns: u16, rows: u16) {
-        self.terminal_size = (columns, rows);
-    }
 }
 
 #[cfg(test)]

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1299,6 +1299,13 @@ impl Painter {
     pub(crate) fn prompt_anchor_is_verified_for_test(&self) -> bool {
         matches!(self.prompt_start_row, PromptStartRow::Verified(_))
     }
+
+    /// Stand in for the size `initialize_prompt_position` would have queried, so a test can
+    /// paint without a terminal. The default `(0, 0)` divides by zero during layout.
+    #[cfg(test)]
+    pub(crate) fn force_terminal_size_for_test(&mut self, columns: u16, rows: u16) {
+        self.terminal_size = (columns, rows);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- Thanks for contributing to Reedline! -->

## Summary <!-- Must Have -->
<!--
Motivate this PR: why did you open it, how did you arrive at this solution?
Mention any changes to Reedline's public API or observable behavior, or mention that there are none.
-->
Since #1093 a completer may answer with `Pending` and compute in the background. Activating a menu inspects its values immediately, so the quick completion and the partial completion both read an empty menu and neither fires, leaving a menu open where a lone suggestion used to be accepted outright.

Both decisions are now replayed when the results land, guarded by a snapshot of the line taken as the menu opened, since a completion applied after the user has typed on is worse than one that never fires.

## Additional notes <!-- Optional -->
<!--
Anything else worth knowing. Link related issues with `closes #123` / `fixes #456` to auto-close them on merge.
-->
Fixes #1142