### PR TITLE
refactor(engine): drop two invariant re-check panics in the event arms

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1575,15 +1575,13 @@ impl Reedline {
             ReedlineEvent::Enter | ReedlineEvent::Submit | ReedlineEvent::SubmitOrNewline
                 if self.menus.iter().any(|menu| menu.is_active()) =>
             {
-                for menu in self.menus.iter_mut() {
-                    if menu.is_active() {
-                        menu.replace_in_buffer(&mut self.editor);
-                        menu.menu_event(MenuEvent::Deactivate);
-
-                        return Ok(EventStatus::Handled);
-                    }
+                if let Some(menu) = self.menus.iter_mut().find(|menu| menu.is_active()) {
+                    menu.replace_in_buffer(&mut self.editor);
+                    menu.menu_event(MenuEvent::Deactivate);
+                    Ok(EventStatus::Handled)
+                } else {
+                    Ok(EventStatus::Inapplicable)
                 }
-                unreachable!()
             }
             ReedlineEvent::Enter => {
                 #[cfg(feature = "bashisms")]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2234,7 +2234,7 @@ impl Reedline {
                     let history_search_by_session = self
                         .history
                         .search(SearchQuery::last_with_prefix_and_cwd(
-                            parsed.prefix.unwrap().to_string(),
+                            parsed.prefix.unwrap_or_default().to_string(),
                             self.cwd.clone().unwrap_or_else(|| {
                                 std::env::current_dir()
                                     .unwrap_or_default()


### PR DESCRIPTION
## Summary

Two panic sites in `engine.rs`, one commit each.

The menu-accept arm for `Enter`/`Submit`/`SubmitOrNewline` re-searched the menus in a loop whose fall-through was `unreachable!()`, after the arm's guard had already proven one is active.
`find` handles both outcomes: the active menu accepts, and if guard and body ever disagree the event reads as `Inapplicable` instead of aborting.

`parse_bang_command` unwrapped `parsed.prefix` in the `BackwardPrefixSearch` arm.
The parser always sets it for that action, but that is a cross-file invariant; `unwrap_or_default` searches with an empty prefix on drift, matching the `parsed_prefix` the fn already computes for the other arms.

No behaviour change while the invariants hold, no public API change.