### PR TITLE
feat(helix): accept a HelixChangeMode event so keybindings can switch mode

### DIFF
--- a/src/edit_mode/base.rs
+++ b/src/edit_mode/base.rs
@@ -15,6 +15,10 @@ pub trait EditMode: Send {
     fn edit_mode(&self) -> PromptEditMode;
 
     /// Handles events that apply only to specific edit modes (e.g changing vi mode)
+    ///
+    /// Only the machine's own state changes here. Any cursor repair the flip
+    /// implies is the engine's job, stated over the rest policy the mode maps
+    /// to — see `Reedline::change_edit_mode`.
     fn handle_mode_specific_event(&mut self, _event: ReedlineEvent) -> EventStatus {
         EventStatus::Inapplicable
     }

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -163,6 +163,10 @@ impl EditMode for Helix {
         match event {
             ReedlineEvent::HelixChangeMode(mode_str) => match HelixMode::from_str(&mode_str) {
                 Ok(mode) => {
+                    // An invariant, not a path reachable today: `dispatch`
+                    // skips the keybinding table while `pending` or `count` is
+                    // set, so no binding fires mid-sequence. Reset anyway,
+                    // rather than lean on that guarantee from over here.
                     self.pending = None;
                     self.count = None;
                     self.mode = mode;
@@ -1473,12 +1477,15 @@ mod test {
         assert_eq!(helix.count, None);
     }
 
-    // --- HelixChangeMode ---
+    // ---- change mode event ----
 
     #[rstest]
     #[case("insert", HelixMode::Insert)]
-    #[case("Normal", HelixMode::Normal)]
+    #[case("Insert", HelixMode::Insert)]
+    #[case("SELECT", HelixMode::Select)]
     #[case("select", HelixMode::Select)]
+    #[case("normal", HelixMode::Normal)]
+    #[case("NoRmAl", HelixMode::Normal)]
     fn change_mode_event_switches_the_machine(#[case] name: &str, #[case] expected: HelixMode) {
         let mut helix = normal();
         let status = helix.handle_mode_specific_event(ReedlineEvent::HelixChangeMode(name.into()));

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -1,24 +1,29 @@
 mod helix_keybindings;
 
+use std::str::FromStr;
+
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 pub use helix_keybindings::{
     default_helix_insert_keybindings, default_helix_normal_keybindings,
     default_helix_select_keybindings,
 };
+use strum::EnumString;
 
 use super::{is_plain_char, is_text_char, parse_non_key_event};
 
 use crate::{
-    Direction, EditCommand, EditMode, FindStop, Granularity, Keybindings, MotionTarget,
-    PromptEditMode, PromptHelixMode, ReedlineEvent, WordEdge, WordKind,
+    enums::EventStatus, Direction, EditCommand, EditMode, FindStop, Granularity, Keybindings,
+    MotionTarget, PromptEditMode, PromptHelixMode, ReedlineEvent, WordEdge, WordKind,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString)]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
 enum HelixMode {
     Normal,
     Insert,
     Select,
 }
+
 /// A prefix key waiting for its argument.
 ///
 /// `Find` and `Replace` take an arbitrary char as data, so no finite key
@@ -152,6 +157,20 @@ impl EditMode for Helix {
             HelixMode::Insert => PromptEditMode::Helix(PromptHelixMode::Insert),
             HelixMode::Normal => PromptEditMode::Helix(PromptHelixMode::Normal),
             HelixMode::Select => PromptEditMode::Helix(PromptHelixMode::Select),
+        }
+    }
+    fn handle_mode_specific_event(&mut self, event: ReedlineEvent) -> EventStatus {
+        match event {
+            ReedlineEvent::HelixChangeMode(mode_str) => match HelixMode::from_str(&mode_str) {
+                Ok(mode) => {
+                    self.pending = None;
+                    self.count = None;
+                    self.mode = mode;
+                    EventStatus::Handled
+                }
+                Err(_) => EventStatus::Inapplicable,
+            },
+            _ => EventStatus::Inapplicable,
         }
     }
 }
@@ -1452,5 +1471,42 @@ mod test {
             ])
         );
         assert_eq!(helix.count, None);
+    }
+
+    // --- HelixChangeMode ---
+
+    #[rstest]
+    #[case("insert", HelixMode::Insert)]
+    #[case("Normal", HelixMode::Normal)]
+    #[case("select", HelixMode::Select)]
+    fn change_mode_event_switches_the_machine(#[case] name: &str, #[case] expected: HelixMode) {
+        let mut helix = normal();
+        let status = helix.handle_mode_specific_event(ReedlineEvent::HelixChangeMode(name.into()));
+        assert!(matches!(status, EventStatus::Handled));
+        assert_eq!(helix.mode, expected);
+    }
+
+    #[test]
+    fn change_mode_event_rejects_an_unknown_mode() {
+        let mut helix = normal();
+        let status =
+            helix.handle_mode_specific_event(ReedlineEvent::HelixChangeMode("emacs".into()));
+        assert!(matches!(status, EventStatus::Inapplicable));
+        assert_eq!(helix.mode, HelixMode::Normal);
+    }
+
+    #[test]
+    fn change_mode_event_abandons_a_half_typed_sequence() {
+        let mut helix = normal();
+        // Arm a count and a pending find; the switch must clear both so the
+        // next key is not eaten as the find argument in the new mode.
+        helix.parse_event(chr('3'));
+        helix.parse_event(chr('f'));
+        assert!(helix.pending.is_some(), "setup: find is armed");
+
+        helix.handle_mode_specific_event(ReedlineEvent::HelixChangeMode("insert".into()));
+        assert_eq!(helix.pending, None);
+        assert_eq!(helix.count, None);
+        assert_eq!(helix.mode, HelixMode::Insert);
     }
 }

--- a/src/edit_mode/vi/mod.rs
+++ b/src/edit_mode/vi/mod.rs
@@ -6,6 +6,7 @@ mod vi_keybindings;
 use std::str::FromStr;
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use strum::EnumString;
 pub use vi_keybindings::{default_vi_insert_keybindings, default_vi_normal_keybindings};
 
 use super::{is_plain_char, is_text_char, parse_non_key_event, EditMode};
@@ -15,24 +16,12 @@ use crate::{
     Direction, MotionTarget, PromptEditMode, PromptViMode,
 };
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, EnumString)]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
 enum ViMode {
     Normal,
     Insert,
     Visual,
-}
-
-impl FromStr for ViMode {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "normal" => Ok(ViMode::Normal),
-            "insert" => Ok(ViMode::Insert),
-            "visual" => Ok(ViMode::Visual),
-            _ => Err(()),
-        }
-    }
 }
 
 /// This parses incoming input `Event`s like a Vi-Style editor
@@ -220,6 +209,7 @@ impl EditMode for Vi {
         match event {
             ReedlineEvent::ViChangeMode(mode_str) => match ViMode::from_str(&mode_str) {
                 Ok(mode) => {
+                    self.cache.clear();
                     self.mode = mode;
                     EventStatus::Handled
                 }
@@ -236,6 +226,7 @@ mod test {
     use crate::{Direction, Granularity, MotionTarget, WordEdge, WordKind};
     use crossterm::event::{MouseEvent, MouseEventKind};
     use pretty_assertions::assert_eq;
+    use rstest::rstest;
 
     fn key(code: KeyCode, modifiers: KeyModifiers) -> ReedlineRawEvent {
         ReedlineRawEvent::try_from(Event::Key(KeyEvent::new(code, modifiers))).unwrap()
@@ -845,5 +836,43 @@ mod test {
 
         let dot = vi.parse_event(key(KeyCode::Char('.'), KeyModifiers::NONE));
         assert_eq!(dot, ReedlineEvent::Multiple(vec![dw]));
+    }
+
+    // --- ViChangeMode ---
+
+    #[rstest]
+    #[case("insert", ViMode::Insert)]
+    #[case("Normal", ViMode::Normal)]
+    #[case("VISUAL", ViMode::Visual)]
+    fn change_mode_event_switches_the_machine(#[case] name: &str, #[case] expected: ViMode) {
+        let mut vi = Vi::default();
+        let status = vi.handle_mode_specific_event(ReedlineEvent::ViChangeMode(name.into()));
+        assert!(matches!(status, EventStatus::Handled));
+        assert_eq!(vi.mode, expected);
+    }
+
+    #[test]
+    fn change_mode_event_rejects_an_unknown_mode() {
+        let mut vi = Vi::default();
+        let status = vi.handle_mode_specific_event(ReedlineEvent::ViChangeMode("select".into()));
+        assert!(matches!(status, EventStatus::Inapplicable));
+        assert_eq!(vi.mode, ViMode::Insert);
+    }
+
+    #[test]
+    fn change_mode_event_abandons_a_half_typed_sequence() {
+        let mut vi = Vi {
+            mode: ViMode::Normal,
+            ..Default::default()
+        };
+        // Arm a counted find; the switch must clear the cache so the next key
+        // is not parsed as the find argument in the new mode.
+        let _ = vi.parse_event(key(KeyCode::Char('3'), KeyModifiers::NONE));
+        let _ = vi.parse_event(key(KeyCode::Char('f'), KeyModifiers::NONE));
+        assert!(!vi.cache.is_empty(), "setup: sequence is armed");
+
+        vi.handle_mode_specific_event(ReedlineEvent::ViChangeMode("insert".into()));
+        assert!(vi.cache.is_empty());
+        assert_eq!(vi.mode, ViMode::Insert);
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1409,8 +1409,9 @@ impl Reedline {
             | ReedlineEvent::MenuRight
             | ReedlineEvent::MenuPageNext
             | ReedlineEvent::MenuPagePrevious
-            | ReedlineEvent::ViChangeMode(_)
-            | ReedlineEvent::HelixChangeMode(_) => Ok(EventStatus::Inapplicable),
+            | ReedlineEvent::ViChangeMode(_) => Ok(EventStatus::Inapplicable),
+            #[cfg(feature = "helix")]
+            ReedlineEvent::HelixChangeMode(_) => Ok(EventStatus::Inapplicable),
         }
     }
 
@@ -1783,9 +1784,9 @@ impl Reedline {
                 // Exhausting the event handlers is still considered handled
                 Ok(EventStatus::Inapplicable)
             }
-            ReedlineEvent::ViChangeMode(_) | ReedlineEvent::HelixChangeMode(_) => {
-                Ok(self.change_edit_mode(event))
-            }
+            ReedlineEvent::ViChangeMode(_) => Ok(self.change_edit_mode(event)),
+            #[cfg(feature = "helix")]
+            ReedlineEvent::HelixChangeMode(_) => Ok(self.change_edit_mode(event)),
             ReedlineEvent::Mouse {
                 column,
                 row,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -36,9 +36,9 @@ use {
             semantic_prompt::{Osc133ClickEventsMarkers, SemanticPromptMarkers},
         },
         utils::text_manipulation,
-        AbbrExpandContext, EditCommand, ExampleHighlighter, Highlighter, LineBuffer, Menu,
-        MenuEvent, MouseButton, Prompt, PromptHistorySearch, ReedlineMenu, Signal, UndoBehavior,
-        ValidationResult, Validator,
+        AbbrExpandContext, Direction, EditCommand, ExampleHighlighter, Highlighter, LineBuffer,
+        Menu, MenuEvent, MouseButton, Prompt, PromptHistorySearch, ReedlineMenu, Signal,
+        UndoBehavior, ValidationResult, Validator,
     },
     crossterm::{
         cursor::{SetCursorStyle, Show},
@@ -1783,9 +1783,8 @@ impl Reedline {
                 // Exhausting the event handlers is still considered handled
                 Ok(EventStatus::Inapplicable)
             }
-            ReedlineEvent::ViChangeMode(_) => Ok(self.edit_mode.handle_mode_specific_event(event)),
-            ReedlineEvent::HelixChangeMode(_) => {
-                Ok(self.edit_mode.handle_mode_specific_event(event))
+            ReedlineEvent::ViChangeMode(_) | ReedlineEvent::HelixChangeMode(_) => {
+                Ok(self.change_edit_mode(event))
             }
             ReedlineEvent::Mouse {
                 column,
@@ -1799,6 +1798,34 @@ impl Reedline {
             }
             ReedlineEvent::None => Ok(EventStatus::Inapplicable),
         }
+    }
+
+    /// Route a mode-switch event to the active edit mode, then repair the cursor
+    /// the flip left behind.
+    ///
+    /// A machine's own transitions emit their repairs as events, the way `i`
+    /// collapses the selection on the way into helix insert. An event-driven
+    /// flip never reaches that path, so the repair has to happen here. The one
+    /// that bites is leaving a block caret for a bar caret: a block policy rests
+    /// as a min-width-1 selection, and `insert_char` deletes the selection
+    /// before inserting, so the first keystroke would replace the covered
+    /// grapheme.
+    ///
+    /// Stated over the `RestPolicy` rather than per machine, so helix
+    /// normal/select and vi visual are one rule instead of three cases, and a
+    /// future machine inherits it.
+    fn change_edit_mode(&mut self, event: ReedlineEvent) -> EventStatus {
+        let before = self.edit_mode.edit_mode().rest_policy();
+        let status = self.edit_mode.handle_mode_specific_event(event);
+        let after = self.edit_mode.edit_mode().rest_policy();
+        if before.is_block() && !after.is_block() {
+            // `run_edit_commands` re-syncs the policy from the mode the machine
+            // now reports, so this resolves under `after`. Collapsing under the
+            // block policy being left would re-widen the cursor and undo it.
+            // Backward is the edge `i` lands on.
+            self.run_edit_commands(&[EditCommand::CollapseSelection(Direction::Backward)]);
+        }
+        status
     }
 
     fn handle_mouse_click(&mut self, column: u16, row: u16) -> Result<()> {
@@ -2955,7 +2982,6 @@ mod tests {
     }
 
     /// Drive one key per batch, stopping at the first `Signal`.
-    #[cfg(feature = "helix")]
     fn drive_until_signal(rl: &mut Reedline, keys: &[KeyEvent]) -> Option<Signal> {
         let prompt = DefaultPrompt::default();
         for k in keys {
@@ -3054,6 +3080,86 @@ mod tests {
         );
         assert!(signal.is_none(), "incomplete input must not submit");
         assert_eq!(rl.editor.get_buffer(), "\"a\n\n");
+    }
+
+    /// A keybinding flip into insert must collapse the resting selection first,
+    /// exactly as `i` does. The helix block cursor *is* a one-grapheme
+    /// selection, and `insert_char` deletes the selection before inserting, so
+    /// without the collapse the first keystroke replaces the covered grapheme.
+    #[cfg(feature = "helix")]
+    #[test]
+    fn helix_change_mode_into_insert_keeps_the_covered_grapheme() {
+        let mut bindings = crate::default_helix_normal_keybindings();
+        bindings.add_binding(
+            KeyModifiers::NONE,
+            KeyCode::Char('z'),
+            ReedlineEvent::HelixChangeMode("insert".into()),
+        );
+        let mut rl = Reedline::create()
+            .with_edit_mode(Box::new(
+                crate::Helix::default().with_normal_keybindings(bindings),
+            ))
+            .with_validator(Box::new(crate::DefaultValidator));
+        rl.painter.force_prompt_anchored_for_test(0);
+        // `hh` walks the caret back onto the `a`, so the cursor covers a
+        // grapheme with buffer on both sides of it.
+        let signal = drive_until_signal(
+            &mut rl,
+            &[
+                ch('"'),
+                ch('a'),
+                ch('b'),
+                ch('c'),
+                key(KeyCode::Esc),
+                ch('h'),
+                ch('h'),
+                ch('z'),
+                ch('X'),
+            ],
+        );
+        assert!(signal.is_none(), "incomplete input must not submit");
+        // Not `"Xbc`: the covered `a` is a resting cursor, not a selection the
+        // insert should consume.
+        assert_eq!(rl.editor.get_buffer(), "\"Xabc");
+    }
+
+    /// Vi visual rests min-width-1 under `RestPolicy::Block` just as helix does,
+    /// so the same rule has to cover a `ViChangeMode` flip out of it. Without the
+    /// collapse the visual selection is still live and the first keystroke
+    /// replaces it.
+    #[test]
+    fn vi_change_mode_out_of_visual_keeps_the_covered_grapheme() {
+        let mut bindings = crate::default_vi_normal_keybindings();
+        bindings.add_binding(
+            KeyModifiers::NONE,
+            KeyCode::Char('z'),
+            ReedlineEvent::ViChangeMode("insert".into()),
+        );
+        let mut rl = Reedline::create()
+            .with_edit_mode(Box::new(crate::Vi::new(
+                crate::default_vi_insert_keybindings(),
+                bindings,
+            )))
+            .with_validator(Box::new(crate::DefaultValidator));
+        rl.painter.force_prompt_anchored_for_test(0);
+        // `hh` walks back onto the `a`, `v` enters visual covering it.
+        let signal = drive_until_signal(
+            &mut rl,
+            &[
+                ch('"'),
+                ch('a'),
+                ch('b'),
+                ch('c'),
+                key(KeyCode::Esc),
+                ch('h'),
+                ch('h'),
+                ch('v'),
+                ch('z'),
+                ch('X'),
+            ],
+        );
+        assert!(signal.is_none(), "incomplete input must not submit");
+        assert_eq!(rl.editor.get_buffer(), "\"Xabc");
     }
 
     /// The submitted path cannot assert on the buffer (`submit_buffer` clears

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1409,7 +1409,8 @@ impl Reedline {
             | ReedlineEvent::MenuRight
             | ReedlineEvent::MenuPageNext
             | ReedlineEvent::MenuPagePrevious
-            | ReedlineEvent::ViChangeMode(_) => Ok(EventStatus::Inapplicable),
+            | ReedlineEvent::ViChangeMode(_)
+            | ReedlineEvent::HelixChangeMode(_) => Ok(EventStatus::Inapplicable),
         }
     }
 
@@ -1783,6 +1784,9 @@ impl Reedline {
                 Ok(EventStatus::Inapplicable)
             }
             ReedlineEvent::ViChangeMode(_) => Ok(self.edit_mode.handle_mode_specific_event(event)),
+            ReedlineEvent::HelixChangeMode(_) => {
+                Ok(self.edit_mode.handle_mode_specific_event(event))
+            }
             ReedlineEvent::Mouse {
                 column,
                 row,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1131,6 +1131,9 @@ pub enum ReedlineEvent {
 
     /// Change mode (vi mode only)
     ViChangeMode(String),
+
+    /// Change mode (helix mode only)
+    HelixChangeMode(String),
 }
 
 pub enum EventStatus {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1129,10 +1129,23 @@ pub enum ReedlineEvent {
     /// Open text editor
     OpenEditor,
 
-    /// Change mode (vi mode only)
+    /// Switch the vi state machine to a named mode (vi mode only).
+    ///
+    /// Accepts `normal`, `insert` or `visual`, matched case-insensitively. Any
+    /// other name leaves the mode alone and reports the event inapplicable. On
+    /// its own that is a keybinding that does nothing; inside an
+    /// [`UntilFound`](ReedlineEvent::UntilFound) it hands the key to the next
+    /// event in the list instead.
     ViChangeMode(String),
 
-    /// Change mode (helix mode only)
+    /// Switch the helix state machine to a named mode (helix mode only).
+    ///
+    /// Accepts `normal`, `insert` or `select`, matched case-insensitively. Any
+    /// other name leaves the mode alone and reports the event inapplicable. On
+    /// its own that is a keybinding that does nothing; inside an
+    /// [`UntilFound`](ReedlineEvent::UntilFound) it hands the key to the next
+    /// event in the list instead.
+    #[cfg(feature = "helix")]
     HelixChangeMode(String),
 }
 


### PR DESCRIPTION
## Summary

There is no way to move helix between its modes from a keybinding; vi has `ViChangeMode`.
This is its mirror: `ReedlineEvent::HelixChangeMode(String)`, routed to `handle_mode_specific_event`, parsed with a strum `EnumString` (case-insensitive) and applied as a mode flip.
The switch also drops a half-typed sequence (`pending`, `count`), so the next key is not eaten as a find argument in the new mode.

Second commit: vi gets the same two fixes. Its `cache` survived the flip (`3f` then a switch binding fed the next key to the old sequence), and its hand-rolled `FromStr` becomes the same `EnumString`, so `Insert`/`NORMAL` spellings work there too.

Like vi's, the flip is raw: it skips the machine's event-mediated transitions, so an extended selection survives a switch out of select, and an unknown mode string is silently inapplicable.
Both limits are for the larger mode-switching design (emacs/vi/helix machines); this is the small piece so people can start configuring.

## Additional notes

New `ReedlineEvent` variant; nushell's `reedline_config.rs` event parser needs a matching arm before it is spellable in `$env.config` (follow-up there).
Tests: mode tables incl. case-insensitivity, unknown mode, armed sequence abandoned, for both machines.