### PR TITLE
fix(keybindings): accept an empty UntilFound instead of panicking

### DIFF
--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -315,4 +315,40 @@ mod test {
             Some(ReedlineEvent::UntilFound(vec![]))
         );
     }
+
+    #[test]
+    fn rebinding_a_key_replaces_the_previous_event() {
+        let mut kb = Keybindings::new();
+        kb.add_binding(
+            KeyModifiers::CONTROL,
+            KeyCode::Char('r'),
+            ReedlineEvent::SearchHistory,
+        );
+        kb.add_binding(
+            KeyModifiers::CONTROL,
+            KeyCode::Char('r'),
+            ReedlineEvent::ClearScreen,
+        );
+        assert_eq!(
+            kb.find_binding(KeyModifiers::CONTROL, KeyCode::Char('r')),
+            Some(ReedlineEvent::ClearScreen)
+        );
+        assert_eq!(kb.get_keybindings().len(), 1);
+    }
+
+    #[test]
+    fn remove_binding_returns_the_bound_event_and_unbinds() {
+        let mut kb = Keybindings::new();
+        kb.add_binding(
+            KeyModifiers::NONE,
+            KeyCode::Tab,
+            ReedlineEvent::Menu("m".into()),
+        );
+        assert_eq!(
+            kb.remove_binding(KeyModifiers::NONE, KeyCode::Tab),
+            Some(ReedlineEvent::Menu("m".into()))
+        );
+        assert_eq!(kb.find_binding(KeyModifiers::NONE, KeyCode::Tab), None);
+        assert_eq!(kb.remove_binding(KeyModifiers::NONE, KeyCode::Tab), None);
+    }
 }

--- a/src/edit_mode/keybindings.rs
+++ b/src/edit_mode/keybindings.rs
@@ -39,22 +39,14 @@ impl Keybindings {
 
     /// Adds a keybinding
     ///
-    /// # Panics
-    ///
-    /// If `command` is an empty [`ReedlineEvent::UntilFound`]
+    /// An empty [`ReedlineEvent::UntilFound`] is accepted; it never matches
+    /// anything and behaves like an unbound key.
     pub fn add_binding(
         &mut self,
         modifier: KeyModifiers,
         key_code: KeyCode,
         command: ReedlineEvent,
     ) {
-        if let ReedlineEvent::UntilFound(subcommands) = &command {
-            assert!(
-                !subcommands.is_empty(),
-                "UntilFound should contain a series of potential events to handle"
-            );
-        }
-
         let key_combo = KeyCombination { modifier, key_code };
         self.bindings.insert(key_combo, command);
     }
@@ -304,4 +296,23 @@ pub fn add_common_selection_bindings(kb: &mut Keybindings) {
         KC::Char('a'),
         edit_bind(EC::SelectAll),
     );
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn empty_until_found_is_accepted() {
+        let mut kb = Keybindings::new();
+        kb.add_binding(
+            KeyModifiers::NONE,
+            KeyCode::Char('x'),
+            ReedlineEvent::UntilFound(vec![]),
+        );
+        assert_eq!(
+            kb.find_binding(KeyModifiers::NONE, KeyCode::Char('x')),
+            Some(ReedlineEvent::UntilFound(vec![]))
+        );
+    }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1304,8 +1304,9 @@ impl Reedline {
                         }
                     }
                 }
-                // Exhausting the event handlers is still considered handled
-                Ok(EventStatus::Handled)
+                // No candidate applied, so nothing changed: report that, which
+                // also lets an enclosing `UntilFound` keep trying.
+                Ok(EventStatus::Inapplicable)
             }
             ReedlineEvent::CtrlD => {
                 if self.editor.is_empty() {
@@ -1779,7 +1780,8 @@ impl Reedline {
                         }
                     }
                 }
-                // Exhausting the event handlers is still considered handled
+                // No candidate applied, so nothing changed: report that, which
+                // also lets an enclosing `UntilFound` keep trying.
                 Ok(EventStatus::Inapplicable)
             }
             ReedlineEvent::ViChangeMode(_) => Ok(self.edit_mode.handle_mode_specific_event(event)),


### PR DESCRIPTION
## Summary

`Keybindings::add_binding` asserted that an `UntilFound` has at least one candidate.
nushell forwards `until: []` from user config unchecked, thus a single odd config line panicked the shell at startup,
while both engine arms that unpack `UntilFound` already fall through on an empty list.
The assert is gone and the doc comment states the contract instead.

Two small things rode along:
the history-search arm now reports an exhausted `UntilFound` as `Inapplicable` like the editor arm has since #267 (no forced repaint, enclosing chains keep trying),
and `keybindings.rs` gets its first tests (empty `UntilFound`, rebinding replaces, `remove_binding`).

No public API change.
Observable behavior: an empty `UntilFound` behaves like an unbound key instead of panicking.

## Additional notes

While writing the tests i noticed the `Serialize`/`Deserialize` derives on `Keybindings` cannot round-trip through JSON (`KeyCombination` is a struct map key).
Left alone here since nothing uses them, but worth a follow-up!