### PR TITLE
fix(engine): keep history traversal alive while moving inside a recalled entry

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2855,6 +2855,57 @@ mod tests {
         assert_eq!(reedline.current_buffer_contents(), multiline_command);
     }
 
+    // --- history walk across a recalled multi-line entry (#1109 regression) ---
+
+    /// History holds `older` then `one\ntwo` (newest).
+    fn two_entry_history_engine() -> Reedline {
+        let mut rl = seam_engine(Box::<Emacs>::default());
+        for cmd in ["older", "one\ntwo"] {
+            rl.history
+                .save(HistoryItem::from_command_line(cmd))
+                .expect("save history");
+        }
+        rl
+    }
+
+    #[test]
+    fn down_inside_recalled_multiline_entry_keeps_walking_forward() {
+        let mut rl = two_entry_history_engine();
+        drive(&mut rl, &[key(KeyCode::Up)]);
+        assert_eq!(rl.editor.get_buffer(), "one\ntwo", "setup");
+        assert_eq!(rl.editor.insertion_point(), 3, "setup: end of line 1");
+
+        drive(&mut rl, &[key(KeyCode::Down)]);
+        assert_eq!(rl.editor.get_buffer(), "one\ntwo", "moves to line 2 first");
+        assert!(rl.editor.insertion_point() > 3, "setup: on line 2");
+
+        drive(&mut rl, &[key(KeyCode::Down)]);
+        assert_eq!(
+            rl.editor.get_buffer(),
+            "",
+            "from the last line, Down walks forward to the empty draft"
+        );
+    }
+
+    #[test]
+    fn up_inside_recalled_multiline_entry_keeps_walking_back() {
+        let mut rl = two_entry_history_engine();
+        drive(&mut rl, &[key(KeyCode::Up), key(KeyCode::Down)]);
+        assert_eq!(rl.editor.get_buffer(), "one\ntwo", "setup");
+        assert!(rl.editor.insertion_point() > 3, "setup: on line 2");
+
+        drive(&mut rl, &[key(KeyCode::Up)]);
+        assert_eq!(rl.editor.get_buffer(), "one\ntwo", "moves to line 1 first");
+        assert!(rl.editor.insertion_point() <= 3, "setup: on line 1");
+
+        drive(&mut rl, &[key(KeyCode::Up)]);
+        assert_eq!(
+            rl.editor.get_buffer(),
+            "older",
+            "from the first line, Up walks back to the older entry"
+        );
+    }
+
     #[test]
     fn thread_safe() {
         fn f<S: Send>(_: S) {}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2014,7 +2014,12 @@ impl Reedline {
         if self.input_mode == InputMode::HistoryTraversal {
             self.input_mode = InputMode::Regular;
         }
+        self.apply_edit_commands(commands);
+    }
 
+    /// [`run_edit_commands`](Self::run_edit_commands) without ending history
+    /// traversal, for the engine's own line moves inside a recalled entry.
+    fn apply_edit_commands(&mut self, commands: &[EditCommand]) {
         // Adopt the current edit mode's rest policy so these commands resolve
         // under it (e.g. block-caret selection geometry) — but *without*
         // committing the cursor first. A commit here would apply the policy's
@@ -2036,10 +2041,10 @@ impl Reedline {
             // If we're at the top, move to previous history
             self.previous_history();
         } else {
-            // Through `run_edit_commands` so the cursor settles under the mode's
+            // Through `apply_edit_commands` so the cursor settles under the mode's
             // rest policy — a bare `editor.move_line_up` skips the commit boundary,
             // leaving a vi-normal caret past the last grapheme on a short line.
-            self.run_edit_commands(&[EditCommand::MoveLineUp { select: false }]);
+            self.apply_edit_commands(&[EditCommand::MoveLineUp { select: false }]);
         }
     }
 
@@ -2050,7 +2055,7 @@ impl Reedline {
             self.next_history();
         } else {
             // See `up_command`: settle under the rest policy via the commit boundary.
-            self.run_edit_commands(&[EditCommand::MoveLineDown { select: false }]);
+            self.apply_edit_commands(&[EditCommand::MoveLineDown { select: false }]);
         }
     }
 


### PR DESCRIPTION
## Summary

`up_command`/`down_command` move inside a recalled multi-line entry before they reach for history.
Since #1109 they do so through `run_edit_commands`, which also ends `InputMode::HistoryTraversal`.
The next Up/Down at the buffer edge thus started a fresh `HistoryCursor` from the recalled text, found nothing past it and wrote the prefix back: the walk was stuck on the entry.

Split the body into `apply_edit_commands`, which runs the commands under the rest policy without touching the input mode, and use that for the two in-entry line moves.
`run_edit_commands` still ends traversal on any edit.
Restores the pre-#1109 behaviour, all edit modes.
No public API change.