### PR TITLE
refactor(menu): read the picked example through and_then instead of expect

### DIFF
--- a/src/menu/description_menu.rs
+++ b/src/menu/description_menu.rs
@@ -585,11 +585,7 @@ impl Menu for DescriptionMenu {
     /// The buffer gets replaced in the Span location
     fn replace_in_buffer(&self, editor: &mut Editor) {
         if let Some(mut suggestion) = self.get_value() {
-            if let Some(example_index) = self.example_index {
-                let example = self
-                    .examples
-                    .get(example_index)
-                    .expect("the example index is always checked");
+            if let Some(example) = self.example_index.and_then(|i| self.examples.get(i)) {
                 suggestion.value.clone_from(example);
             }
             replace_in_buffer(Some(suggestion), editor, self.settings.output_mode);


### PR DESCRIPTION
## Summary

`DescriptionMenu::replace_in_buffer` unwrapped `example_index` and then `examples.get(..)` with an `expect`.
The index is only ever set inside `examples` and reset when the list is rebuilt, so it held, but `and_then` asks the one question the fn has, is there a picked example, without a way to panic.
If the invariant ever slips the suggestion goes in unchanged instead of aborting on Enter.
No behaviour change, no public API change.