### PR TITLE
chore: fold the sqlite/sqlite-dynlib cfg pairs into a _sqlite feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,10 @@ bashisms = []
 external_printer = ["crossbeam"]
 idle_callback = []
 helix = []
-sqlite = ["rusqlite/bundled", "serde_json"]
-sqlite-dynlib = ["rusqlite", "serde_json"]
+sqlite = ["rusqlite/bundled", "serde_json", "_sqlite"]
+sqlite-dynlib = ["rusqlite", "serde_json", "_sqlite"]
+# Internal marker enabled by both sqlite features; never enable it directly.
+_sqlite = []
 system_clipboard = ["arboard"]
 libc = ["crossterm/libc"]
 

--- a/examples/cwd_aware_hinter.rs
+++ b/examples/cwd_aware_hinter.rs
@@ -27,9 +27,9 @@ fn create_item(cwd: &str, cmd: &str, exit_status: i64) -> reedline::HistoryItem 
 
 fn create_filled_example_history(home_dir: &str, orig_dir: &str) -> Box<dyn reedline::History> {
     use reedline::History;
-    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+    #[cfg(not(feature = "_sqlite"))]
     let mut history = Box::new(reedline::FileBackedHistory::new(100));
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     let mut history = Box::new(reedline::SqliteBackedHistory::in_memory().unwrap());
 
     history.save(create_item(orig_dir, "dummy", 0)).unwrap(); // add dummy item so ids start with 1

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -14,7 +14,7 @@ use {
     },
 };
 
-#[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+#[cfg(not(feature = "_sqlite"))]
 use reedline::FileBackedHistory;
 #[cfg(feature = "helix")]
 use reedline::{default_helix_insert_keybindings, default_helix_normal_keybindings, Helix};
@@ -34,7 +34,7 @@ fn main() -> reedline::Result<()> {
         None
     };
 
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     let history = Box::new(
         reedline::SqliteBackedHistory::with_file(
             "history.sqlite3".into(),
@@ -43,7 +43,7 @@ fn main() -> reedline::Result<()> {
         )
         .map_err(std::io::Error::other)?,
     );
-    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+    #[cfg(not(feature = "_sqlite"))]
     let history = Box::new(FileBackedHistory::with_file(50, "history.txt".into())?);
     let commands = vec![
         "test".into(),
@@ -139,10 +139,10 @@ fn main() -> reedline::Result<()> {
                 break;
             }
             Ok(Signal::Success(buffer)) => {
-                #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+                #[cfg(feature = "_sqlite")]
                 let start = std::time::Instant::now();
                 // save timestamp, cwd, hostname to history
-                #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+                #[cfg(feature = "_sqlite")]
                 if !buffer.is_empty() {
                     line_editor
                         .update_last_command_context(&|mut c: reedline::HistoryItem| {
@@ -197,7 +197,7 @@ fn main() -> reedline::Result<()> {
                     continue;
                 }
                 println!("Our buffer: {buffer}");
-                #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+                #[cfg(feature = "_sqlite")]
                 if !buffer.is_empty() {
                     line_editor
                         .update_last_command_context(&|mut c| {

--- a/examples/transient_prompt.rs
+++ b/examples/transient_prompt.rs
@@ -4,7 +4,7 @@
 // Prompts for previous lines will be replaced with a shorter prompt
 
 use nu_ansi_term::{Color, Style};
-#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+#[cfg(feature = "_sqlite")]
 use reedline::SqliteBackedHistory;
 use reedline::{
     default_emacs_keybindings, ColumnarMenu, DefaultCompleter, DefaultHinter, DefaultPrompt, Emacs,
@@ -110,7 +110,7 @@ fn main() -> io::Result<()> {
         .with_ansi_colors(true)
         .with_history_exclusion_prefix(Some(String::from(" ")))
         .with_transient_prompt(Box::new(TransientPrompt {}));
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     {
         line_editor = line_editor.with_history(Box::new(SqliteBackedHistory::in_memory().unwrap()));
     }

--- a/src/history/base.rs
+++ b/src/history/base.rs
@@ -244,9 +244,9 @@ pub trait History: Send {
 
 #[cfg(test)]
 mod test {
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     const IS_FILE_BASED: bool = false;
-    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+    #[cfg(not(feature = "_sqlite"))]
     const IS_FILE_BASED: bool = true;
 
     use crate::HistorySessionId;
@@ -268,11 +268,11 @@ mod test {
 
     use super::*;
     fn create_filled_example_history() -> Result<Box<dyn History>> {
-        #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+        #[cfg(feature = "_sqlite")]
         let mut history = crate::SqliteBackedHistory::in_memory()?;
-        #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+        #[cfg(not(feature = "_sqlite"))]
         let mut history = crate::FileBackedHistory::default();
-        #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+        #[cfg(not(feature = "_sqlite"))]
         history.save(create_item(1, "/", "dummy", 0))?; // add dummy item so ids start with 1
         history.save(create_item(1, "/home/me", "cd ~/Downloads", 0))?; // 1
         history.save(create_item(1, "/home/me/Downloads", "unzp foo.zip", 1))?; // 2
@@ -290,7 +290,7 @@ mod test {
         Ok(Box::new(history))
     }
 
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn update_item() -> Result<()> {
         let mut history = create_filled_example_history()?;
@@ -432,7 +432,7 @@ mod test {
     // test that clear() works as expected across multiple instances of History
     #[test]
     fn clear_history_with_backing_file() -> Result<()> {
-        #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+        #[cfg(feature = "_sqlite")]
         fn open_history() -> Box<dyn History> {
             Box::new(
                 crate::SqliteBackedHistory::with_file("target/test-history.db".into(), None, None)
@@ -440,7 +440,7 @@ mod test {
             )
         }
 
-        #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+        #[cfg(not(feature = "_sqlite"))]
         fn open_history() -> Box<dyn History> {
             Box::new(
                 crate::FileBackedHistory::with_file(100, "target/test-history.txt".into()).unwrap(),
@@ -468,7 +468,7 @@ mod test {
         Ok(())
     }
 
-    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+    #[cfg(not(feature = "_sqlite"))]
     #[test]
     fn history_size_zero() -> Result<()> {
         let mut history = crate::FileBackedHistory::new(0)?;

--- a/src/history/cursor.rs
+++ b/src/history/cursor.rs
@@ -109,9 +109,9 @@ mod tests {
     use super::*;
 
     fn create_history() -> (Box<dyn History>, HistoryCursor) {
-        #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+        #[cfg(feature = "_sqlite")]
         let hist = Box::new(SqliteBackedHistory::in_memory().unwrap());
-        #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+        #[cfg(not(feature = "_sqlite"))]
         let hist = Box::<FileBackedHistory>::default();
         (
             hist,
@@ -191,7 +191,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+    #[cfg(not(feature = "_sqlite"))]
     #[test]
     fn appends_only_unique() -> Result<()> {
         let (mut hist, _) = create_history();
@@ -428,7 +428,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(any(feature = "sqlite", feature = "sqlite-dynlib")))]
+    #[cfg(not(feature = "_sqlite"))]
     #[test]
     fn truncates_file_to_capacity() -> Result<()> {
         use tempfile::tempdir;

--- a/src/history/item.rs
+++ b/src/history/item.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+#[cfg(feature = "_sqlite")]
 use rusqlite::ToSql;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{fmt::Display, time::Duration};
@@ -35,7 +35,7 @@ impl Display for HistorySessionId {
     }
 }
 
-#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+#[cfg(feature = "_sqlite")]
 impl ToSql for HistorySessionId {
     fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
         Ok(rusqlite::types::ToSqlOutput::Owned(

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -2,9 +2,9 @@ mod base;
 mod cursor;
 mod file_backed;
 mod item;
-#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+#[cfg(feature = "_sqlite")]
 mod sqlite_backed;
-#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+#[cfg(feature = "_sqlite")]
 pub use sqlite_backed::SqliteBackedHistory;
 
 pub use base::{

--- a/src/history/sqlite_backed.rs
+++ b/src/history/sqlite_backed.rs
@@ -670,7 +670,7 @@ mod tests {
         }
     }
 
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn save_and_load_with_extra() -> crate::Result<()> {
         let mut db = SqliteBackedHistory::in_memory()?;
@@ -691,7 +691,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn save_with_extra_null_more_info_roundtrips() -> crate::Result<()> {
         let mut db = SqliteBackedHistory::in_memory()?;
@@ -704,7 +704,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn search_with_extra_more_info_json_matches() -> crate::Result<()> {
         let mut db = SqliteBackedHistory::in_memory()?;
@@ -760,7 +760,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn search_with_extra_null_more_info_not_matched() -> crate::Result<()> {
         let mut db = SqliteBackedHistory::in_memory()?;
@@ -784,7 +784,7 @@ mod tests {
 
     /// Verify that Bool, Integer, and Text filters do not collide with each other
     /// even when the raw JSON bytes look similar (e.g. `true` vs `1` vs `"1"`).
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn json_filter_value_no_type_collisions() -> crate::Result<()> {
         let mut db = SqliteBackedHistory::in_memory()?;
@@ -900,7 +900,7 @@ mod tests {
     }
 
     /// Verify that Real(f) does not collide with Integer values stored at the same path.
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn json_filter_value_real_vs_integer() -> crate::Result<()> {
         // Two structs so we can store the same path ($.score) as either real or integer.
@@ -977,7 +977,7 @@ mod tests {
 
     /// Verify that Null matches JSON null at a path but not SQL-NULL more_info
     /// or a path that is simply absent from the JSON object.
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn json_filter_value_null_vs_missing_path() -> crate::Result<()> {
         #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -1057,7 +1057,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn typed_and_untyped_interop() -> crate::Result<()> {
         let mut db = SqliteBackedHistory::in_memory()?;
@@ -1078,7 +1078,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn trait_update_preserves_typed_more_info() -> crate::Result<()> {
         let mut db = SqliteBackedHistory::in_memory()?;
@@ -1112,7 +1112,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn trait_update_missing_id_errors() {
         let mut db = SqliteBackedHistory::in_memory().unwrap();
@@ -1120,7 +1120,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     #[test]
     fn update_with_extra_modifies_typed_more_info() -> crate::Result<()> {
         let mut db = SqliteBackedHistory::in_memory()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,7 @@ mod result;
 pub use result::{ReedlineError, ReedlineErrorVariants, Result};
 
 mod history;
-#[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+#[cfg(feature = "_sqlite")]
 pub use history::SqliteBackedHistory;
 pub use history::{
     CommandLineSearch, FileBackedHistory, History, HistoryItem, HistoryItemExtraInfo,

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum ReedlineErrorVariants {
     // todo: we should probably be more specific here
-    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]
+    #[cfg(feature = "_sqlite")]
     /// Error within history database
     #[error("error within history database: {0}")]
     HistoryDatabaseError(String),


### PR DESCRIPTION
## Summary

Every SQLite-gated item in the crate has to name both features,
so the same `cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))` line is repeated at 40 sites.
That is noisy, and it is a drift hazard:
a new gated item that names only one of the two silently disappears for users of the other,
since nothing errors when the union is incomplete.

This adds an internal `_sqlite = []` marker feature that both public features enable,
and rewrites every gate to `cfg(feature = "_sqlite")`.
Purely mechanical otherwise.

No public API change:
`sqlite` and `sqlite-dynlib` keep their exact meaning,
and `_sqlite` is documented in `Cargo.toml` as internal-only.

### Before

    #[cfg(any(feature = "sqlite", feature = "sqlite-dynlib"))]

at 29 sites, plus 11 `not(...)` twins.

### After

    #[cfg(feature = "_sqlite")]