### PR TITLE
chore!: drop the helix feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         rust:
           - stable
         # Define the feature sets that will be built here (for caching you define a separate name)
-        style: [bashisms, default, sqlite, basqlite, external_printer, helix]
+        style: [bashisms, default, sqlite, basqlite, external_printer]
         include:
           - style: bashisms
             flags: "--features bashisms"
@@ -27,8 +27,6 @@ jobs:
             flags: "--features sqlite"
           - style: basqlite
             flags: "--features bashisms,sqlite"
-          - style: helix
-            flags: "--features helix"
 
 
     runs-on: ${{ matrix.platform }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,9 @@ serde_json = "1.0"
 tempfile = "3.3.0"
 
 [features]
-default = ["helix"]
+default = []
 bashisms = []
 external_printer = []
-helix = []
 sqlite = ["rusqlite/bundled", "serde_json", "_sqlite"]
 sqlite-dynlib = ["rusqlite", "serde_json", "_sqlite"]
 # Internal marker enabled by both sqlite features; never enable it directly.
@@ -60,10 +59,6 @@ required-features = ["sqlite"]
 [[example]]
 name = "external_printer"
 required-features = ["external_printer"]
-
-[[example]]
-name = "helix"
-required-features = ["helix"]
 
 [package.metadata.docs.rs]
 # Whether to pass `--all-features` to Cargo (default: false)

--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ let mut line_editor = Reedline::create().with_edit_mode(Box::new(Vi::new(
 
 ```rust
 // Selection-first editing: motions carry the selection, verbs act on it.
-// Requires the `helix` feature (enabled by default).
 
 use reedline::{default_helix_normal_keybindings, Helix, Reedline};
 
@@ -225,7 +224,6 @@ history and menus.
 - `sqlite`: Provides the `SqliteBackedHistory` to store richer information in the history. Statically links the required sqlite version.
 - `sqlite-dynlib`: Alternative to the feature `sqlite`. Will not statically link. Requires `sqlite >= 3.38` to link dynamically!
 - `external_printer`: **Experimental:** Thread-safe `ExternalPrinter` handle to print lines from concurrently running threads.
-- `helix`: Selection-first `Helix`/Kakoune-style edit mode, where a motion moves the selection and a verb acts on it. On by default; the `Helix` type and its keybinding defaults are gated behind it, so `default-features = false` builds compile without the mode.
 
 ## Are we prompt yet? (Development status)
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -16,7 +16,6 @@ use {
 
 #[cfg(not(feature = "_sqlite"))]
 use reedline::FileBackedHistory;
-#[cfg(feature = "helix")]
 use reedline::{default_helix_insert_keybindings, default_helix_normal_keybindings, Helix};
 use reedline::{CursorConfig, MenuBuilder, OutputMode};
 
@@ -78,11 +77,8 @@ fn main() -> reedline::Result<()> {
     let cursor_config = CursorConfig {
         vi_insert: Some(SetCursorStyle::BlinkingBar),
         vi_normal: Some(SetCursorStyle::SteadyBlock),
-        #[cfg(feature = "helix")]
         hx_insert: Some(SetCursorStyle::BlinkingBar),
-        #[cfg(feature = "helix")]
         hx_normal: Some(SetCursorStyle::SteadyBlock),
-        #[cfg(feature = "helix")]
         hx_select: Some(SetCursorStyle::SteadyUnderScore),
         ..CursorConfig::default()
     };
@@ -242,7 +238,6 @@ fn vi_edit_mode() -> Box<dyn EditMode> {
     Box::new(Vi::new(insert_keybindings, normal_keybindings))
 }
 
-#[cfg(feature = "helix")]
 fn helix_edit_mode() -> Box<dyn EditMode> {
     let mut normal_keybindings = default_helix_normal_keybindings();
     let mut insert_keybindings = default_helix_insert_keybindings();
@@ -257,18 +252,6 @@ fn helix_edit_mode() -> Box<dyn EditMode> {
             .with_insert_keybindings(insert_keybindings)
             .with_normal_keybindings(normal_keybindings),
     )
-}
-
-/// `--helix` is accepted whether or not the feature is compiled in, since the
-/// example itself has no `required-features`. Say so rather than falling
-/// through to emacs silently.
-#[cfg(not(feature = "helix"))]
-fn helix_edit_mode() -> Box<dyn EditMode> {
-    eprintln!(
-        "--helix needs the feature: cargo run --example demo --features helix -- --helix\n\
-         falling back to emacs"
-    );
-    emacs_edit_mode()
 }
 
 fn add_menu_keybindings(keybindings: &mut Keybindings) {

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -294,12 +294,10 @@ impl Editor {
                 self.move_left_until_char(*c, true, true, *select)
             }
             EditCommand::SelectAll => self.select_all(),
-            #[cfg(feature = "helix")]
             EditCommand::SelectLine => self.select_line(),
             EditCommand::CutSelection { granularity } => {
                 self.cut_selection_to_cut_buffer(*granularity)
             }
-            #[cfg(feature = "helix")]
             EditCommand::EraseSelection => self.erase_selection(),
             EditCommand::CopySelection => self.copy_selection_to_cut_buffer(),
             EditCommand::LowercaseSelection => self.lowercase_selection(),
@@ -1306,7 +1304,6 @@ impl Editor {
     /// express: [`Select`](EditCommand::Select) re-anchors at the origin and
     /// [`Extend`](EditCommand::Extend) keeps its anchor, so neither can move
     /// both edges to line boundaries *and* notice they were there already.
-    #[cfg(feature = "helix")]
     fn select_line(&mut self) {
         let buf = self.line_buffer.get_buffer();
         let cursor = self.line_buffer.cursor();
@@ -1352,7 +1349,6 @@ impl Editor {
     ///
     /// `OperatorVerb::Erase` is the register-free deletion the motion-shaped
     /// `Erase` already uses; only the span differs.
-    #[cfg(feature = "helix")]
     fn erase_selection(&mut self) {
         if let Some((start, end)) = self.get_selection() {
             let sel = Cursor::new(start, end);
@@ -4337,7 +4333,6 @@ mod test {
 
     /// Helix-only editor behaviour. One gate for the whole block so it
     /// lifts in a single edit once helix stops being feature gated.
-    #[cfg(feature = "helix")]
     mod helix {
         use super::*;
         use pretty_assertions::assert_eq;

--- a/src/core_editor/line.rs
+++ b/src/core_editor/line.rs
@@ -38,7 +38,6 @@ pub(crate) fn end_of_line(buf: &str, pos: usize) -> usize {
 /// [`LineBuffer::line_non_blank_start_index`](super::LineBuffer::line_non_blank_start_index)
 /// searches on into the buffer and settles for the terminator, so it *moves* on
 /// a blank line. The bound also keeps a `\r\n`'s `\r` out of the haystack.
-#[cfg(feature = "helix")]
 pub(crate) fn first_non_blank(buf: &str, pos: usize) -> Option<usize> {
     let start = start_of_line(buf, pos);
     buf[start..end_of_line(buf, pos)]
@@ -81,7 +80,6 @@ mod tests {
         assert_eq!(end_of_line("ab\r\ncd", 5), 6);
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn first_non_blank_finds_the_indent_end() {
         assert_eq!(first_non_blank("    foo", 0), Some(4));
@@ -90,7 +88,6 @@ mod tests {
         assert_eq!(first_non_blank("    foo", 6), Some(4)); // origin past the indent
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn first_non_blank_reports_into_the_buffer_not_the_line() {
         // "ab\n  cd": a0 b1 \n2 ' '3 ' '4 c5 d6. `find` reports into the sliced
@@ -99,7 +96,6 @@ mod tests {
         assert_eq!(first_non_blank("ab\n  cd", 6), Some(5));
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn first_non_blank_is_none_on_a_blank_line() {
         // The point of the bound: never report the *next* line's first
@@ -110,7 +106,6 @@ mod tests {
         assert_eq!(first_non_blank("foo\n\nbar", 4), None); // empty middle line
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn first_non_blank_ignores_a_carriage_return() {
         // `end_of_line` keeps the \r out, so a CRLF blank line reads as blank.

--- a/src/core_editor/resolve.rs
+++ b/src/core_editor/resolve.rs
@@ -110,7 +110,6 @@ pub(crate) fn resolve_motion(
         // of the *anchor* it falls, which only `Cursor::put_cursor` can see (the
         // `Extend` dispatch in `Editor` routes this target there). Staying put
         // on a blank line is `resolve_motion` being total, not a special case.
-        #[cfg(feature = "helix")]
         MotionTarget::LineStartNonBlank => {
             span(line::first_non_blank(buf, origin).unwrap_or(origin), false)
         }
@@ -307,7 +306,6 @@ mod tests {
         assert_eq!(m.op_end, m.head);
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn resolve_motion_line_start_non_blank_lands_on_the_indent_end() {
         // Same landing from either side, under either geometry: a destination
@@ -325,7 +323,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn resolve_motion_stays_put_for_line_start_non_blank_with_nowhere_to_go() {
         // Resting at `origin` keeps `resolve_motion` total, so the blank-line

--- a/src/core_editor/rest_policy.rs
+++ b/src/core_editor/rest_policy.rs
@@ -32,7 +32,6 @@ pub(crate) enum RestPolicy {
     /// [`Block`](RestPolicy::Block) with the terminator counted as a cell, so
     /// `l` walks onto the `\n` and an operator there joins the lines. Helix
     /// normal / select, whose `Range` is over the newline like any other char.
-    #[cfg(feature = "helix")]
     BlockOverNewline,
 }
 
@@ -42,7 +41,6 @@ impl RestPolicy {
     pub(crate) fn is_block(self) -> bool {
         match self {
             RestPolicy::Block => true,
-            #[cfg(feature = "helix")]
             RestPolicy::BlockOverNewline => true,
             RestPolicy::Between | RestPolicy::OnGrapheme => false,
         }
@@ -53,7 +51,6 @@ impl RestPolicy {
     pub(crate) fn covers_terminator(self) -> bool {
         match self {
             RestPolicy::Between | RestPolicy::OnGrapheme | RestPolicy::Block => false,
-            #[cfg(feature = "helix")]
             RestPolicy::BlockOverNewline => true,
         }
     }
@@ -122,7 +119,6 @@ pub(crate) fn commit(buf: &str, c: Cursor, policy: RestPolicy) -> Cursor {
             }
         }
         RestPolicy::Block => block(buf, c, false),
-        #[cfg(feature = "helix")]
         RestPolicy::BlockOverNewline => block(buf, c, true),
     }
 }
@@ -377,7 +373,6 @@ mod tests {
 
     // --- commit: BlockOverNewline --------------------------------------------
 
-    #[cfg(feature = "helix")]
     #[test]
     fn block_over_newline_widens_onto_the_terminator() {
         // The one difference from `Block`: "ab\ncd" at the `\n` (byte 2) covers
@@ -392,7 +387,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn block_over_newline_covers_a_whole_crlf() {
         // CRLF is one grapheme, so the cell is both bytes: "ab\r\ncd" at 2.
@@ -402,7 +396,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn block_over_newline_still_will_not_widen_across_a_line() {
         // The *backward* guard is kept: at the end of a buffer ending in `\n`
@@ -419,7 +412,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn block_over_newline_matches_block_away_from_terminators() {
         for (buf, pos) in [("hello", 2), ("caf\u{e9}", 3), ("hello", 5), ("", 0)] {
@@ -442,7 +434,6 @@ mod tests {
             RestPolicy::Between,
             RestPolicy::OnGrapheme,
             RestPolicy::Block,
-            #[cfg(feature = "helix")]
             RestPolicy::BlockOverNewline,
         ] {
             for buf in [MIXED, MULTILINE] {

--- a/src/edit_mode/cursors.rs
+++ b/src/edit_mode/cursors.rs
@@ -15,13 +15,10 @@ pub struct CursorConfig {
     pub vi_normal: Option<SetCursorStyle>,
     /// The cursor to be used when in emacs mode
     pub emacs: Option<SetCursorStyle>,
-    #[cfg(feature = "helix")]
     /// The cursor to be used when in hx insert mode
     pub hx_insert: Option<SetCursorStyle>,
-    #[cfg(feature = "helix")]
     /// The cursor to be used when in hx normal mode
     pub hx_normal: Option<SetCursorStyle>,
-    #[cfg(feature = "helix")]
     /// The cursor to be used when in hx select mode
     pub hx_select: Option<SetCursorStyle>,
 }

--- a/src/edit_mode/mod.rs
+++ b/src/edit_mode/mod.rs
@@ -1,7 +1,6 @@
 mod base;
 mod cursors;
 mod emacs;
-#[cfg(feature = "helix")]
 mod helix;
 mod keybindings;
 mod vi;
@@ -9,7 +8,6 @@ mod vi;
 pub use base::EditMode;
 pub use cursors::CursorConfig;
 pub use emacs::{default_emacs_keybindings, Emacs};
-#[cfg(feature = "helix")]
 pub use helix::{
     default_helix_insert_keybindings, default_helix_normal_keybindings,
     default_helix_select_keybindings, Helix,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1407,7 +1407,6 @@ impl Reedline {
             | ReedlineEvent::MenuPageNext
             | ReedlineEvent::MenuPagePrevious
             | ReedlineEvent::ViChangeMode(_) => Ok(EventStatus::Inapplicable),
-            #[cfg(feature = "helix")]
             ReedlineEvent::HelixChangeMode(_) => Ok(EventStatus::Inapplicable),
         }
     }
@@ -1781,7 +1780,6 @@ impl Reedline {
                 Ok(EventStatus::Inapplicable)
             }
             ReedlineEvent::ViChangeMode(_) => Ok(self.change_edit_mode(event)),
-            #[cfg(feature = "helix")]
             ReedlineEvent::HelixChangeMode(_) => Ok(self.change_edit_mode(event)),
             ReedlineEvent::Mouse {
                 column,
@@ -3135,7 +3133,6 @@ mod tests {
 
     /// `DefaultValidator` reads an unclosed `"` as incomplete, so `Enter` breaks
     /// the line instead of submitting it and leaves the buffer inspectable.
-    #[cfg(feature = "helix")]
     fn helix_engine_with_validator() -> Reedline {
         let mut rl = Reedline::create()
             .with_edit_mode(Box::<crate::Helix>::default())
@@ -3152,7 +3149,6 @@ mod tests {
     // branch the one that can observe it: a submitted buffer is cleared before
     // anything can be asserted about it.
 
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_normal_submit_keeps_the_grapheme_under_the_cursor() {
         let mut rl = helix_engine_with_validator();
@@ -3173,7 +3169,6 @@ mod tests {
         assert_eq!(rl.editor.get_buffer(), "\"abc\n");
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_normal_submit_breaks_at_the_cursor_not_past_it() {
         let mut rl = helix_engine_with_validator();
@@ -3200,7 +3195,6 @@ mod tests {
 
     /// Helix rests *on* the line terminator under `BlockOverNewline`, which vi
     /// never does, so a break from there is a case vi's handling never answers.
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_normal_submit_breaks_from_a_terminator() {
         let mut rl = helix_engine_with_validator();
@@ -3223,7 +3217,6 @@ mod tests {
     /// exactly as `i` does. The helix block cursor *is* a one-grapheme
     /// selection, and `insert_char` deletes the selection before inserting, so
     /// without the collapse the first keystroke replaces the covered grapheme.
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_change_mode_into_insert_keeps_the_covered_grapheme() {
         let mut bindings = crate::default_helix_normal_keybindings();
@@ -3301,7 +3294,6 @@ mod tests {
 
     /// The submitted path cannot assert on the buffer (`submit_buffer` clears
     /// it), so pin it through the returned signal instead.
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_normal_submit_returns_the_whole_buffer() {
         let mut rl = Reedline::create().with_edit_mode(Box::<crate::Helix>::default());
@@ -3330,7 +3322,6 @@ mod tests {
 
     /// Two lines, built through the incomplete branch since a bare Enter would
     /// submit. Leaves the caret on the second line, in insert mode.
-    #[cfg(feature = "helix")]
     fn two_line_helix_engine() -> Reedline {
         let mut rl = helix_engine_with_validator();
         drive_until_signal(
@@ -3353,7 +3344,6 @@ mod tests {
         rl
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_normal_k_moves_a_line_before_it_reaches_history() {
         let mut rl = two_line_helix_engine();
@@ -3370,7 +3360,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_normal_k_recalls_history_at_the_first_line() {
         let mut rl = seam_engine(Box::<crate::Helix>::default());
@@ -3393,7 +3382,6 @@ mod tests {
         assert_eq!(rl.editor.get_buffer(), "one");
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_select_extends_with_arrow_keys() {
         // The original report: `v` then arrows moved the caret but dropped the
@@ -3421,7 +3409,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_select_j_extends_to_the_column_normal_mode_would_land_on() {
         let mut rl = two_line_helix_engine();
@@ -3445,7 +3432,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_tilde_switches_case_and_keeps_the_selection() {
         let mut rl = seam_engine(Box::<crate::Helix>::default());
@@ -3460,7 +3446,6 @@ mod tests {
         assert_eq!(rl.editor.get_buffer(), "ab");
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_backtick_lowercases_and_alt_backtick_uppercases() {
         let alt_backtick = KeyEvent::new(KeyCode::Char('`'), KeyModifiers::ALT);
@@ -3479,7 +3464,6 @@ mod tests {
 
     // --- `%`, `A`, `I` ---
 
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_percent_selects_the_whole_buffer() {
         let mut rl = seam_engine(Box::<crate::Helix>::default());
@@ -3492,7 +3476,6 @@ mod tests {
 
     /// Appending has to land *past* the last grapheme: the block cursor rests on
     /// it, while insert mode sits between graphemes.
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_capital_a_appends_past_the_last_grapheme() {
         use crate::PromptHelixMode;
@@ -3513,7 +3496,6 @@ mod tests {
     }
 
     /// The leading space is what separates this from a plain line start.
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_capital_i_inserts_at_the_first_non_blank() {
         let mut rl = seam_engine(Box::<crate::Helix>::default());
@@ -3527,7 +3509,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "helix")]
     fn with_edit_mode_builder_accepts_custom_helix_mode() {
         use crate::PromptHelixMode;
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -185,7 +185,6 @@ pub enum MotionTarget {
     LineEdge(Direction),
     /// First non-whitespace character on the current line (helix `gs`). A blank
     /// line has none, so the motion stays put.
-    #[cfg(feature = "helix")]
     LineStartNonBlank,
     /// Whole-buffer edge: `Backward` = start (`gg`), `Forward` = end (`G`).
     BufferEdge(Direction),
@@ -241,7 +240,6 @@ impl MotionTarget {
             // Destination-shaped targets go here. Where they lie depends on the
             // cursor, so callers resolve first and compare after.
             MotionTarget::Position(_) => None,
-            #[cfg(feature = "helix")]
             MotionTarget::LineStartNonBlank => None,
         }
     }
@@ -625,14 +623,12 @@ pub enum EditCommand {
     ///
     /// Repeating therefore grows it a line at a time, so a count is the command
     /// applied that many times.
-    #[cfg(feature = "helix")]
     SelectLine,
 
     /// Delete the selection without filling the cut buffer (helix `Alt-d`).
     ///
     /// [`CutSelection`](EditCommand::CutSelection) clobbers the register, which
     /// is exactly what this avoids when the text is not wanted back.
-    #[cfg(feature = "helix")]
     EraseSelection,
 
     /// Cut selection to local buffer
@@ -811,9 +807,7 @@ impl EditCommand {
             EditCommand::SwapCursorAndAnchor => EditType::MoveCursor { select: true },
 
             EditCommand::SelectAll => EditType::MoveCursor { select: true },
-            #[cfg(feature = "helix")]
             EditCommand::EraseSelection => EditType::EditText,
-            #[cfg(feature = "helix")]
             EditCommand::SelectLine => EditType::MoveCursor { select: true },
             // Text edits
             EditCommand::InsertChar(_)
@@ -1145,7 +1139,6 @@ pub enum ReedlineEvent {
     /// its own that is a keybinding that does nothing; inside an
     /// [`UntilFound`](ReedlineEvent::UntilFound) it hands the key to the next
     /// event in the list instead.
-    #[cfg(feature = "helix")]
     HelixChangeMode(String),
 }
 
@@ -1190,17 +1183,5 @@ impl TryFrom<Event> for ReedlineRawEvent {
 impl From<ReedlineRawEvent> for Event {
     fn from(event: ReedlineRawEvent) -> Self {
         event.0
-    }
-}
-
-#[cfg(feature = "helix")]
-impl TryFrom<ReedlineRawEvent> for KeyEvent {
-    type Error = ReedlineRawEvent;
-
-    fn try_from(event: ReedlineRawEvent) -> Result<Self, Self::Error> {
-        match event.0 {
-            Event::Key(key_event) => Ok(key_event),
-            other => Err(ReedlineRawEvent(other)),
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,11 +187,8 @@
 //! ## Use `Helix` edit mode
 //!
 //! Selection-first editing: motions carry the selection, verbs act on it.
-//! Requires the `helix` feature (enabled by default), which also gates the
-//! types below.
 //!
 //! ```rust
-//! # #[cfg(feature = "helix")] {
 //! use reedline::{default_helix_normal_keybindings, Helix, Reedline};
 //!
 //! let mut normal_keybindings = default_helix_normal_keybindings();
@@ -200,7 +197,6 @@
 //! let line_editor = Reedline::create().with_edit_mode(Box::new(
 //!     Helix::default().with_normal_keybindings(normal_keybindings),
 //! ));
-//! # }
 //! ```
 //!
 //! Run `cargo run --example helix` for the mode on its own, or
@@ -214,7 +210,6 @@
 //! - `sqlite`: Provides the `SqliteBackedHistory` to store richer information in the history. Statically links the required sqlite version.
 //! - `sqlite-dynlib`: Alternative to the feature `sqlite`. Will not statically link. Requires `sqlite >= 3.38` to link dynamically!
 //! - `external_printer`: **Experimental:** `ExternalPrinter` to print lines from concurrently running threads; each thread gets its own thread-safe sender via `ExternalPrinter::sender()`.
-//! - `helix`: Selection-first `Helix`/Kakoune-style edit mode, where a motion moves the selection and a verb acts on it. On by default; the `Helix` type and its keybinding defaults are gated behind it, so `default-features = false` builds compile without the mode.
 //!
 //! ## Are we prompt yet? (Development status)
 //!
@@ -281,7 +276,6 @@ pub use history::{
 };
 
 mod prompt;
-#[cfg(feature = "helix")]
 pub use prompt::PromptHelixMode;
 pub use prompt::{
     DefaultPrompt, DefaultPromptSegment, Prompt, PromptEditMode, PromptEditModeDiscriminants,
@@ -294,7 +288,6 @@ pub use edit_mode::{
     default_emacs_keybindings, default_vi_insert_keybindings, default_vi_normal_keybindings,
     CursorConfig, EditMode, Emacs, Keybindings, Vi,
 };
-#[cfg(feature = "helix")]
 pub use edit_mode::{
     default_helix_insert_keybindings, default_helix_normal_keybindings,
     default_helix_select_keybindings, Helix,

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -949,7 +949,6 @@ pub(crate) fn truncate_with_ansi(s: &str, max_width: usize) -> Cow<'_, str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "helix")]
     use crate::PromptHelixMode;
     use crate::{EditCommand, LineBuffer, PromptEditMode, PromptViMode, Span};
     use nu_ansi_term::Color;
@@ -959,16 +958,10 @@ mod tests {
     /// count that grapheme as part of the word instead of stranding it after the
     /// replacement (`foo` + `foobar` used to yield `foobaro`).
     #[rstest]
-    #[cfg_attr(
-        feature = "helix",
-        case::helix_normal(PromptEditMode::Helix(PromptHelixMode::Normal), "foo", "foobar")
-    )]
+    #[case::helix_normal(PromptEditMode::Helix(PromptHelixMode::Normal), "foo", "foobar")]
     #[case::vi_normal(PromptEditMode::Vi(PromptViMode::Normal), "foo", "foobar")]
     // The covered grapheme is multi-byte: stepping by bytes would split it.
-    #[cfg_attr(
-        feature = "helix",
-        case::multibyte(PromptEditMode::Helix(PromptHelixMode::Normal), "café", "cafétería")
-    )]
+    #[case::multibyte(PromptEditMode::Helix(PromptHelixMode::Normal), "café", "cafétería")]
     fn completion_covers_the_caret_grapheme(
         #[case] mode: PromptEditMode,
         #[case] buffer: &str,

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1,5 +1,4 @@
 use crate::terminal_extensions::semantic_prompt::{PromptKind, SemanticPromptMarkers};
-#[cfg(feature = "helix")]
 use crate::PromptHelixMode;
 use crate::{CursorConfig, PromptEditMode, PromptViMode};
 
@@ -657,11 +656,8 @@ impl Painter {
                 PromptEditMode::Emacs => shapes.emacs,
                 PromptEditMode::Vi(PromptViMode::Insert) => shapes.vi_insert,
                 PromptEditMode::Vi(PromptViMode::Normal | PromptViMode::Visual) => shapes.vi_normal,
-                #[cfg(feature = "helix")]
                 PromptEditMode::Helix(PromptHelixMode::Insert) => shapes.hx_insert,
-                #[cfg(feature = "helix")]
                 PromptEditMode::Helix(PromptHelixMode::Normal) => shapes.hx_normal,
-                #[cfg(feature = "helix")]
                 PromptEditMode::Helix(PromptHelixMode::Select) => shapes.hx_select,
                 _ => None,
             };

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -66,7 +66,6 @@ pub enum PromptEditMode {
     Vi(PromptViMode),
 
     /// A helix/Kakoune like mode
-    #[cfg(feature = "helix")]
     Helix(PromptHelixMode),
 
     /// A custom mode
@@ -82,10 +81,8 @@ impl PromptEditMode {
             PromptEditMode::Vi(PromptViMode::Visual) => RestPolicy::Block,
             // Helix counts the line terminator as a cell, so `l` reaches it and
             // `d` there joins the lines; vi visual stops short of it.
-            #[cfg(feature = "helix")]
             PromptEditMode::Helix(PromptHelixMode::Normal)
             | PromptEditMode::Helix(PromptHelixMode::Select) => RestPolicy::BlockOverNewline,
-            #[cfg(feature = "helix")]
             PromptEditMode::Helix(PromptHelixMode::Insert) => RestPolicy::Between,
             PromptEditMode::Vi(PromptViMode::Insert)
             | PromptEditMode::Default
@@ -106,7 +103,6 @@ impl PromptEditMode {
     /// paint a highlight there.
     pub(crate) fn retains_selection_after_edit(&self) -> bool {
         match self {
-            #[cfg(feature = "helix")]
             PromptEditMode::Helix(_) => true,
             PromptEditMode::Vi(_)
             | PromptEditMode::Default
@@ -124,7 +120,6 @@ impl PromptEditMode {
             // exclusive for the word/line/grapheme motions they emit (a forward
             // find stays inclusive, matching its operator span), so the
             // gap-indexed `Span` is the natural reading.
-            #[cfg(feature = "helix")]
             PromptEditMode::Helix(_) => SelectionExtent::Span,
             PromptEditMode::Default | PromptEditMode::Emacs | PromptEditMode::Custom(_) => {
                 SelectionExtent::Span
@@ -149,7 +144,6 @@ pub enum PromptViMode {
 }
 
 /// The helix/Kakoune like modes that the prompt can be in
-#[cfg(feature = "helix")]
 #[derive(Serialize, Deserialize, Clone, Debug, EnumIter, Default, PartialEq, Eq)]
 pub enum PromptHelixMode {
     /// Normal mode carries an at least 1 grapheme wide selection and
@@ -186,17 +180,14 @@ pub enum PromptEditModeDiscriminants {
     ViInsert,
 
     /// Helix normal mode
-    #[cfg(feature = "helix")]
     #[strum(serialize = "HelixNormal", serialize = "helix_normal")]
     HelixNormal,
 
     /// Helix insert mode
-    #[cfg(feature = "helix")]
     #[strum(serialize = "HelixInsert", serialize = "helix_insert")]
     HelixInsert,
 
     /// Helix select mode
-    #[cfg(feature = "helix")]
     #[strum(serialize = "HelixSelect", serialize = "helix_select")]
     HelixSelect,
 
@@ -212,7 +203,6 @@ impl From<PromptViMode> for PromptEditMode {
 
 impl Display for PromptEditMode {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        #[cfg(feature = "helix")]
         use PromptHelixMode as Helix;
         use PromptViMode as Vi;
         match self {
@@ -221,11 +211,8 @@ impl Display for PromptEditMode {
             Self::Vi(Vi::Normal) => write!(f, "Vi_Normal"),
             Self::Vi(Vi::Insert) => write!(f, "Vi_Insert"),
             Self::Vi(Vi::Visual) => write!(f, "Vi_Visual"),
-            #[cfg(feature = "helix")]
             Self::Helix(Helix::Normal) => write!(f, "Helix_Normal"),
-            #[cfg(feature = "helix")]
             Self::Helix(Helix::Insert) => write!(f, "Helix_Insert"),
-            #[cfg(feature = "helix")]
             Self::Helix(Helix::Select) => write!(f, "Helix_Select"),
             Self::Custom(s) => write!(f, "Custom_{s}"),
         }
@@ -236,7 +223,6 @@ impl IntoDiscriminant for PromptEditMode {
     type Discriminant = PromptEditModeDiscriminants;
 
     fn discriminant(&self) -> Self::Discriminant {
-        #[cfg(feature = "helix")]
         use PromptHelixMode as Helix;
         use PromptViMode as Vi;
         match self {
@@ -247,11 +233,8 @@ impl IntoDiscriminant for PromptEditMode {
             // Splitting that pair is its own change.
             Self::Vi(Vi::Normal | Vi::Visual) => Self::Discriminant::ViNormal,
             Self::Vi(Vi::Insert) => Self::Discriminant::ViInsert,
-            #[cfg(feature = "helix")]
             Self::Helix(Helix::Normal) => Self::Discriminant::HelixNormal,
-            #[cfg(feature = "helix")]
             Self::Helix(Helix::Insert) => Self::Discriminant::HelixInsert,
-            #[cfg(feature = "helix")]
             Self::Helix(Helix::Select) => Self::Discriminant::HelixSelect,
             Self::Custom(_) => Self::Discriminant::Custom,
         }
@@ -331,7 +314,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn each_helix_mode_gets_its_own_discriminant() {
         use PromptEditModeDiscriminants as D;
@@ -359,7 +341,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "helix")]
     #[test]
     fn helix_discriminants_round_trip_through_their_names() {
         use std::str::FromStr;

--- a/src/prompt/default.rs
+++ b/src/prompt/default.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "helix")]
 use crate::prompt::base::PromptHelixMode;
 use crate::{Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode};
 
@@ -64,7 +63,6 @@ impl Prompt for DefaultPrompt {
     fn render_prompt_indicator(&self, edit_mode: PromptEditMode) -> Cow<'_, str> {
         match edit_mode {
             PromptEditMode::Default | PromptEditMode::Emacs => DEFAULT_PROMPT_INDICATOR.into(),
-            #[cfg(feature = "helix")]
             PromptEditMode::Helix(hx_mode) => match hx_mode {
                 PromptHelixMode::Normal | PromptHelixMode::Select => {
                     DEFAULT_VI_NORMAL_PROMPT_INDICATOR.into()

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -1,7 +1,6 @@
 mod base;
 mod default;
 
-#[cfg(feature = "helix")]
 pub use base::PromptHelixMode;
 pub use base::{
     Prompt, PromptEditMode, PromptEditModeDiscriminants, PromptHistorySearch,

--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -108,7 +108,6 @@ pub fn get_reedline_default_keybindings() -> Vec<(String, String, String, String
 
     // Only the table layer; the bulk of the helix bindings live in its state
     // machine, which `Keybindings` iteration cannot see.
-    #[cfg(feature = "helix")]
     options.extend([
         ("helix_normal", crate::default_helix_normal_keybindings()),
         ("helix_insert", crate::default_helix_insert_keybindings()),


### PR DESCRIPTION
## Summary

The `helix` flag gates no dependency,
yet 90 cfg sites made public API shapes feature-dependent,
which is the worst kind of feature flag to maintain.

Also deletes `TryFrom<ReedlineRawEvent> for KeyEvent`,
which landed with the helix work and never got a caller.