### PR TITLE
fix(vi): saturate the count parser and cap it at u16::MAX

### DIFF
--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -182,11 +182,12 @@ where
         Some(x) if x.is_ascii_digit() => {
             let mut count: usize = 0;
             while let Some(&c) = input.peek() {
-                if c.is_ascii_digit() {
-                    let c = c.to_digit(10).expect("already checked if is a digit");
+                if let Some(d) = c.to_digit(10) {
                     let _ = input.next();
-                    count *= 10;
-                    count += c as usize;
+                    count = count
+                        .saturating_mul(10)
+                        .saturating_add(d as usize)
+                        .min(u16::MAX as usize);
                 } else {
                     return Some(count);
                 }
@@ -271,6 +272,16 @@ mod tests {
                 motion: ParseResult::Incomplete,
             }
         );
+    }
+
+    #[test]
+    fn oversized_count_saturates_instead_of_overflowing() {
+        // 20 digits overflow usize; the count clamps like helix does.
+        let mut input: Vec<char> = "99999999999999999999".chars().collect();
+        input.push('x');
+        let output = vi_parse(&input);
+        assert_eq!(output.multiplier, Some(u16::MAX as usize));
+        assert_eq!(output.command, Some(Command::DeleteChar));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Vi's `parse_number` accumulated the count with plain `*= 10` / `+=`, so twenty digits overflowed `usize`
(panic in debug, wrap in release) and anything close to it asked `repeat_n` for a giant event vec.
Helix already clamps its count at `u16::MAX` for exactly this reason (`helix/mod.rs`), thus vi now matches.
The digit test is `to_digit(10)` itself, which drops the `expect` that sat on the same line.

No public API change.
Observable behavior: counts above 65535 clamp instead of panicking; anything below is unchanged.

## Additional notes

Regression test `oversized_count_saturates_instead_of_overflowing` fails on the old arithmetic with `attempt to multiply with overflow`.