### PR TITLE
chore: raise rust-version to the 1.95 the locked deps requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Rust toolchain (MSRV)
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: "1.86"
+          toolchain: "1.95"
 
       - name: Check the library builds on the MSRV
         run: cargo check --locked --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,20 @@ jobs:
 
       - name: Doctests
         run: cargo test --doc ${{ matrix.flags }}
+
+  # Guards the `rust-version` claim in Cargo.toml, compiling the library as a
+  # consumer on the MSRV would. Kept as a CI job instead of a rust-toolchain.toml
+  # on purpose; everything else floats on stable.
+  msrv-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust toolchain (MSRV)
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: "1.86"
+
+      - name: Check the library builds on the MSRV
+        run: cargo check --locked --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "reedline"
 repository = "https://github.com/nushell/reedline"
-rust-version = "1.63.0"
+rust-version = "1.86.0"
 version = "0.49.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "reedline"
 repository = "https://github.com/nushell/reedline"
-rust-version = "1.86.0"
+rust-version = "1.95.0"
 version = "0.49.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -41,7 +41,7 @@ fn main() -> reedline::Result<()> {
             history_session_id,
             Some(chrono::Utc::now()),
         )
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
+        .map_err(std::io::Error::other)?,
     );
     #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
     let history = Box::new(FileBackedHistory::with_file(50, "history.txt".into())?);
@@ -193,9 +193,7 @@ fn main() -> reedline::Result<()> {
                 }
                 if buffer.trim() == "clear-history" {
                     let hstry = Box::new(line_editor.history_mut());
-                    hstry
-                        .clear()
-                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    hstry.clear().map_err(std::io::Error::other)?;
                     continue;
                 }
                 println!("Our buffer: {buffer}");

--- a/src/core_editor/line_buffer.rs
+++ b/src/core_editor/line_buffer.rs
@@ -299,7 +299,7 @@ impl LineBuffer {
     fn at_end_of_line_with_preceding_whitespace(&self) -> bool {
         !self.is_empty() // No point checking if empty
         && self.cursor.head() == self.lines.len()
-        && self.lines.chars().last().map_or(false, |c| c.is_whitespace())
+        && self.lines.chars().last().is_some_and(|c| c.is_whitespace())
     }
 
     /// Cursor position at the end of the current whitespace block.

--- a/src/core_editor/word.rs
+++ b/src/core_editor/word.rs
@@ -109,8 +109,8 @@ pub(crate) fn locate_word(
             return false;
         }
         match edge {
-            WordEdge::Start => before.map_or(true, |b| is_boundary(b, ch)),
-            WordEdge::End => after.map_or(true, |a| is_boundary(ch, a)),
+            WordEdge::Start => before.is_none_or(|b| is_boundary(b, ch)),
+            WordEdge::End => after.is_none_or(|a| is_boundary(ch, a)),
         }
     };
 

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -79,8 +79,7 @@ impl ParsedViSequence {
 
     fn apply_multiplier(&self, raw_events: Option<Vec<ReedlineOption>>) -> ReedlineEvent {
         if let Some(raw_events) = raw_events {
-            let events = std::iter::repeat(raw_events)
-                .take(self.total_multiplier())
+            let events = std::iter::repeat_n(raw_events, self.total_multiplier())
                 .flatten()
                 .filter_map(ReedlineOption::into_reedline_event)
                 .collect::<Vec<ReedlineEvent>>();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -937,7 +937,7 @@ impl Reedline {
     fn take_repaint_request(&self) -> bool {
         self.repaint_signal
             .as_ref()
-            .map_or(false, RepaintSignal::take)
+            .is_some_and(RepaintSignal::take)
     }
 
     /// Whether the input loop must poll with a timeout instead of blocking
@@ -949,7 +949,7 @@ impl Reedline {
             || self
                 .repaint_signal
                 .as_ref()
-                .map_or(false, |sig| Arc::strong_count(&sig.flag) > 1);
+                .is_some_and(|sig| Arc::strong_count(&sig.flag) > 1);
 
         #[cfg(feature = "external_printer")]
         {
@@ -1121,7 +1121,7 @@ impl Reedline {
         let owed = self
             .deferred_menu_completion
             .as_ref()
-            .map_or(false, |deferred| deferred.still_applies(menu, &self.editor));
+            .is_some_and(|deferred| deferred.still_applies(menu, &self.editor));
 
         // Values were just refreshed above, so the menu must not re-fetch them.
         let accept_lone_value =
@@ -2116,7 +2116,7 @@ impl Reedline {
             && buffer[word_end..]
                 .chars()
                 .next()
-                .map_or(false, |ch| !ch.is_whitespace())
+                .is_some_and(|ch| !ch.is_whitespace())
         {
             // The cursor is in the middle of a word, e.g. "hello|world"
             return None;

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -321,7 +321,7 @@ impl ColumnarMenu {
         match self.default_details.traversal_dir {
             TraversalDirection::Vertical => {
                 let cols = values / self.get_rows();
-                if values % self.get_rows() != 0 {
+                if !values.is_multiple_of(self.get_rows()) {
                     cols + 1
                 } else {
                     cols

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -305,7 +305,7 @@ impl ColumnarMenu {
             0 if self.phase.awaiting_results() => 0,
             // Should be one row for actual empty results
             0 => 1,
-            total_values => (total_values + self.get_cols() - 1) / self.get_cols(),
+            total_values => total_values.div_ceil(self.get_cols()),
         }
     }
 

--- a/src/menu/description_menu.rs
+++ b/src/menu/description_menu.rs
@@ -217,7 +217,7 @@ impl DescriptionMenu {
         }
 
         let rows = values / self.get_cols();
-        if values % self.get_cols() != 0 {
+        if !values.is_multiple_of(self.get_cols()) {
             rows + 1
         } else {
             rows

--- a/src/painting/utils.rs
+++ b/src/painting/utils.rs
@@ -84,7 +84,7 @@ pub(crate) fn estimate_single_line_wraps(line: &str, terminal_columns: u16) -> u
     let estimated_width = line_width(line);
 
     // integer ceiling rounding division for positive divisors
-    let estimated_line_count = (estimated_width + terminal_columns - 1) / terminal_columns;
+    let estimated_line_count = estimated_width.div_ceil(terminal_columns);
 
     // Any wrapping will add to our overall line count
     estimated_line_count.saturating_sub(1)

--- a/src/validator/default.rs
+++ b/src/validator/default.rs
@@ -5,7 +5,7 @@ pub struct DefaultValidator;
 
 impl Validator for DefaultValidator {
     fn validate(&self, line: &str) -> ValidationResult {
-        if line.split('"').count() % 2 == 0 || incomplete_brackets(line) {
+        if line.split('"').count().is_multiple_of(2) || incomplete_brackets(line) {
             ValidationResult::Incomplete
         } else {
             ValidationResult::Complete


### PR DESCRIPTION
# Summary

Raises `rust-version` from 1.63.0 to 1.95.0 and adds a CI job that keeps the claim honest.

1.63.0 has been fiction for a while: the source uses `let-else` (stable since 1.65),
and the locked dependency tree floors at `rustqlite` 0.40 (rust 1.95), due to the use of `cfg_select` macro, for the `sqlite` feature.
Nothing checked the claim, thus it drifted.

The new `msrv-check` job compiles the library on 1.86 as a consumer would.

Contributors and the existing jobs float on stable, providing contributors with all the features of their compiler. (no rust-toolchain.toml)
This one job just guards the floor.

Edition stays 2021; a dependency being edition 2024 only requires a compiler that can build it, which 1.95 provides.

## Additional notes

Toolchains with the MSRV-aware resolver will be held on the previous release
silently, so the changelog should state "MSRV is now 1.95".
