### PR TITLE
refactor(editor): make EditStack a zipper so no index can go stale

### DIFF
--- a/src/core_editor/edit_stack.rs
+++ b/src/core_editor/edit_stack.rs
@@ -1,7 +1,11 @@
 #[derive(Debug, PartialEq, Eq)]
 pub struct EditStack<T> {
-    internal_list: Vec<T>,
-    index: usize,
+    /// States before the current one, oldest first.
+    undo: Vec<T>,
+    /// The state currently pointed at. Always exists, so no index bounds to check.
+    current: T,
+    /// States after the current one, nearest first (a stack).
+    redo: Vec<T>,
 }
 
 impl<T> EditStack<T> {
@@ -10,54 +14,54 @@ impl<T> EditStack<T> {
         T: Default,
     {
         EditStack {
-            internal_list: vec![T::default()],
-            index: 0,
+            undo: Vec::new(),
+            current: T::default(),
+            redo: Vec::new(),
         }
     }
 }
 
 impl<T> EditStack<T>
 where
-    T: Default + Clone + Send,
+    T: Default,
 {
     /// Go back one point in the undo stack. If present on first edit do nothing
     pub(super) fn undo(&mut self) -> &T {
-        self.index = if self.index == 0 { 0 } else { self.index - 1 };
-        &self.internal_list[self.index]
+        if let Some(prev) = self.undo.pop() {
+            let cur = std::mem::replace(&mut self.current, prev);
+            self.redo.push(cur);
+        }
+        &self.current
     }
 
     /// Go forward one point in the undo stack. If present on the last edit do nothing
     pub(super) fn redo(&mut self) -> &T {
-        self.index = if self.index == self.internal_list.len() - 1 {
-            self.index
-        } else {
-            self.index + 1
-        };
-        &self.internal_list[self.index]
+        if let Some(next) = self.redo.pop() {
+            let cur = std::mem::replace(&mut self.current, next);
+            self.undo.push(cur);
+        }
+        &self.current
     }
 
     /// Insert a new entry to the undo stack.
     /// NOTE: (IMP): If we have hit undo a few times then discard all the other values that come
     /// after the current point
     pub(super) fn insert(&mut self, value: T) {
-        if self.index < self.internal_list.len() - 1 {
-            self.internal_list.resize_with(self.index + 1, || {
-                panic!("Impossible state reached: Bug in UndoStack logic")
-            });
-        }
-        self.internal_list.push(value);
-        self.index += 1;
+        self.redo.clear();
+        let prev = std::mem::replace(&mut self.current, value);
+        self.undo.push(prev);
     }
 
     /// Reset the stack to the initial state
     pub(super) fn reset(&mut self) {
-        self.index = 0;
-        self.internal_list = vec![T::default()];
+        self.undo.clear();
+        self.redo.clear();
+        self.current = T::default();
     }
 
     /// Return the entry currently being pointed to
     pub(super) fn current(&mut self) -> &T {
-        &self.internal_list[self.index]
+        &self.current
     }
 }
 
@@ -71,9 +75,12 @@ mod test {
     where
         T: Clone,
     {
+        let (before, rest) = values.split_at(index);
+        let (current, after) = rest.split_first().expect("index within values");
         EditStack {
-            internal_list: values.to_vec(),
-            index,
+            undo: before.to_vec(),
+            current: current.clone(),
+            redo: after.iter().rev().cloned().collect(),
         }
     }
 


### PR DESCRIPTION
## Summary

Found while sweeping the crate for panic surfaces with `clippy::indexing_slicing` and friends.
`EditStack` held `Vec<T>` plus a `usize` index,
a shape that admits states the type never meant to allow (an empty list, an index past the end),
thus every method re-guarded an invariant with indexing, `len() - 1` arithmetic, or an outright `panic!`.

Splitting the stack into `undo` / `current` / `redo` makes only valid states representable,
and the four guards and the `panic!` fall away rather than getting handled.
`mem::replace` moves the outgoing state instead of cloning it,
which is also why the impl no longer needs `T: Clone + Send`, only `Default` for `reset`.

No public API change: the type is private to `core_editor`,
and the five `pub(super)` methods keep their signatures, so `Editor` is untouched.

### Before

    internal_list: Vec<T>,   // never empty, by convention
    index: usize,            // always < len, by convention

### After

    undo: Vec<T>,     // states before the current one, oldest first
    current: T,       // always exists, nothing to bounds-check
    redo: Vec<T>,     // states after the current one, nearest first