### PR TITLE
feat(helix): give select mode its own keybinding table

### DIFF
--- a/src/edit_mode/helix/helix_keybindings.rs
+++ b/src/edit_mode/helix/helix_keybindings.rs
@@ -5,10 +5,10 @@ use crate::{
         add_common_control_bindings, add_common_edit_bindings, add_common_navigation_bindings,
         add_common_selection_bindings, edit_bind, Keybindings,
     },
-    EditCommand,
+    Direction, EditCommand, MotionTarget, WordEdge, WordKind,
 };
 
-/// Default Helix normal-mode keybindings (shared with select mode).
+/// Default Helix normal-mode keybindings.
 ///
 /// These cover the keys the modal layer in [`super::Helix`] does not interpret
 /// itself: control chords, navigation/menu keys and the like. Plain characters
@@ -32,7 +32,7 @@ pub fn default_helix_normal_keybindings() -> Keybindings {
         edit_bind(EditCommand::Delete),
     );
     // `Alt-d` drops the selection without filling the register, where `d`
-    // clobbers it. The table is shared with select mode, which wants it too.
+    // clobbers it. Select mode wants it too, so the select table keeps it.
     kb.add_binding(
         KeyModifiers::ALT,
         KeyCode::Char('d'),
@@ -45,6 +45,89 @@ pub fn default_helix_normal_keybindings() -> Keybindings {
         KeyCode::Char('`'),
         edit_bind(EditCommand::UppercaseSelection),
     );
+
+    kb
+}
+
+/// Default Helix select-mode keybindings.
+///
+/// The normal-mode table with every mode-blind navigation key overridden by
+/// its extending twin, so a motion typed on a key mirrors what its modal
+/// sibling does in select mode: arrows extend like `h`/`j`/`k`/`l`, word
+/// chords like `b`/`w`, line and buffer edges like `gh`/`gl`/`gg`/`ge`.
+/// Up/Down never reach menus or history, matching the modal `j`/`k`, since
+/// history traversal would replace the buffer the selection is anchored in.
+/// The history-hint events ride only on normal-mode `End`/`Ctrl-e`/
+/// `Ctrl-Right`: accepting a hint inserts text, which select mode must not do.
+pub fn default_helix_select_keybindings() -> Keybindings {
+    use Direction as D;
+    use KeyCode as KC;
+    use KeyModifiers as KM;
+    use MotionTarget as MT;
+
+    let mut kb = default_helix_normal_keybindings();
+
+    let extend = |target: MT| edit_bind(EditCommand::Extend(target));
+    let word = |direction: D| MT::Word {
+        kind: WordKind::Word,
+        edge: WordEdge::Start,
+        direction,
+    };
+
+    // Arrows: the modal `h`/`l` extend by grapheme, `j`/`k` by line.
+    kb.add_binding(KM::NONE, KC::Left, extend(MT::Grapheme(D::Backward)));
+    kb.add_binding(KM::NONE, KC::Right, extend(MT::Grapheme(D::Forward)));
+    kb.add_binding(
+        KM::NONE,
+        KC::Up,
+        edit_bind(EditCommand::MoveLineUp { select: true }),
+    );
+    kb.add_binding(
+        KM::NONE,
+        KC::Down,
+        edit_bind(EditCommand::MoveLineDown { select: true }),
+    );
+    // The emacs-style aliases of Up/Down follow them.
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Char('p'),
+        edit_bind(EditCommand::MoveLineUp { select: true }),
+    );
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Char('n'),
+        edit_bind(EditCommand::MoveLineDown { select: true }),
+    );
+    // Word chords, the `b`/`w` twins.
+    kb.add_binding(KM::CONTROL, KC::Left, extend(word(D::Backward)));
+    kb.add_binding(KM::CONTROL, KC::Right, extend(word(D::Forward)));
+    // Line edges (`gh`/`gl`) on Home/End and their emacs aliases.
+    kb.add_binding(KM::NONE, KC::Home, extend(MT::LineEdge(D::Backward)));
+    kb.add_binding(KM::NONE, KC::End, extend(MT::LineEdge(D::Forward)));
+    kb.add_binding(
+        KM::CONTROL,
+        KC::Char('a'),
+        extend(MT::LineEdge(D::Backward)),
+    );
+    kb.add_binding(KM::CONTROL, KC::Char('e'), extend(MT::LineEdge(D::Forward)));
+    // Buffer edges (`gg`/`ge`) on Ctrl-Home/End and the Alt-</> jumps.
+    kb.add_binding(KM::CONTROL, KC::Home, extend(MT::BufferEdge(D::Backward)));
+    kb.add_binding(KM::CONTROL, KC::End, extend(MT::BufferEdge(D::Forward)));
+    kb.add_binding(KM::ALT, KC::Char('<'), extend(MT::BufferEdge(D::Backward)));
+    kb.add_binding(KM::ALT, KC::Char('>'), extend(MT::BufferEdge(D::Forward)));
+    // The kitty keyboard protocol spellings of Alt-</>.
+    kb.add_binding(
+        KM::SHIFT | KM::ALT,
+        KC::Char(','),
+        extend(MT::BufferEdge(D::Backward)),
+    );
+    kb.add_binding(
+        KM::SHIFT | KM::ALT,
+        KC::Char('.'),
+        extend(MT::BufferEdge(D::Forward)),
+    );
+    // Backspace follows `h`, as it follows normal mode's collapsing left step.
+    kb.add_binding(KM::NONE, KC::Backspace, extend(MT::Grapheme(D::Backward)));
 
     kb
 }

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -1,7 +1,10 @@
 mod helix_keybindings;
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-pub use helix_keybindings::{default_helix_insert_keybindings, default_helix_normal_keybindings};
+pub use helix_keybindings::{
+    default_helix_insert_keybindings, default_helix_normal_keybindings,
+    default_helix_select_keybindings,
+};
 
 use super::{is_plain_char, is_text_char, parse_non_key_event};
 
@@ -125,6 +128,8 @@ pub struct Helix {
     insert_keybindings: Keybindings,
     /// Keybinding lookup table for normal mode
     normal_keybindings: Keybindings,
+    /// Keybinding lookup table for select mode
+    select_keybindings: Keybindings,
     mode: HelixMode,
     /// Count prefix being accumulated (`3w`).
     count: Option<usize>,
@@ -169,13 +174,22 @@ impl Helix {
         self
     }
 
-    /// Replace the normal-mode keybinding table, keeping the insert-mode
-    /// default. Shared by normal and select mode, and consulted before the
-    /// state machine, so a binding here shadows the built-in key of the same
-    /// name.
+    /// Replace the normal-mode keybinding table, keeping the insert- and
+    /// select-mode defaults. Consulted before the state machine, so a binding
+    /// here shadows the built-in key of the same name.
     #[must_use]
     pub fn with_normal_keybindings(mut self, keybindings: Keybindings) -> Self {
         self.normal_keybindings = keybindings;
+        self
+    }
+
+    /// Replace the select-mode keybinding table, keeping the other defaults.
+    /// Layer onto [`default_helix_select_keybindings`] rather than the normal
+    /// table, or the extending navigation twins (arrows, `Home`/`End`, ...)
+    /// fall back to their mode-blind normal-mode behavior.
+    #[must_use]
+    pub fn with_select_keybindings(mut self, keybindings: Keybindings) -> Self {
+        self.select_keybindings = keybindings;
         self
     }
 
@@ -205,7 +219,11 @@ impl Helix {
             // Esc must always reach the machine, otherwise modes get stranded.
             (None, code) => {
                 if self.count.is_none() && code != KeyCode::Esc {
-                    if let Some(event) = self.normal_keybindings.find_binding(key.modifiers, code) {
+                    let table = match self.mode {
+                        HelixMode::Select => &self.select_keybindings,
+                        _ => &self.normal_keybindings,
+                    };
+                    if let Some(event) = table.find_binding(key.modifiers, code) {
                         return event;
                     }
                 }
@@ -258,6 +276,7 @@ impl Default for Helix {
         Self {
             insert_keybindings: default_helix_insert_keybindings(),
             normal_keybindings: default_helix_normal_keybindings(),
+            select_keybindings: default_helix_select_keybindings(),
             mode: HelixMode::Insert,
             count: None,
             pending: None,
@@ -770,6 +789,96 @@ mod test {
         assert_eq!(
             helix.parse_event(key(KeyCode::Char('c'), KeyModifiers::CONTROL)),
             ReedlineEvent::CtrlC
+        );
+    }
+
+    // ---- the select-mode keybinding table ----
+
+    #[test]
+    fn select_mode_consults_its_own_table() {
+        // Arrows mirror their modal siblings: `l` extends by grapheme, `k`
+        // moves by line without reaching menus or history.
+        let mut helix = normal();
+        let _ = helix.parse_event(chr('v'));
+        assert_eq!(
+            helix.parse_event(key(KeyCode::Right, KeyModifiers::NONE)),
+            ReedlineEvent::Edit(vec![EditCommand::Extend(MotionTarget::Grapheme(
+                Direction::Forward
+            ))])
+        );
+        assert_eq!(
+            helix.parse_event(key(KeyCode::Up, KeyModifiers::NONE)),
+            ReedlineEvent::Edit(vec![EditCommand::MoveLineUp { select: true }])
+        );
+    }
+
+    #[test]
+    fn normal_mode_arrows_keep_menu_navigation() {
+        // The select table must not leak into normal mode, where an open menu
+        // takes the arrows first.
+        let mut helix = normal();
+        assert_eq!(
+            helix.parse_event(key(KeyCode::Left, KeyModifiers::NONE)),
+            ReedlineEvent::UntilFound(vec![ReedlineEvent::MenuLeft, ReedlineEvent::Left])
+        );
+    }
+
+    #[test]
+    fn select_mode_backspace_extends() {
+        let mut helix = normal();
+        let _ = helix.parse_event(chr('v'));
+        assert_eq!(
+            helix.parse_event(key(KeyCode::Backspace, KeyModifiers::NONE)),
+            ReedlineEvent::Edit(vec![EditCommand::Extend(MotionTarget::Grapheme(
+                Direction::Backward
+            ))])
+        );
+    }
+
+    #[test]
+    fn select_mode_home_and_end_extend_to_the_line_edges() {
+        let mut helix = normal();
+        let _ = helix.parse_event(chr('v'));
+        assert_eq!(
+            helix.parse_event(key(KeyCode::Home, KeyModifiers::NONE)),
+            ReedlineEvent::Edit(vec![EditCommand::Extend(MotionTarget::LineEdge(
+                Direction::Backward
+            ))])
+        );
+        assert_eq!(
+            helix.parse_event(key(KeyCode::End, KeyModifiers::NONE)),
+            ReedlineEvent::Edit(vec![EditCommand::Extend(MotionTarget::LineEdge(
+                Direction::Forward
+            ))])
+        );
+    }
+
+    #[test]
+    fn custom_select_table_shadows_the_default() {
+        let mut bindings = default_helix_select_keybindings();
+        bindings.add_binding(
+            KeyModifiers::NONE,
+            KeyCode::Right,
+            ReedlineEvent::ClearScreen,
+        );
+        let mut helix = Helix {
+            mode: HelixMode::Normal,
+            ..Default::default()
+        }
+        .with_select_keybindings(bindings);
+        // normal mode still uses the untouched normal table
+        assert_eq!(
+            helix.parse_event(key(KeyCode::Right, KeyModifiers::NONE)),
+            ReedlineEvent::UntilFound(vec![
+                ReedlineEvent::HistoryHintComplete,
+                ReedlineEvent::MenuRight,
+                ReedlineEvent::Right,
+            ])
+        );
+        let _ = helix.parse_event(chr('v'));
+        assert_eq!(
+            helix.parse_event(key(KeyCode::Right, KeyModifiers::NONE)),
+            ReedlineEvent::ClearScreen
         );
     }
 

--- a/src/edit_mode/mod.rs
+++ b/src/edit_mode/mod.rs
@@ -10,7 +10,10 @@ pub use base::EditMode;
 pub use cursors::CursorConfig;
 pub use emacs::{default_emacs_keybindings, Emacs};
 #[cfg(feature = "helix")]
-pub use helix::{default_helix_insert_keybindings, default_helix_normal_keybindings, Helix};
+pub use helix::{
+    default_helix_insert_keybindings, default_helix_normal_keybindings,
+    default_helix_select_keybindings, Helix,
+};
 pub use keybindings::Keybindings;
 pub use vi::{default_vi_insert_keybindings, default_vi_normal_keybindings, Vi};
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3117,6 +3117,34 @@ mod tests {
 
     #[cfg(feature = "helix")]
     #[test]
+    fn helix_select_extends_with_arrow_keys() {
+        // The original report: `v` then arrows moved the caret but dropped the
+        // anchor, since the arrows resolved through the mode-blind normal
+        // table to `MoveRight { select: false }`.
+        let mut rl = helix_engine_with_validator();
+        drive_until_signal(
+            &mut rl,
+            &[
+                ch('"'),
+                ch('a'),
+                ch('b'),
+                ch('c'),
+                key(KeyCode::Esc),
+                ch('g'),
+                ch('h'),
+                ch('v'),
+            ],
+        );
+        drive_until_signal(&mut rl, &[key(KeyCode::Right), key(KeyCode::Right)]);
+        assert_eq!(
+            rl.editor.get_selection(),
+            Some((0, 3)),
+            "arrows must extend like `l` does"
+        );
+    }
+
+    #[cfg(feature = "helix")]
+    #[test]
     fn helix_select_j_extends_to_the_column_normal_mode_would_land_on() {
         let mut rl = two_line_helix_engine();
         // `k` from the `f` (column 2) lands on the `b`, also column 2.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,10 @@ pub use edit_mode::{
     CursorConfig, EditMode, Emacs, Keybindings, Vi,
 };
 #[cfg(feature = "helix")]
-pub use edit_mode::{default_helix_insert_keybindings, default_helix_normal_keybindings, Helix};
+pub use edit_mode::{
+    default_helix_insert_keybindings, default_helix_normal_keybindings,
+    default_helix_select_keybindings, Helix,
+};
 
 mod highlighter;
 pub use highlighter::{AbbrExpandContext, ExampleHighlighter, Highlighter, SimpleMatchHighlighter};


### PR DESCRIPTION
<!-- Thanks for contributing to Reedline! -->

## Summary <!-- Must Have -->
<!--
Motivate this PR: why did you open it, how did you arrive at this solution?
Mention any changes to Reedline's public API or observable behavior, or mention that there are none.
-->
The keybinding table is consulted before the modal parser and the one table was shared by normal and select mode, so every key bound there acted mode-blind: arrows, `Home`/`End`, the word chords and their emacs aliases moved with `select: false`, dropping the anchor that `v` had just placed, and Up/Down walked menus and history out from under the selection. Only the plain chars the parser interprets (`hjkl`, `w`, ...) extended.

`default_helix_select_keybindings` layers the extending twin of each mode-blind navigation key over the normal-mode table: arrows follow `h`/`j`/`k`/`l`, word chords `b`/`w`, line and buffer edges `gh`/`gl`/`gg`/`ge`, with Up/Down going straight to line movement since history would replace the buffer the selection is anchored in. The history-hint events stay normal-only, since accepting a hint inserts text. `Helix::with_select_keybindings` replaces the table, mirroring the two existing builders.

### Before <!-- Much Appreciated -->
<!--
Describe behavior, function or implementation BEFORE your changes.
If not applicable, just remove the heading.
-->

### After <!-- Much Appreciated -->
<!--
Describe behavior, function or implementation AFTER your changes.
If not applicable, just remove the heading.
-->

## Additional notes <!-- Optional -->
<!--
Anything else worth knowing. Link related issues with `closes #123` / `fixes #456` to auto-close them on merge.
-->
