### PR TITLE
fix: guard the zero-width divisions in the painter and menus

### DIFF
--- a/src/menu/description_menu.rs
+++ b/src/menu/description_menu.rs
@@ -546,17 +546,15 @@ impl Menu for DescriptionMenu {
             let default_width = if let Some(col_width) = self.default_details.col_width {
                 col_width
             } else {
-                let col_width = painter.screen_width() / self.default_details.columns;
+                // Floored: `with_columns(0)` is representable.
+                let col_width = painter.screen_width() / self.default_details.columns.max(1);
                 col_width as usize
             };
 
             // Adjusting the working width of the column based the max line width found
-            // in the menu values
-            if max_width > default_width {
-                self.working_details.col_width = max_width;
-            } else {
-                self.working_details.col_width = default_width;
-            };
+            // in the menu values. Floored: both can be 0 on a 0-width
+            // terminal, and `possible_cols` divides by this.
+            self.working_details.col_width = max_width.max(default_width).max(1);
 
             // The working columns is adjusted based on possible number of columns
             // that could be fitted in the screen with the calculated column width
@@ -663,5 +661,65 @@ impl Menu for DescriptionMenu {
                 self.create_example_string(use_ansi_coloring)
             )
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::painting::{Painter, W};
+    use crate::{Span, Suggestion};
+
+    struct FakeCompleter {
+        completions: Vec<String>,
+    }
+
+    impl Completer for FakeCompleter {
+        fn complete(&mut self, _line: &str, pos: usize) -> crate::CompletionResult {
+            crate::CompletionResult::fresh(
+                self.completions
+                    .iter()
+                    .map(|c| Suggestion {
+                        value: c.to_string(),
+                        span: Span { start: 0, end: pos },
+                        ..Default::default()
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }
+    }
+
+    fn setup_menu(menu: &mut DescriptionMenu, terminal_size: (u16, u16)) {
+        let mut editor = Editor::default();
+        let mut completer = FakeCompleter {
+            completions: ["alpha", "beta", "gamma"].map(String::from).to_vec(),
+        };
+        let mut painter = Painter::new(W::sink());
+        painter.handle_resize(terminal_size.0, terminal_size.1);
+        menu.menu_event(MenuEvent::Activate(false));
+        menu.update_working_details(&mut editor, &mut completer, &painter);
+    }
+
+    /// `with_columns(0)` reaches the layout's screen-width division.
+    #[test]
+    fn zero_configured_columns_does_not_panic_the_layout() {
+        let mut menu = DescriptionMenu::default().with_columns(0);
+        setup_menu(&mut menu, (30, 10));
+        assert!(!menu.menu_string(10, false).is_empty());
+    }
+
+    /// Empty suggestions on a 0-width terminal zero both width candidates,
+    /// and `possible_cols` divides by their max.
+    #[test]
+    fn zero_width_terminal_does_not_panic_the_layout() {
+        let mut menu = DescriptionMenu::default();
+        let mut editor = Editor::default();
+        let mut completer = FakeCompleter {
+            completions: vec![],
+        };
+        let mut painter = Painter::new(W::sink());
+        painter.handle_resize(0, 0);
+        menu.menu_event(MenuEvent::Activate(false));
+        menu.update_working_details(&mut editor, &mut completer, &painter);
     }
 }

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1241,11 +1241,12 @@ impl Painter {
                     // the first line has to deal with the prompt
                     let first_line_len = line.len() + prompt_len;
                     // at least, it is one line
-                    ((first_line_len as u16) / (self.screen_width())) + 1
+                    // max(1): a mid-resize terminal can report width 0 (#842)
+                    ((first_line_len as u16) / self.screen_width().max(1)) + 1
                 }
                 _ => {
                     // the n-th line, no prompt, at least, it is one line
-                    ((line.len() as u16) / self.screen_width()) + 1
+                    ((line.len() as u16) / self.screen_width().max(1)) + 1
                 }
             };
             // count up screen-lines

--- a/src/painting/prompt_lines.rs
+++ b/src/painting/prompt_lines.rs
@@ -113,7 +113,9 @@ impl<'prompt> PromptLines<'prompt> {
         let cursor_y = (estimate_required_lines(&buffer_width_prompt, terminal_columns) as u16)
             .saturating_sub(1); // 0 based
 
-        let cursor_x = (total_width % terminal_columns as usize) as u16;
+        // Floored: terminals report a 0 width mid-resize (#842), like
+        // `estimate_single_line_wraps` already handles.
+        let cursor_x = (total_width % terminal_columns.max(1) as usize) as u16;
 
         (cursor_x, cursor_y as u16)
     }
@@ -231,6 +233,15 @@ mod tests {
         "this is a text that contains newlines\n::: and very loooooooooooooooong text that wraps",
         40,
         (8, 3)
+    )]
+    // A mid-resize terminal can report width 0 (#842); the cursor lands on
+    // the home column instead of dividing by zero.
+    #[case(
+        "~/path/",
+        "❯ ",
+        "input",
+        0,
+        (0, 0)
     )]
 
     fn test_cursor_pos(


### PR DESCRIPTION
## Summary

The counterpart of #1186 for the rest of the repo:
a clippy `arithmetic_side_effects` sweep found five more divisions that reach a raw, possibly-zero width.

Terminals report a 0 width mid-resize or over odd ttys,
and `estimate_single_line_wraps` already treats that as no-wrap (#842),
but the cursor-x remainder in `prompt_lines`, the wrap estimate in `print_external_message`,
and the description menu's `possible_cols` still divide by the raw width.
The description menu also divides by the raw `with_columns` value, which 0 is representable for.

All five get the same `.max(1)` floor. No public API change.