### PR TITLE
fix(engine): drop the todo!() arm for SubstringSearch in history navi…

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1996,16 +1996,12 @@ impl Reedline {
                         .set_line_buffer(original, UndoBehavior::HistoryNavigation);
                 }
             }
-            HistoryNavigationQuery::PrefixSearch(prefix) => {
-                if let Some(prefix_result) = self.history_cursor.string_at_cursor() {
-                    self.editor
-                        .set_buffer(prefix_result, UndoBehavior::HistoryNavigation);
-                } else {
-                    self.editor
-                        .set_buffer(prefix, UndoBehavior::HistoryNavigation);
-                }
+            HistoryNavigationQuery::PrefixSearch(prefix)
+            | HistoryNavigationQuery::SubstringSearch(prefix) => {
+                let buffer = self.history_cursor.string_at_cursor().unwrap_or(prefix);
+                self.editor
+                    .set_buffer(buffer, UndoBehavior::HistoryNavigation);
             }
-            HistoryNavigationQuery::SubstringSearch(_) => todo!(),
         }
     }
 


### PR DESCRIPTION
## Summary

`update_buffer_from_history` had `HistoryNavigationQuery::SubstringSearch(_) => todo!()`.
Search mode is handled by `handle_history_search_event` and never reaches this match, thus the arm was unreachable, but a `todo!()` is still a live panic waiting for a refactor to route through it.
Substring and prefix queries want the same treatment here (take the cursor's item, else fall back to the query text), so the two arms are merged.

No public API change.
No observable behavior change on any reachable path.