### PR TITLE
refactor(menu): slice the list page with get instead of indexing

### DIFF
--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -441,7 +441,7 @@ impl Menu for ListMenu {
             };
 
             let end = end.min(self.total_values());
-            &self.values[start..end]
+            self.values.get(start..end).unwrap_or(&[])
         }
     }
 


### PR DESCRIPTION
## Summary

The page slice in `ListMenu::get_values` clamps `end` to the values but sums `start` from the recorded page sizes.
If those ever outrun `values` (pages built for an earlier, longer result), `start > end` and the range indexing panics mid-paint.
`get(start..end).unwrap_or(&[])` shows the empty menu, NO RECORDS FOUND, instead.
No behaviour change while the page sizes are consistent, no public API change.