### PR TITLE
refactor(engine): read the excluded history item through Option instead of unwrap

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -890,7 +890,7 @@ impl Reedline {
     ) -> crate::Result<()> {
         match &self.history_last_run_id {
             Some(Self::FILTERED_ITEM_ID) => {
-                self.history_excluded_item = Some(f(self.history_excluded_item.take().unwrap()));
+                self.history_excluded_item = self.history_excluded_item.take().map(f);
                 Ok(())
             }
             Some(r) => self.history.update(*r, f),
@@ -1977,15 +1977,15 @@ impl Reedline {
     /// When using the up/down traversal or fish/zsh style prefix search update the main line buffer accordingly.
     /// Not used for the separate modal reverse search!
     fn update_buffer_from_history(&mut self) {
+        if self.history_cursor_on_excluded {
+            if let Some(item) = &self.history_excluded_item {
+                self.editor
+                    .set_buffer(item.command_line.clone(), UndoBehavior::HistoryNavigation);
+            }
+            return;
+        }
+
         match self.history_cursor.get_navigation() {
-            _ if self.history_cursor_on_excluded => self.editor.set_buffer(
-                self.history_excluded_item
-                    .as_ref()
-                    .unwrap()
-                    .command_line
-                    .clone(),
-                UndoBehavior::HistoryNavigation,
-            ),
             HistoryNavigationQuery::Normal(original) => {
                 if let Some(buffer_to_paint) = self.history_cursor.string_at_cursor() {
                     self.editor


### PR DESCRIPTION
## Summary

Two `unwrap`s on `history_excluded_item` in `engine.rs`.
Both hold by an invariant kept elsewhere: `submit_buffer` sets `history_last_run_id` to `FILTERED_ITEM_ID` and `history_excluded_item` together, and `previous_history`/`next_history` only raise `history_cursor_on_excluded` after checking the item is there.
`Option::map` and `if let` say the same without a way to panic.
The excluded-cursor arm leaves the `match` in `update_buffer_from_history`, since the navigation query is meaningless while the flag is set.
No behaviour change, no public API change.