### PR TITLE
fix(hinter): stop panicking when the history search fails

### DIFF
--- a/src/hinter/default.rs
+++ b/src/hinter/default.rs
@@ -81,8 +81,10 @@ impl DefaultHinter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
+
     use crate::{
-        history::{HistoryItem, HistoryItemId, HistorySessionId, SearchQuery},
+        history::{FileBackedHistory, HistoryItem, HistoryItemId, HistorySessionId, SearchQuery},
         result::{ReedlineError, ReedlineErrorVariants},
         Result,
     };
@@ -128,6 +130,51 @@ mod tests {
         fn session(&self) -> Option<HistorySessionId> {
             None
         }
+    }
+
+    fn history_with(lines: &[&str]) -> FileBackedHistory {
+        let mut history = FileBackedHistory::new(16).unwrap();
+        for line in lines {
+            history.save(HistoryItem::from_command_line(*line)).unwrap();
+        }
+        history
+    }
+
+    #[rstest]
+    #[case::rest_of_latest_match("hello ", "world")]
+    #[case::multibyte_prefix("café ", "latte")]
+    #[case::exact_entry_leaves_nothing("hello world", "")]
+    #[case::no_match("zzz", "")]
+    fn hint_is_the_rest_of_the_latest_matching_entry(#[case] line: &str, #[case] hint: &str) {
+        let history = history_with(&["café latte", "hello world"]);
+        let mut hinter = DefaultHinter::default();
+        assert_eq!(hinter.handle(line, line.len(), &history, false, ""), hint);
+    }
+
+    #[test]
+    fn no_hint_below_min_chars() {
+        let history = history_with(&["hello world"]);
+        let mut hinter = DefaultHinter::default().with_min_chars(3);
+        assert_eq!(hinter.handle("he", 2, &history, false, ""), "");
+        assert_eq!(hinter.handle("hel", 3, &history, false, ""), "lo world");
+    }
+
+    #[test]
+    fn accepting_exposes_the_whole_hint_and_its_first_token() {
+        let history = history_with(&["git commit --amend"]);
+        let mut hinter = DefaultHinter::default();
+        hinter.handle("git ", 4, &history, false, "");
+        assert_eq!(hinter.complete_hint(), "commit --amend");
+        assert_eq!(hinter.next_hint_token(), "commit");
+    }
+
+    #[test]
+    fn ansi_coloring_wraps_the_same_hint() {
+        let history = history_with(&["hello world"]);
+        let mut hinter = DefaultHinter::default();
+        let painted = hinter.handle("hello ", 6, &history, true, "");
+        assert_ne!(painted, "world");
+        assert_eq!(strip_ansi_escapes::strip_str(&painted), "world");
     }
 
     #[test]

--- a/src/hinter/default.rs
+++ b/src/hinter/default.rs
@@ -23,7 +23,7 @@ impl Hinter for DefaultHinter {
                     line.to_string(),
                     history.session(),
                 ))
-                .expect("todo: error handling")
+                .unwrap_or_default()
                 .first()
                 .map_or_else(String::new, |entry| {
                     entry
@@ -75,5 +75,64 @@ impl DefaultHinter {
     pub fn with_min_chars(mut self, min_chars: usize) -> Self {
         self.min_chars = min_chars;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        history::{HistoryItem, HistoryItemId, HistorySessionId, SearchQuery},
+        result::{ReedlineError, ReedlineErrorVariants},
+        Result,
+    };
+
+    /// A backend whose every call fails, standing in for a locked or unreadable database.
+    struct FailingHistory;
+
+    fn fail<T>() -> Result<T> {
+        Err(ReedlineError(ReedlineErrorVariants::OtherHistoryError(
+            "backend down",
+        )))
+    }
+
+    impl History for FailingHistory {
+        fn save(&mut self, _: HistoryItem) -> Result<HistoryItem> {
+            fail()
+        }
+        fn load(&self, _: HistoryItemId) -> Result<HistoryItem> {
+            fail()
+        }
+        fn count(&self, _: SearchQuery) -> Result<i64> {
+            fail()
+        }
+        fn search(&self, _: SearchQuery) -> Result<Vec<HistoryItem>> {
+            fail()
+        }
+        fn update(
+            &mut self,
+            _: HistoryItemId,
+            _: &dyn Fn(HistoryItem) -> HistoryItem,
+        ) -> Result<()> {
+            fail()
+        }
+        fn clear(&mut self) -> Result<()> {
+            fail()
+        }
+        fn delete(&mut self, _: HistoryItemId) -> Result<()> {
+            fail()
+        }
+        fn sync(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+        fn session(&self) -> Option<HistorySessionId> {
+            None
+        }
+    }
+
+    #[test]
+    fn a_failing_history_yields_no_hint_instead_of_a_panic() {
+        let mut hinter = DefaultHinter::default();
+        assert_eq!(hinter.handle("hello ", 6, &FailingHistory, false, ""), "");
     }
 }


### PR DESCRIPTION
## Summary

`DefaultHinter::handle` did `history.search(...).expect("todo: error handling")`.
It runs on every keystroke,
so with `SqliteBackedHistory` a locked or unreadable database took the whole editor down at the first typed character.
Found while sweeping the crate for panic surfaces.

This falls through to no hint instead, the same choice `CwdAwareHinter` already makes on the same call.
No public API change.

The honest fix is an error channel on `Hinter::handle`,
which currently returns a bare `String` and leaves the impl nowhere to send an `Err`.
That breaks every downstream `Hinter`, so it belongs to a breaking follow-up not inside the no panic cleanup.

### Before

History error inside the hinter: panic.

### After

History error inside the hinter: no hint for that keystroke, editor keeps working.

## Additional notes

Two commits.
The fix rides with a regression test against a `History` stub whose every call fails; with the old `expect` restored the test panics at the exact line.
The second commit adds coverage for the rest of `DefaultHinter`, which had none: prefix hinting including a multi-byte prefix, `min_chars`, `complete_hint`/`next_hint_token`, and ANSI coloring.