### PR TITLE
fix(menu): close the division panics in the columnar menu

### DIFF
--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -9,6 +9,7 @@ use crate::{
     Completer, Suggestion,
 };
 use nu_ansi_term::ansi::RESET;
+use std::num::{NonZero, NonZeroUsize};
 
 /// The traversal direction of the menu
 #[derive(Debug, PartialEq, Eq)]
@@ -211,14 +212,12 @@ impl ColumnarMenu {
     fn position_from_index(&self, index: usize) -> (u16, u16) {
         match self.default_details.traversal_dir {
             TraversalDirection::Vertical => {
-                let row = index % self.get_rows() as usize;
-                let col = index / self.get_rows() as usize;
-                (row as u16, col as u16)
+                let rows = NonZeroUsize::from(self.grid_rows());
+                ((index % rows) as u16, (index / rows) as u16)
             }
             TraversalDirection::Horizontal => {
-                let row = index / self.get_used_cols() as usize;
-                let col = index % self.get_used_cols() as usize;
-                (row as u16, col as u16)
+                let cols = NonZeroUsize::from(self.grid_cols());
+                ((index / cols) as u16, (index % cols) as u16)
             }
         }
     }
@@ -228,9 +227,9 @@ impl ColumnarMenu {
         let num_values = self.get_values().len() as u16;
         match self.default_details.traversal_dir {
             TraversalDirection::Vertical => {
-                if col_pos >= self.get_used_cols() - 1 {
+                if col_pos >= self.grid_cols().get() - 1 {
                     // Last column, might not be full
-                    let mod_val = num_values % self.get_rows();
+                    let mod_val = num_values % self.grid_rows();
                     if mod_val == 0 {
                         // Full column
                         self.get_rows().saturating_sub(1)
@@ -244,7 +243,7 @@ impl ColumnarMenu {
                 }
             }
             TraversalDirection::Horizontal => {
-                let mod_val = num_values % self.get_used_cols();
+                let mod_val = num_values % self.grid_cols();
                 if mod_val > 0 && col_pos >= mod_val {
                     // Column with last row empty
                     self.get_rows().saturating_sub(2)
@@ -261,7 +260,7 @@ impl ColumnarMenu {
         let num_values = self.get_values().len() as u16;
         match self.default_details.traversal_dir {
             TraversalDirection::Vertical => {
-                let mod_val = num_values % self.get_rows();
+                let mod_val = num_values % self.grid_rows();
                 if mod_val > 0 && row_pos >= mod_val {
                     // Row with last column empty
                     self.get_used_cols().saturating_sub(2)
@@ -271,9 +270,9 @@ impl ColumnarMenu {
                 }
             }
             TraversalDirection::Horizontal => {
-                if row_pos >= self.get_rows() - 1 {
+                if row_pos >= self.grid_rows().get() - 1 {
                     // Last row, might not be full
-                    let mod_val = num_values % self.get_used_cols();
+                    let mod_val = num_values % self.grid_cols();
                     if mod_val == 0 {
                         // Full row
                         self.get_used_cols().saturating_sub(1)
@@ -291,44 +290,56 @@ impl ColumnarMenu {
 
     /// Menu index based on column and row position
     fn index(&self) -> usize {
-        let index = match self.default_details.traversal_dir {
-            TraversalDirection::Vertical => self.col_pos * self.get_rows() + self.row_pos,
-            TraversalDirection::Horizontal => self.row_pos * self.get_used_cols() + self.col_pos,
-        };
-        index.into()
+        // Widened to usize so a large grid cannot overflow u16.
+        match self.default_details.traversal_dir {
+            TraversalDirection::Vertical => {
+                usize::from(self.col_pos) * usize::from(self.grid_rows().get())
+                    + usize::from(self.row_pos)
+            }
+            TraversalDirection::Horizontal => {
+                usize::from(self.row_pos) * usize::from(self.grid_cols().get())
+                    + usize::from(self.col_pos)
+            }
+        }
     }
 
     /// Calculates how many rows the menu will use
+    ///
+    /// The *layout* answer, so it may be 0 while a completion is still in
+    /// flight; grid arithmetic asks [`grid_rows`](Self::grid_rows) instead.
     fn get_rows(&self) -> u16 {
-        match self.get_values().len() as u16 {
+        if self.get_values().is_empty() && self.phase.awaiting_results() {
             // No reason to save space if we're waiting for results.
-            0 if self.phase.awaiting_results() => 0,
-            // Should be one row for actual empty results
-            0 => 1,
-            total_values => total_values.div_ceil(self.get_cols()),
+            0
+        } else {
+            self.grid_rows().get()
         }
+    }
+
+    /// How many rows the value grid has, at least 1 by construction: `%` and
+    /// `/` by it cannot panic and need no per-site zero check.
+    fn grid_rows(&self) -> NonZero<u16> {
+        let values = self.get_values().len() as u16;
+        NonZero::new(values.div_ceil(self.get_cols())).unwrap_or(NonZero::<u16>::MIN)
     }
 
     /// Calculates how many columns will be used to display values
     fn get_used_cols(&self) -> u16 {
+        self.grid_cols().get()
+    }
+
+    /// The column counterpart of [`grid_rows`](Self::grid_rows), likewise at
+    /// least 1 by construction.
+    fn grid_cols(&self) -> NonZero<u16> {
         let values = self.get_values().len() as u16;
-
-        if values == 0 {
-            // When the values are empty the "NO RECORDS FOUND" message is shown, taking 1 column
-            return 1;
-        }
-
-        match self.default_details.traversal_dir {
+        let cols = match self.default_details.traversal_dir {
             TraversalDirection::Vertical => {
-                let cols = values / self.get_rows();
-                if !values.is_multiple_of(self.get_rows()) {
-                    cols + 1
-                } else {
-                    cols
-                }
+                let rows = self.grid_rows();
+                values / rows + u16::from(!values.is_multiple_of(rows.get()))
             }
             TraversalDirection::Horizontal => self.get_cols().min(values),
-        }
+        };
+        NonZero::new(cols).unwrap_or(NonZero::<u16>::MIN)
     }
 
     /// Returns working details col width
@@ -525,6 +536,8 @@ impl ColumnarMenu {
                 self.reload(updated, editor, completer)
             }
             MenuEvent::Deactivate => {}
+            // No values, no grid: nothing to move over.
+            _ if self.get_values().is_empty() => {}
             MenuEvent::NextElement => self.move_next(),
             MenuEvent::PreviousElement => self.move_previous(),
             MenuEvent::MoveUp => self.move_up(),
@@ -1025,6 +1038,47 @@ mod tests {
         fn complete(&mut self, _line: &str, _pos: usize) -> crate::CompletionResult {
             crate::CompletionResult::Pending
         }
+    }
+
+    /// Movement over an empty, still-pending menu is a no-op instead of
+    /// dividing by the 0 rows the awaiting phase reports (vertical panicked).
+    #[test]
+    fn movement_on_an_awaiting_empty_menu_is_a_noop() {
+        let mut menu = ColumnarMenu::default()
+            .with_name("testmenu")
+            .with_traversal_direction(TraversalDirection::Vertical);
+        let mut editor = Editor::default();
+        let mut pending = PendingCompleter;
+        setup_menu(&mut menu, &mut editor, &mut pending, (30, 10));
+        assert_eq!(menu.get_rows(), 0, "setup: layout reserves no lines");
+
+        let mut painter = Painter::new(W::sink());
+        painter.handle_resize(30, 10);
+        for event in [
+            MenuEvent::NextElement,
+            MenuEvent::PreviousElement,
+            MenuEvent::MoveUp,
+            MenuEvent::MoveDown,
+            MenuEvent::MoveLeft,
+            MenuEvent::MoveRight,
+        ] {
+            menu.menu_event(event);
+            menu.update_working_details(&mut editor, &mut pending, &painter);
+        }
+        assert_eq!(menu.index(), 0, "the cursor stays on the home cell");
+    }
+
+    /// The divisors never collapse to 0, even while the layout answer is 0.
+    #[test]
+    fn grid_dimensions_stay_nonzero_while_awaiting() {
+        let mut menu = ColumnarMenu::default().with_name("testmenu");
+        let mut editor = Editor::default();
+        let mut pending = PendingCompleter;
+        setup_menu(&mut menu, &mut editor, &mut pending, (30, 10));
+        assert_eq!(menu.get_rows(), 0);
+        assert_eq!(menu.grid_rows().get(), 1);
+        assert_eq!(menu.grid_cols().get(), 1);
+        assert_eq!(menu.position_from_index(0), (0, 0));
     }
 
     #[test]

--- a/src/menu/columnar_menu.rs
+++ b/src/menu/columnar_menu.rs
@@ -568,17 +568,21 @@ impl ColumnarMenu {
         } else {
             // If no default width is found, then the total screen width is used to estimate
             // the column width based on the default number of columns
+            // Floored: `with_columns(0)` is representable.
             let default_width = self
                 .default_details
                 .col_width
-                .unwrap_or_else(|| screen_width / self.default_details.columns as usize);
+                .unwrap_or_else(|| screen_width / self.default_details.columns.max(1) as usize);
 
             // Adjusting the working width of the column based the max line width found
             // in the menu values
             let required_width =
                 self.completions.longest_suggestion + self.default_details.col_padding;
 
-            self.working_details.col_width = required_width.max(default_width).min(screen_width);
+            // Floored: 0 on a 0-width terminal, and `possible_columns`
+            // divides by this.
+            self.working_details.col_width =
+                required_width.max(default_width).min(screen_width).max(1);
 
             // The working columns is adjusted based on possible number of columns
             // that could be fitted in the screen with the calculated column width
@@ -728,7 +732,9 @@ impl Menu for ColumnarMenu {
             // This reduces the flickering when printing the menu
             match self.default_details.traversal_dir {
                 TraversalDirection::Vertical => {
-                    let num_rows: usize = self.get_rows().into();
+                    // `grid_rows`, since `step_by(0)` panics: the type proves
+                    // what the enclosing non-empty branch implies.
+                    let num_rows: usize = NonZeroUsize::from(self.grid_rows()).get();
                     let rows_to_draw = num_rows.min(available_lines.into());
                     let mut menu_string = String::new();
                     for line in 0..rows_to_draw {
@@ -750,8 +756,11 @@ impl Menu for ColumnarMenu {
                     menu_string
                 }
                 TraversalDirection::Horizontal => {
-                    let available_values = (available_lines * self.get_cols()) as usize;
-                    let skip_values = (self.skip_rows * self.get_used_cols()) as usize;
+                    // Widened to usize so the products cannot overflow u16.
+                    let available_values =
+                        usize::from(available_lines) * usize::from(self.get_cols());
+                    let skip_values =
+                        usize::from(self.skip_rows) * usize::from(self.grid_cols().get());
 
                     self.get_values()
                         .iter()
@@ -1038,6 +1047,28 @@ mod tests {
         fn complete(&mut self, _line: &str, _pos: usize) -> crate::CompletionResult {
             crate::CompletionResult::Pending
         }
+    }
+
+    /// `with_columns(0)` reaches the layout's screen-width division.
+    #[test]
+    fn zero_configured_columns_does_not_panic_the_layout() {
+        let mut menu = ColumnarMenu::default()
+            .with_name("testmenu")
+            .with_columns(0);
+        let mut editor = Editor::default();
+        let mut completer = FakeCompleter::new(&["alpha", "beta", "gamma"]);
+        setup_menu(&mut menu, &mut editor, &mut completer, (30, 10));
+        assert!(!menu.menu_string(10, false).is_empty());
+    }
+
+    /// A 0x0 terminal clamps `col_width` to 0, which `possible_columns`
+    /// divides by.
+    #[test]
+    fn zero_width_terminal_does_not_panic_the_layout() {
+        let mut menu = ColumnarMenu::default().with_name("testmenu");
+        let mut editor = Editor::default();
+        let mut completer = FakeCompleter::new(&["alpha", "beta", "gamma"]);
+        setup_menu(&mut menu, &mut editor, &mut completer, (0, 0));
     }
 
     /// Movement over an empty, still-pending menu is a no-op instead of


### PR DESCRIPTION
## Summary

Moving the selection while a completion is still in flight panics:
get_rows answers 0 in that state so the painter reserves no lines,
and the same 0 reaches index % rows in position_from_index.

The root problem is one number answering two questions,
"how many lines to reserve" (0 is correct while awaiting) and "how many rows does the grid have" (never 0).
So the fix splits them: get_rows keeps the layout answer,
new private grid_rows/grid_cols carry the arithmetic one as NonZero<u16>,
which makes every % and / by them infallible by type instead of guarded per site.
A guard arm in apply_event additionally makes movement over an empty menu a no-op.

The second commit closes the two other reachable divisions in the file
(with_columns(0) through the builder, col_width 0 on a 0-width terminal).

No public API change.