### PR TITLE
refactor: make three invariant re-checks structural

### DIFF
--- a/src/core_editor/line.rs
+++ b/src/core_editor/line.rs
@@ -22,7 +22,7 @@ pub(crate) fn end_of_line(buf: &str, pos: usize) -> usize {
         None => buf.len(),
         Some(i) => {
             let newline = pos + i;
-            if newline > 0 && buf.as_bytes()[newline - 1] == b'\r' {
+            if newline > 0 && buf.as_bytes().get(newline - 1) == Some(&b'\r') {
                 newline - 1
             } else {
                 newline

--- a/src/core_editor/word.rs
+++ b/src/core_editor/word.rs
@@ -83,18 +83,14 @@ pub(crate) fn locate_word(
     edge: WordEdge,
     direction: Direction,
 ) -> usize {
-    // `Unicode` (emacs) is the one flavor not expressible as a char-class
-    // boundary predicate — it uses UAX-29 segmentation, with its own scan.
-    if kind == WordKind::Unicode {
-        return locate_unicode_word(buf, origin, edge, direction);
-    }
     let forward = direction == Direction::Forward;
 
-    // Every other flavor only changes which transitions count as a boundary.
     let is_boundary: fn(char, char) -> bool = match kind {
         WordKind::Word => is_word_boundary,
         WordKind::LongWord => is_long_word_boundary,
-        WordKind::Unicode => unreachable!("handled above"),
+        // `Unicode` (emacs) is the one flavor not expressible as a char-class
+        // boundary predicate — it uses UAX-29 segmentation, with its own scan.
+        WordKind::Unicode => return locate_unicode_word(buf, origin, edge, direction),
     };
 
     // Is `ch` (with neighbors `before`/`after`, `None` at the buffer edges) the

--- a/src/highlighter/example.rs
+++ b/src/highlighter/example.rs
@@ -66,17 +66,14 @@ impl Highlighter for ExampleHighlighter {
                     acc
                 }
             });
-            let buffer_split: Vec<&str> = line.splitn(2, &longest_match).collect();
-
-            styled_text.push((
-                Style::new().fg(self.neutral_color),
-                buffer_split[0].to_string(),
-            ));
-            styled_text.push((Style::new().fg(self.match_color), longest_match));
-            styled_text.push((
-                Style::new().bold().fg(self.neutral_color),
-                buffer_split[1].to_string(),
-            ));
+            if let Some((before, after)) = line.split_once(&longest_match) {
+                styled_text.push((Style::new().fg(self.neutral_color), before.to_string()));
+                styled_text.push((Style::new().fg(self.match_color), longest_match));
+                styled_text.push((
+                    Style::new().bold().fg(self.neutral_color),
+                    after.to_string(),
+                ));
+            }
         } else if self.external_commands.is_empty() {
             styled_text.push((Style::new().fg(self.neutral_color), line.to_string()));
         } else {

--- a/src/hinter/cwd_aware.rs
+++ b/src/hinter/cwd_aware.rs
@@ -42,8 +42,8 @@ impl Hinter for CwdAwareHinter {
                     }
                 })
                 .unwrap_or_default();
-            if !with_cwd.is_empty() {
-                with_cwd[0]
+            if let Some(first) = with_cwd.first() {
+                first
                     .command_line
                     .get(line.len()..)
                     .unwrap_or_default()

--- a/src/painting/utils.rs
+++ b/src/painting/utils.rs
@@ -10,7 +10,7 @@ pub(crate) fn coerce_crlf(input: &str) -> Cow<'_, str> {
     let mut result = Cow::Borrowed(input);
     let mut cursor: usize = 0;
     for (idx, _) in input.match_indices('\n') {
-        if !(idx > 0 && input.as_bytes()[idx - 1] == b'\r') {
+        if !(idx > 0 && input.as_bytes().get(idx - 1) == Some(&b'\r')) {
             match &mut result {
                 Cow::Borrowed(_) => {
                     // Best case 1 allocation, worst case 2 allocations.


### PR DESCRIPTION
## Summary

Three small sites from the panic-surface sweep, none a reachable panic in practice,
each a guard the type did not carry:

- `locate_word`: `WordKind::Unicode` was handled by an early return above a `match` that then needed an `unreachable!` arm for it.
  The return now lives in the match, so three kinds are three arms.
- `end_of_line` and `coerce_crlf`: both read `bytes[i - 1] == b'\r'` under an `i > 0` guard.
  The guard stays for the subtraction; the read goes through `get()`.

No public API change, no behaviour change.