### PR TITLE
feat(editor): Add helix match selection

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -372,6 +372,7 @@ impl Editor {
             EditCommand::CutTextObject { text_object } => self.cut_text_object(*text_object),
             EditCommand::CopyTextObject { text_object } => self.copy_text_object(*text_object),
             EditCommand::AddTextObject { text_object } => self.add_text_object(*text_object),
+            EditCommand::RemoveTextObject { text_object } => self.remove_text_object(*text_object),
         }
         let leaves_selection = matches!(command.edit_type(), EditType::MoveCursor { select: true })
             || matches!(command, EditCommand::PasteAtSelectionEdge { .. })
@@ -389,9 +390,10 @@ impl Editor {
         self.commit_cursor();
 
         let new_undo_behavior = match (command, command.edit_type()) {
-            (EditCommand::AddTextObject { .. }, EditType::MoveCursor { .. }) => {
-                UndoBehavior::CreateUndoPoint
-            }
+            (
+                EditCommand::AddTextObject { .. } | EditCommand::RemoveTextObject { .. },
+                EditType::MoveCursor { .. },
+            ) => UndoBehavior::CreateUndoPoint,
             (_, EditType::MoveCursor { .. }) => UndoBehavior::MoveCursor,
             (EditCommand::InsertChar(c), EditType::EditText) => UndoBehavior::InsertCharacter(*c),
             (EditCommand::Delete, EditType::EditText) => {
@@ -1801,6 +1803,38 @@ impl Editor {
         self.line_buffer.set_cursor(cursor_lefted.flip());
         self.line_buffer.insert_char(pair.0);
         self.place(Cursor::new(cursor.anchor() + 1, cursor.head() + 1));
+    }
+
+    fn remove_text_object(&mut self, text_object: TextObjectType) {
+        if !matches!(
+            text_object,
+            TextObjectType::Brackets(_) | TextObjectType::Quotes(_)
+        ) {
+            return;
+        }
+        let cursor = self.line_buffer.cursor();
+        self.line_buffer.set_cursor(Cursor::point(cursor.head()));
+        // TODO: Ya un bug dans la fonction text_object_range,
+        // un range est trouvé lorsque le curseur se trouve hors du text object
+        // inclus brackets et quotes
+        let Some(range) = self.text_object_range(TextObject {
+            scope: TextObjectScope::Inner,
+            object_type: text_object,
+        }) else {
+            self.line_buffer.set_cursor(cursor);
+            return;
+        };
+        self.line_buffer.clear_range(range.end..range.end + 1);
+        self.line_buffer.clear_range(range.start - 1..range.start);
+        let new_cursor = Cursor::new(
+            if cursor.anchor() > range.start {
+                cursor.anchor() - 1
+            } else {
+                cursor.anchor()
+            },
+            cursor.head() - 1,
+        );
+        self.place(new_cursor);
     }
 
     fn select_text_object(&mut self, text_object: TextObject) {

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -7,7 +7,8 @@ use crate::core_editor::graphemes::{next_grapheme_boundary, prev_grapheme_bounda
 use crate::core_editor::resolve::resolve_selection;
 use crate::core_editor::{commit, line, operator_span, resolve_motion, RestPolicy};
 use crate::enums::{
-    EditType, TextObject, TextObjectBracket, TextObjectScope, TextObjectType, UndoBehavior,
+    EditType, TextObject, TextObjectBracket, TextObjectQuote, TextObjectScope, TextObjectType,
+    UndoBehavior,
 };
 use crate::prompt::PromptEditMode;
 use crate::{core_editor::get_local_clipboard, EditCommand};
@@ -1741,9 +1742,19 @@ impl Editor {
     ///
     /// If multiple quote types exist, returns the innermost pair that surrounds
     /// the cursor. Handles empty quotes as zero-length ranges inside quote.
-    fn quote_text_object_range(&self, text_object_scope: TextObjectScope) -> Option<Range<usize>> {
-        const QUOTE_PAIRS: &[(char, char)] = &[('"', '"'), ('\'', '\''), ('`', '`')];
-        self.matching_pair_group_text_object_range(text_object_scope, QUOTE_PAIRS)
+    fn quote_text_object_range(
+        &self,
+        text_object_scope: TextObjectScope,
+        quote_type: TextObjectQuote,
+    ) -> Option<Range<usize>> {
+        const QUOTE_PAIRS: &[(char, char)] = &[('\'', '\''), ('"', '"'), ('`', '`')];
+        let pairs = match quote_type {
+            TextObjectQuote::SingleQuote => &QUOTE_PAIRS[0..1],
+            TextObjectQuote::DoubleQuote => &QUOTE_PAIRS[1..2],
+            TextObjectQuote::Tick => &QUOTE_PAIRS[2..3],
+            TextObjectQuote::All => QUOTE_PAIRS,
+        };
+        self.matching_pair_group_text_object_range(text_object_scope, pairs)
     }
 
     /// Get the bounds for a text object operation
@@ -1754,7 +1765,9 @@ impl Editor {
             TextObjectType::Brackets(brackets_type) => {
                 self.bracket_text_object_range(text_object.scope, brackets_type)
             }
-            TextObjectType::Quote => self.quote_text_object_range(text_object.scope),
+            TextObjectType::Quotes(quote_type) => {
+                self.quote_text_object_range(text_object.scope, quote_type)
+            }
         }
     }
 
@@ -4043,18 +4056,18 @@ mod test {
     // Test text object jumping behavior in various scenarios
     // Cursor inside empty pairs should operate on current pair (cursor stays, nothing cut)
     #[case(r#"foo()bar"#, 4, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBracket::All) }, "foo()bar", 4, "")] // inside empty brackets
-    #[case(r#"foo""bar"#, 4, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "foo\"\"bar", 4, "")] // inside empty quotes
+    #[case(r#"foo""bar"#, 4, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quotes(TextObjectQuote::All) }, "foo\"\"bar", 4, "")] // inside empty quotes
     // Cursor outside pairs should jump to next pair (even if empty)
     #[case(r#"foo ()bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBracket::All) }, "foo ()bar", 5, "")] // jump to empty brackets
-    #[case(r#"foo ""bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "foo \"\"bar", 5, "")] // jump to empty quote
+    #[case(r#"foo ""bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quotes(TextObjectQuote::All) }, "foo \"\"bar", 5, "")] // jump to empty quote
     #[case(r#"foo (content)bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBracket::All) }, "foo ()bar", 5, "content")] // jump to non-empty brackets
-    #[case(r#"foo "content"bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "foo \"\"bar", 5, "content")] // jump to non-empty quotes
+    #[case(r#"foo "content"bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quotes(TextObjectQuote::All) }, "foo \"\"bar", 5, "content")] // jump to non-empty quotes
     // Cursor between pairs should jump to next pair
     #[case(r#"(first) (second)"#, 8, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBracket::All) }, "(first) ()", 9, "second")] // between brackets
-    #[case(r#""first" "second""#, 8, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "\"first\"\"second\"", 7, " ")] // between quotes
+    #[case(r#""first" "second""#, 8, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quotes(TextObjectQuote::All) }, "\"first\"\"second\"", 7, " ")] // between quotes
     // Around scope should include the pair characters
     #[case(r#"foo (bar)"#, 2, TextObject { scope: TextObjectScope::Around, object_type: TextObjectType::Brackets(TextObjectBracket::All) }, "foo ", 4, "(bar)")] // around includes parentheses
-    #[case(r#"foo "bar""#, 2, TextObject { scope: TextObjectScope::Around, object_type: TextObjectType::Quote }, "foo ", 4, "\"bar\"")] // around includes quotes
+    #[case(r#"foo "bar""#, 2, TextObject { scope: TextObjectScope::Around, object_type: TextObjectType::Quotes(TextObjectQuote::All) }, "foo ", 4, "\"bar\"")] // around includes quotes
     fn test_text_object_jumping_behavior(
         #[case] input: &str,
         #[case] cursor_pos: usize,
@@ -4127,64 +4140,103 @@ mod test {
 
     #[rstest]
     // Test quote_text_object_range with Inner scope - just the content inside quotes
-    #[case(r#"foo"bar"baz"#, 5, TextObjectScope::Inner, Some(4..7))] // cursor inside double quotes
-    #[case("foo'bar'baz", 5, TextObjectScope::Inner, Some(4..7))] // single quotes
-    #[case("foo`bar`baz", 5, TextObjectScope::Inner, Some(4..7))] // backticks
-    #[case(r#"foo""bar"#, 4, TextObjectScope::Inner, Some(4..4))] // empty quotes
-    #[case(r#""nested'inner'outer""#, 8, TextObjectScope::Inner, Some(8..13))] // nested, innermost
-    #[case(r#""nested`mixed'inner'backticks`outer""#, 8, TextObjectScope::Inner, Some(8..29))] // nested, innermost
-    #[case(r#"next"nested'mixed`inner`quotes'outer""#, 0, TextObjectScope::Inner, Some(5..36))] // next nested mixed
-    #[case(r#"foo "bar"baz"#, 0, TextObjectScope::Inner, Some(5..8))] // next pair
-    #[case(r#"foo"bar"baz"#, 2, TextObjectScope::Inner, Some(4..7))] // next from inside word
-    #[case(r#"foo"bar"baz"#, 4, TextObjectScope::Around, Some(3..8))] // around includes quotes
-    #[case(r#"foo"bar"baz"#, 3, TextObjectScope::Around, Some(3..8))] // around on opening quote
-    #[case(r#"foo"bar"baz"#, 2, TextObjectScope::Around, Some(3..8))] // around next quotes
-    #[case(r#"foo""bar"#, 4, TextObjectScope::Around, Some(3..5))] // around empty quotes
-    #[case(r#"foo""bar"#, 1, TextObjectScope::Around, Some(3..5))] // around empty quotes
-    #[case(r#""nested"inner"outer""#, 8, TextObjectScope::Around, Some(7..14))] // nested around includes delimiters
-    #[case(r#"start"nested'inner'outer""#, 2, TextObjectScope::Around, Some(5..25))] // Next outer nested pair
-    #[case("no quotes here", 5, TextObjectScope::Inner, None)] // no quotes found
-    #[case(r#"foo"bar"#, 1, TextObjectScope::Inner, None)] // unclosed quote
-    #[case("foo'bar\nbaz'qux", 5, TextObjectScope::Inner, None)] // quotes don't span multiple lines
-    #[case("foo'bar\nbaz'qux", 0, TextObjectScope::Inner, None)] // quotes don't span multiple lines
-    #[case("foobar\n`baz`qux", 6, TextObjectScope::Inner, None)] // quotes don't span multiple lines
-    #[case("foo\n(bar\nbaz)qux", 0, TextObjectScope::Inner, None)] // next multi-line brackets
-    #[case("foo\n(bar\nbaz)qux", 3, TextObjectScope::Around, None)] // next multi-line brackets
+    #[case(r#"foo"bar"baz"#, 5, TextObjectScope::Inner, TextObjectQuote::All, Some(4..7))] // cursor inside double quotes
+    #[case("foo'bar'baz", 5, TextObjectScope::Inner, TextObjectQuote::All, Some(4..7))] // single quotes
+    #[case("foo`bar`baz", 5, TextObjectScope::Inner, TextObjectQuote::All, Some(4..7))] // backticks
+    #[case(r#"foo"bar"baz"#, 5, TextObjectScope::Inner, TextObjectQuote::DoubleQuote, Some(4..7))] // cursor inside double quotes
+    #[case("foo'bar'baz", 5, TextObjectScope::Inner, TextObjectQuote::SingleQuote, Some(4..7))] // single quotes
+    #[case("foo`bar`baz", 5, TextObjectScope::Inner, TextObjectQuote::Tick, Some(4..7))] // backticks
+    #[case(r#"foo""bar"#, 4, TextObjectScope::Inner, TextObjectQuote::All, Some(4..4))] // empty quotes
+    #[case(r#""nested'inner'outer""#, 8, TextObjectScope::Inner, TextObjectQuote::All, Some(8..13))] // nested, innermost
+    #[case(r#""nested`mixed'inner'backticks`outer""#, 8, TextObjectScope::Inner, TextObjectQuote::All, Some(8..29))] // nested, innermost
+    #[case(r#"next"nested'mixed`inner`quotes'outer""#, 0, TextObjectScope::Inner, TextObjectQuote::All, Some(5..36))] // next nested mixed
+    #[case(r#"foo "bar"baz"#, 0, TextObjectScope::Inner, TextObjectQuote::All, Some(5..8))] // next pair
+    #[case(r#"foo"bar"baz"#, 2, TextObjectScope::Inner, TextObjectQuote::All, Some(4..7))] // next from inside word
+    #[case(r#"foo"bar"baz"#, 4, TextObjectScope::Around, TextObjectQuote::All, Some(3..8))] // around includes quotes
+    #[case(r#"foo"bar"baz"#, 3, TextObjectScope::Around, TextObjectQuote::All, Some(3..8))] // around on opening quote
+    #[case(r#"foo"bar"baz"#, 2, TextObjectScope::Around, TextObjectQuote::All, Some(3..8))] // around next quotes
+    #[case(r#"foo""bar"#, 4, TextObjectScope::Around, TextObjectQuote::All, Some(3..5))] // around empty quotes
+    #[case(r#"foo""bar"#, 1, TextObjectScope::Around, TextObjectQuote::All, Some(3..5))] // around empty quotes
+    #[case(r#""nested"inner"outer""#, 8, TextObjectScope::Around, TextObjectQuote::All, Some(7..14))] // nested around includes delimiters
+    #[case(r#"start"nested'inner'outer""#, 2, TextObjectScope::Around, TextObjectQuote::All, Some(5..25))] // Next outer nested pair
+    #[case(
+        "no quotes here",
+        5,
+        TextObjectScope::Inner,
+        TextObjectQuote::All,
+        None
+    )] // no quotes found
+    #[case(r#"foo"bar"#, 1, TextObjectScope::Inner, TextObjectQuote::All, None)] // unclosed quote
+    #[case(
+        "foo'bar\nbaz'qux",
+        5,
+        TextObjectScope::Inner,
+        TextObjectQuote::All,
+        None
+    )] // quotes don't span multiple lines
+    #[case(
+        "foo'bar\nbaz'qux",
+        0,
+        TextObjectScope::Inner,
+        TextObjectQuote::All,
+        None
+    )] // quotes don't span multiple lines
+    #[case(
+        "foobar\n`baz`qux",
+        6,
+        TextObjectScope::Inner,
+        TextObjectQuote::All,
+        None
+    )] // quotes don't span multiple lines
+    #[case(
+        "foo\n(bar\nbaz)qux",
+        0,
+        TextObjectScope::Inner,
+        TextObjectQuote::All,
+        None
+    )] // next multi-line brackets
+    #[case(
+        "foo\n(bar\nbaz)qux",
+        3,
+        TextObjectScope::Around,
+        TextObjectQuote::All,
+        None
+    )] // next multi-line brackets
     fn test_quote_text_object_range(
         #[case] input: &str,
         #[case] cursor_pos: usize,
         #[case] scope: TextObjectScope,
+        #[case] quote_type: TextObjectQuote,
         #[case] expected: Option<std::ops::Range<usize>>,
     ) {
         let mut editor = editor_with(input);
         editor.line_buffer.set_insertion_point(cursor_pos);
-        let result = editor.quote_text_object_range(scope);
+        let result = editor.quote_text_object_range(scope, quote_type);
         assert_eq!(result, expected);
     }
 
     #[rstest]
     // Test edge cases and complex scenarios for both bracket and quote text objects
-    #[case("", 0, TextObjectScope::Inner, TextObjectBracket::All, None, None)] // empty buffer
-    #[case("a", 0, TextObjectScope::Inner, TextObjectBracket::All, None, None)] // single character
-    #[case("()", 1, TextObjectScope::Inner, TextObjectBracket::All, Some(1..1), None)] // empty brackets, cursor inside
-    #[case(r#""""#, 1, TextObjectScope::Inner, TextObjectBracket::All, None, Some(1..1))] // empty quotes, cursor inside
-    #[case("([{}])", 3, TextObjectScope::Inner, TextObjectBracket::All, Some(3..3), None)] // deeply nested brackets
-    #[case(r#""'`text`'""#, 5, TextObjectScope::Inner, TextObjectBracket::All, None, Some(3..7))] // deeply nested quotes
-    #[case("(text) and [more]", 5, TextObjectScope::Around, TextObjectBracket::All, Some(0..6), None)] // multiple bracket types
-    #[case(r#""text" and 'more'"#, 5, TextObjectScope::Around, TextObjectBracket::All, None, Some(0..6))] // multiple quote types
+    #[case("", 0, TextObjectScope::Inner, None, None)] // empty buffer
+    #[case("a", 0, TextObjectScope::Inner, None, None)] // single character
+    #[case("()", 1, TextObjectScope::Inner, Some(1..1), None)] // empty brackets, cursor inside
+    #[case(r#""""#, 1, TextObjectScope::Inner, None, Some(1..1))] // empty quotes, cursor inside
+    #[case("([{}])", 3, TextObjectScope::Inner, Some(3..3), None)] // deeply nested brackets
+    #[case(r#""'`text`'""#, 5, TextObjectScope::Inner, None, Some(3..7))] // deeply nested quotes
+    #[case("(text) and [more]", 5, TextObjectScope::Around, Some(0..6), None)] // multiple bracket types
+    #[case(r#""text" and 'more'"#, 5, TextObjectScope::Around, None, Some(0..6))] // multiple quote types
     fn test_text_object_edge_cases(
         #[case] input: &str,
         #[case] cursor_pos: usize,
         #[case] scope: TextObjectScope,
-        #[case] bracket_type: TextObjectBracket,
         #[case] expected_bracket: Option<std::ops::Range<usize>>,
         #[case] expected_quote: Option<std::ops::Range<usize>>,
     ) {
         let mut editor = editor_with(input);
         editor.move_to_position(cursor_pos, false);
 
-        let bracket_result = editor.bracket_text_object_range(scope, bracket_type);
-        let quote_result = editor.quote_text_object_range(scope);
+        let bracket_result = editor.bracket_text_object_range(scope, TextObjectBracket::All);
+        let quote_result = editor.quote_text_object_range(scope, TextObjectQuote::All);
 
         assert_eq!(bracket_result, expected_bracket);
         assert_eq!(quote_result, expected_quote);

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -6,7 +6,9 @@ use crate::core_editor::get_system_clipboard;
 use crate::core_editor::graphemes::{next_grapheme_boundary, prev_grapheme_boundary};
 use crate::core_editor::resolve::resolve_selection;
 use crate::core_editor::{commit, line, operator_span, resolve_motion, RestPolicy};
-use crate::enums::{EditType, TextObject, TextObjectScope, TextObjectType, UndoBehavior};
+use crate::enums::{
+    EditType, TextObject, TextObjectBrackets, TextObjectScope, TextObjectType, UndoBehavior,
+};
 use crate::prompt::PromptEditMode;
 use crate::{core_editor::get_local_clipboard, EditCommand};
 use crate::{Direction, Granularity, MotionTarget, WordEdge, WordKind};
@@ -176,6 +178,9 @@ impl Editor {
                     self.place(selection);
                 }
             },
+            EditCommand::SelectPair(t) => {
+                todo!();
+            }
             EditCommand::CollapseSelection(direction) => {
                 let cursor = self.line_buffer.cursor();
                 let pos = match direction {
@@ -363,6 +368,7 @@ impl Editor {
             EditCommand::PasteSystem => self.paste_from_system(),
             EditCommand::CutInsidePair { left, right } => self.cut_inside_pair(*left, *right),
             EditCommand::CopyInsidePair { left, right } => self.copy_inside_pair(*left, *right),
+            EditCommand::SelectInsidePair { left, right } => self.select_inside_pair(*left, *right),
             EditCommand::CutAroundPair { left, right } => self.cut_around_pair(*left, *right),
             EditCommand::CopyAroundPair { left, right } => self.copy_around_pair(*left, *right),
             EditCommand::CutTextObject { text_object } => self.cut_text_object(*text_object),
@@ -1712,9 +1718,17 @@ impl Editor {
     fn bracket_text_object_range(
         &self,
         text_object_scope: TextObjectScope,
+        brackets_type: TextObjectBrackets,
     ) -> Option<Range<usize>> {
-        const BRACKET_PAIRS: &[(char, char)] = &[('(', ')'), ('[', ']'), ('{', '}')];
-        self.matching_pair_group_text_object_range(text_object_scope, BRACKET_PAIRS)
+        const BRACKET_PAIRS: &[(char, char)] = &[('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')];
+        let pairs = match brackets_type {
+            TextObjectBrackets::Parenthesis => &BRACKET_PAIRS[0..1],
+            TextObjectBrackets::SquareBrackets => &BRACKET_PAIRS[1..2],
+            TextObjectBrackets::CurlyBrackets => &BRACKET_PAIRS[2..3],
+            TextObjectBrackets::AngleBrackets => &BRACKET_PAIRS[3..4],
+            TextObjectBrackets::All => BRACKET_PAIRS,
+        };
+        self.matching_pair_group_text_object_range(text_object_scope, pairs)
     }
 
     /// Returns `Some(Range<usize>)` for the range inside quotes (`""`, `''` or `\`\`\`)
@@ -1738,7 +1752,9 @@ impl Editor {
         match text_object.object_type {
             TextObjectType::Word => Some(self.word_text_object_range(text_object.scope)),
             TextObjectType::BigWord => Some(self.big_word_text_object_range(text_object.scope)),
-            TextObjectType::Brackets => self.bracket_text_object_range(text_object.scope),
+            TextObjectType::Brackets(brackets_type) => {
+                self.bracket_text_object_range(text_object.scope, brackets_type)
+            }
             TextObjectType::Quote => self.quote_text_object_range(text_object.scope),
         }
     }
@@ -1752,6 +1768,12 @@ impl Editor {
     fn copy_text_object(&mut self, text_object: TextObject) {
         if let Some(range) = self.text_object_range(text_object) {
             self.copy_range(range);
+        }
+    }
+
+    fn select_text_object(&mut self, text_object: TextObject) {
+        if let Some(range) = self.text_object_range(text_object) {
+            self.place(Cursor::new(range.start, range.end));
         }
     }
 
@@ -1891,6 +1913,20 @@ impl Editor {
             })
         {
             self.copy_range(range);
+        }
+    }
+
+    /// Select text strictly between matching `open_char` and `close_char`.
+    fn select_inside_pair(&mut self, open_char: char, close_char: char) {
+        if let Some(range) = self
+            .line_buffer
+            .range_inside_current_pair(open_char, close_char)
+            .or_else(|| {
+                self.line_buffer
+                    .range_inside_next_pair(open_char, close_char)
+            })
+        {
+            self.place(Cursor::new(range.start, range.end));
         }
     }
 
@@ -4021,18 +4057,18 @@ mod test {
     #[rstest]
     // Test text object jumping behavior in various scenarios
     // Cursor inside empty pairs should operate on current pair (cursor stays, nothing cut)
-    #[case(r#"foo()bar"#, 4, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets }, "foo()bar", 4, "")] // inside empty brackets
+    #[case(r#"foo()bar"#, 4, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBrackets::All) }, "foo()bar", 4, "")] // inside empty brackets
     #[case(r#"foo""bar"#, 4, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "foo\"\"bar", 4, "")] // inside empty quotes
     // Cursor outside pairs should jump to next pair (even if empty)
-    #[case(r#"foo ()bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets }, "foo ()bar", 5, "")] // jump to empty brackets
+    #[case(r#"foo ()bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBrackets::All) }, "foo ()bar", 5, "")] // jump to empty brackets
     #[case(r#"foo ""bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "foo \"\"bar", 5, "")] // jump to empty quote
-    #[case(r#"foo (content)bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets }, "foo ()bar", 5, "content")] // jump to non-empty brackets
+    #[case(r#"foo (content)bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBrackets::All) }, "foo ()bar", 5, "content")] // jump to non-empty brackets
     #[case(r#"foo "content"bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "foo \"\"bar", 5, "content")] // jump to non-empty quotes
     // Cursor between pairs should jump to next pair
-    #[case(r#"(first) (second)"#, 8, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets }, "(first) ()", 9, "second")] // between brackets
+    #[case(r#"(first) (second)"#, 8, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBrackets::All) }, "(first) ()", 9, "second")] // between brackets
     #[case(r#""first" "second""#, 8, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "\"first\"\"second\"", 7, " ")] // between quotes
     // Around scope should include the pair characters
-    #[case(r#"foo (bar)"#, 2, TextObject { scope: TextObjectScope::Around, object_type: TextObjectType::Brackets }, "foo ", 4, "(bar)")] // around includes parentheses
+    #[case(r#"foo (bar)"#, 2, TextObject { scope: TextObjectScope::Around, object_type: TextObjectType::Brackets(TextObjectBrackets::All) }, "foo ", 4, "(bar)")] // around includes parentheses
     #[case(r#"foo "bar""#, 2, TextObject { scope: TextObjectScope::Around, object_type: TextObjectType::Quote }, "foo ", 4, "\"bar\"")] // around includes quotes
     fn test_text_object_jumping_behavior(
         #[case] input: &str,
@@ -4052,37 +4088,55 @@ mod test {
 
     #[rstest]
     // Test bracket_text_object_range with Inner scope - just the content inside brackets
-    #[case("foo(bar)baz", 5, TextObjectScope::Inner, Some(4..7))] // cursor inside brackets
-    #[case("foo[bar]baz", 5, TextObjectScope::Inner, Some(4..7))] // square brackets
-    #[case("foo{bar}baz", 5, TextObjectScope::Inner, Some(4..7))] // square brackets
-    #[case("foo()bar", 4, TextObjectScope::Inner, Some(4..4))] // empty brackets
-    #[case("(nested[inner]outer)", 8, TextObjectScope::Inner, Some(8..13))] // nested, innermost
-    #[case("(nested[mixed{inner}brackets]outer)", 8, TextObjectScope::Inner, Some(8..28))] // nested, innermost
-    #[case("next(nested[mixed{inner}brackets]outer)", 0, TextObjectScope::Inner, Some(5..38))] // next nested mixed
-    #[case("foo (bar)baz", 0, TextObjectScope::Inner, Some(5..8))] // next pair from line start
-    #[case("    (bar)baz", 1, TextObjectScope::Inner, Some(5..8))] // next pair from whitespace
-    #[case("foo(bar)baz", 2, TextObjectScope::Inner, Some(4..7))] // next pair from word
-    #[case("foo(bar\nbaz)qux", 8, TextObjectScope::Inner, Some(4..11))] // multi-line brackets
-    #[case("foo\n(bar\nbaz)qux", 0, TextObjectScope::Inner, Some(5..12))] // next multi-line brackets
-    #[case("foo\n(bar\nbaz)qux", 3, TextObjectScope::Around, Some(4..13))] // next multi-line brackets
-    #[case("{hello}", 3, TextObjectScope::Around, Some(0..7))] // includes curly brackets
-    #[case("foo()bar", 4, TextObjectScope::Around, Some(3..5))] // around empty brackets
-    #[case("(nested(inner)outer)", 8, TextObjectScope::Around, Some(7..14))] // nested around includes delimiters
-    #[case("start(nested(inner)outer)", 2, TextObjectScope::Around, Some(5..25))] // Next outer nested pair
-    #[case("(mixed{nested)brackets", 1, TextObjectScope::Inner, Some(1..13))] // mixed nesting
-    #[case("(unclosed(nested)brackets", 1, TextObjectScope::Inner, Some(10..16))] // unclosed bracket, find next closed
-    #[case("no brackets here", 5, TextObjectScope::Inner, None)] // no brackets found
-    #[case("(unclosed", 1, TextObjectScope::Inner, None)] // unclosed bracket
-    #[case("(mismatched}", 1, TextObjectScope::Inner, None)] // mismatched brackets
+    #[case("foo(bar)baz", 5, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..7))] // cursor inside brackets
+    #[case("foo[bar]baz", 5, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..7))] // square brackets
+    #[case("foo{bar}baz", 5, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..7))] // curly brackets
+    #[case("foo<bar>baz", 5, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..7))] // angle brackets
+    #[case("foo(bar)baz", 5, TextObjectScope::Inner, TextObjectBrackets::Parenthesis, Some(4..7))] // cursor inside brackets
+    #[case("foo[bar]baz", 5, TextObjectScope::Inner, TextObjectBrackets::SquareBrackets, Some(4..7))] // square brackets
+    #[case("foo{bar}baz", 5, TextObjectScope::Inner, TextObjectBrackets::CurlyBrackets, Some(4..7))] // curly brackets
+    #[case("foo<bar>baz", 5, TextObjectScope::Inner, TextObjectBrackets::AngleBrackets, Some(4..7))] // angle brackets
+    #[case("foo()bar", 4, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..4))] // empty brackets
+    #[case("(nested[inner]outer)", 8, TextObjectScope::Inner, TextObjectBrackets::All, Some(8..13))] // nested, innermost
+    #[case("(nested[mixed{inner}brackets]outer)", 8, TextObjectScope::Inner, TextObjectBrackets::All, Some(8..28))] // nested, innermost
+    #[case("next(nested[mixed{inner}brackets]outer)", 0, TextObjectScope::Inner, TextObjectBrackets::All, Some(5..38))] // next nested mixed
+    #[case("foo (bar)baz", 0, TextObjectScope::Inner, TextObjectBrackets::All, Some(5..8))] // next pair from line start
+    #[case("    (bar)baz", 1, TextObjectScope::Inner, TextObjectBrackets::All, Some(5..8))] // next pair from whitespace
+    #[case("foo(bar)baz", 2, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..7))] // next pair from word
+    #[case("foo(bar\nbaz)qux", 8, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..11))] // multi-line brackets
+    #[case("foo\n(bar\nbaz)qux", 0, TextObjectScope::Inner, TextObjectBrackets::All, Some(5..12))] // next multi-line brackets
+    #[case("foo\n(bar\nbaz)qux", 3, TextObjectScope::Around, TextObjectBrackets::All, Some(4..13))] // next multi-line brackets
+    #[case("{hello}", 3, TextObjectScope::Around, TextObjectBrackets::All, Some(0..7))] // includes curly brackets
+    #[case("foo()bar", 4, TextObjectScope::Around, TextObjectBrackets::All, Some(3..5))] // around empty brackets
+    #[case("(nested(inner)outer)", 8, TextObjectScope::Around, TextObjectBrackets::All, Some(7..14))] // nested around includes delimiters
+    #[case("start(nested(inner)outer)", 2, TextObjectScope::Around, TextObjectBrackets::All, Some(5..25))] // Next outer nested pair
+    #[case("(mixed{nested)brackets", 1, TextObjectScope::Inner, TextObjectBrackets::All, Some(1..13))] // mixed nesting
+    #[case("(unclosed(nested)brackets", 1, TextObjectScope::Inner, TextObjectBrackets::All, Some(10..16))] // unclosed bracket, find next closed
+    #[case(
+        "no brackets here",
+        5,
+        TextObjectScope::Inner,
+        TextObjectBrackets::All,
+        None
+    )] // no brackets found
+    #[case("(unclosed", 1, TextObjectScope::Inner, TextObjectBrackets::All, None)] // unclosed bracket
+    #[case(
+        "(mismatched}",
+        1,
+        TextObjectScope::Inner,
+        TextObjectBrackets::All,
+        None
+    )] // mismatched brackets
     fn test_bracket_text_object_range(
         #[case] input: &str,
         #[case] cursor_pos: usize,
         #[case] scope: TextObjectScope,
+        #[case] bracket_type: TextObjectBrackets,
         #[case] expected: Option<std::ops::Range<usize>>,
     ) {
         let mut editor = editor_with(input);
         editor.move_to_position(cursor_pos, false);
-        let result = editor.bracket_text_object_range(scope);
+        let result = editor.bracket_text_object_range(scope, bracket_type);
         assert_eq!(result, expected);
     }
 
@@ -4125,25 +4179,26 @@ mod test {
 
     #[rstest]
     // Test edge cases and complex scenarios for both bracket and quote text objects
-    #[case("", 0, TextObjectScope::Inner, None, None)] // empty buffer
-    #[case("a", 0, TextObjectScope::Inner, None, None)] // single character
-    #[case("()", 1, TextObjectScope::Inner, Some(1..1), None)] // empty brackets, cursor inside
-    #[case(r#""""#, 1, TextObjectScope::Inner, None, Some(1..1))] // empty quotes, cursor inside
-    #[case("([{}])", 3, TextObjectScope::Inner, Some(3..3), None)] // deeply nested brackets
-    #[case(r#""'`text`'""#, 5, TextObjectScope::Inner, None, Some(3..7))] // deeply nested quotes
-    #[case("(text) and [more]", 5, TextObjectScope::Around, Some(0..6), None)] // multiple bracket types
-    #[case(r#""text" and 'more'"#, 5, TextObjectScope::Around, None, Some(0..6))] // multiple quote types
+    #[case("", 0, TextObjectScope::Inner, TextObjectBrackets::All, None, None)] // empty buffer
+    #[case("a", 0, TextObjectScope::Inner, TextObjectBrackets::All, None, None)] // single character
+    #[case("()", 1, TextObjectScope::Inner, TextObjectBrackets::All, Some(1..1), None)] // empty brackets, cursor inside
+    #[case(r#""""#, 1, TextObjectScope::Inner, TextObjectBrackets::All, None, Some(1..1))] // empty quotes, cursor inside
+    #[case("([{}])", 3, TextObjectScope::Inner, TextObjectBrackets::All, Some(3..3), None)] // deeply nested brackets
+    #[case(r#""'`text`'""#, 5, TextObjectScope::Inner, TextObjectBrackets::All, None, Some(3..7))] // deeply nested quotes
+    #[case("(text) and [more]", 5, TextObjectScope::Around, TextObjectBrackets::All, Some(0..6), None)] // multiple bracket types
+    #[case(r#""text" and 'more'"#, 5, TextObjectScope::Around, TextObjectBrackets::All, None, Some(0..6))] // multiple quote types
     fn test_text_object_edge_cases(
         #[case] input: &str,
         #[case] cursor_pos: usize,
         #[case] scope: TextObjectScope,
+        #[case] bracket_type: TextObjectBrackets,
         #[case] expected_bracket: Option<std::ops::Range<usize>>,
         #[case] expected_quote: Option<std::ops::Range<usize>>,
     ) {
         let mut editor = editor_with(input);
         editor.move_to_position(cursor_pos, false);
 
-        let bracket_result = editor.bracket_text_object_range(scope);
+        let bracket_result = editor.bracket_text_object_range(scope, bracket_type);
         let quote_result = editor.quote_text_object_range(scope);
 
         assert_eq!(bracket_result, expected_bracket);

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -1797,7 +1797,7 @@ impl Editor {
         self.line_buffer.insert_char(pair.1);
         self.line_buffer.set_cursor(cursor_lefted.flip());
         self.line_buffer.insert_char(pair.0);
-        self.line_buffer.set_cursor(cursor);
+        self.place(Cursor::new(cursor.anchor() + 1, cursor.head() + 1));
     }
 
     fn select_text_object(&mut self, text_object: TextObject) {

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -178,8 +178,8 @@ impl Editor {
                     self.place(selection);
                 }
             },
-            EditCommand::SelectPair(t) => {
-                todo!();
+            EditCommand::SelectTextObject(t) => {
+                self.select_text_object(*t);
             }
             EditCommand::CollapseSelection(direction) => {
                 let cursor = self.line_buffer.cursor();

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -373,6 +373,7 @@ impl Editor {
             EditCommand::CopyAroundPair { left, right } => self.copy_around_pair(*left, *right),
             EditCommand::CutTextObject { text_object } => self.cut_text_object(*text_object),
             EditCommand::CopyTextObject { text_object } => self.copy_text_object(*text_object),
+            EditCommand::AddTextObject { text_object } => self.add_text_object(*text_object),
         }
         let leaves_selection = matches!(command.edit_type(), EditType::MoveCursor { select: true })
             || matches!(command, EditCommand::PasteAtSelectionEdge { .. })
@@ -1781,6 +1782,26 @@ impl Editor {
         if let Some(range) = self.text_object_range(text_object) {
             self.copy_range(range);
         }
+    }
+
+    fn add_text_object(&mut self, text_object: TextObjectType) {
+        let pair = match text_object {
+            TextObjectType::Brackets(TextObjectBracket::Parenthesis) => ('(', ')'),
+            TextObjectType::Brackets(TextObjectBracket::SquareBracket) => ('[', ']'),
+            TextObjectType::Brackets(TextObjectBracket::CurlyBracket) => ('{', '}'),
+            TextObjectType::Brackets(TextObjectBracket::AngleBracket) => ('<', '>'),
+            TextObjectType::Quotes(TextObjectQuote::SingleQuote) => ('\'', '\''),
+            TextObjectType::Quotes(TextObjectQuote::DoubleQuote) => ('"', '"'),
+            TextObjectType::Quotes(TextObjectQuote::Tick) => ('`', '`'),
+            _ => return,
+        };
+        let cursor = self.line_buffer.cursor();
+        let cursor_lefted = cursor.with_direction(super::cursor::Direction::Forward);
+        self.line_buffer.set_cursor(cursor_lefted);
+        self.line_buffer.insert_char(pair.1);
+        self.line_buffer.set_cursor(cursor_lefted.flip());
+        self.line_buffer.insert_char(pair.0);
+        self.line_buffer.set_cursor(cursor);
     }
 
     fn select_text_object(&mut self, text_object: TextObject) {

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -1797,10 +1797,10 @@ impl Editor {
             _ => return,
         };
         let cursor = self.line_buffer.cursor();
-        let cursor_lefted = cursor.with_direction(super::cursor::Direction::Forward);
-        self.line_buffer.set_cursor(cursor_lefted);
+        let cursor_left = cursor.with_direction(super::cursor::Direction::Forward);
+        self.line_buffer.set_cursor(cursor_left);
         self.line_buffer.insert_char(pair.1);
-        self.line_buffer.set_cursor(cursor_lefted.flip());
+        self.line_buffer.set_cursor(cursor_left.flip());
         self.line_buffer.insert_char(pair.0);
         self.place(Cursor::new(cursor.anchor() + 1, cursor.head() + 1));
     }

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -1814,9 +1814,6 @@ impl Editor {
         }
         let cursor = self.line_buffer.cursor();
         self.line_buffer.set_cursor(Cursor::point(cursor.head()));
-        // TODO: Ya un bug dans la fonction text_object_range,
-        // un range est trouvé lorsque le curseur se trouve hors du text object
-        // inclus brackets et quotes
         let Some(range) = self.text_object_range(TextObject {
             scope: TextObjectScope::Inner,
             object_type: text_object,

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -365,10 +365,6 @@ impl Editor {
             EditCommand::CopySelectionSystem => self.copy_selection_to_system(),
             #[cfg(feature = "system_clipboard")]
             EditCommand::PasteSystem => self.paste_from_system(),
-            EditCommand::CutInsidePair { left, right } => self.cut_inside_pair(*left, *right),
-            EditCommand::CopyInsidePair { left, right } => self.copy_inside_pair(*left, *right),
-            EditCommand::CutAroundPair { left, right } => self.cut_around_pair(*left, *right),
-            EditCommand::CopyAroundPair { left, right } => self.copy_around_pair(*left, *right),
             EditCommand::CutTextObject { text_object } => self.cut_text_object(*text_object),
             EditCommand::CopyTextObject { text_object } => self.copy_text_object(*text_object),
             EditCommand::AddTextObject { text_object } => self.add_text_object(*text_object),

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -4167,87 +4167,250 @@ mod test {
     }
 
     #[rstest]
-    #[case("", 0..0, TextObjectType::Quotes(TextObjectQuote::DoubleQuote), "\"\"")] // add text object in an empty buffer
-    #[case("", 0..0, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "{}")] // add another type of text object in an empty buffer
-    #[case("text", 0..4, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "{text}")] // add a text object around a word
-    #[case("text", 0..1, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "{t}ext")] // add a text object around a character
-    #[case("text", 0..4, TextObjectType::Word, "text")] // Attempting to add a "word" around a word, which won't do anything
-    #[case("text", 0..4, TextObjectType::BigWord, "text")] // Attempting to add a "big word" around a word, which won't do anything
-    #[case("text1 text2 text3", 6..11, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {text2} text3")] // Add a text object around a word in the middle of the buffer
-    #[case("text1 {text2} text3", 7..12, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {{text2}} text3")] // Add a new text object around a word inside of the same text object
+    #[case(
+        "",
+        Cursor::new(0, 0),
+        TextObjectType::Quotes(TextObjectQuote::DoubleQuote),
+        "\"\""
+    )] // add text object in an empty buffer
+    #[case(
+        "",
+        Cursor::new(0, 0),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "{}"
+    )] // add another type of text object in an empty buffer
+    #[case(
+        "text",
+        Cursor::new(0, 4),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "{text}"
+    )] // add a text object around a word
+    #[case(
+        "text",
+        Cursor::new(0, 1),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "{t}ext"
+    )] // add a text object around a character
+    #[case("text", Cursor::new(0, 4), TextObjectType::Word, "text")] // Attempting to add a "word" around a word, which won't do anything
+    #[case("text", Cursor::new(0, 4), TextObjectType::BigWord, "text")] // Attempting to add a "big word" around a word, which won't do anything
+    #[case(
+        "text1 text2 text3",
+        Cursor::new(6, 11),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "text1 {text2} text3"
+    )] // Add a text object around a word in the middle of the buffer
+    #[case(
+        "text1 {text2} text3",
+        Cursor::new(7, 12),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "text1 {{text2}} text3"
+    )] // Add a new text object around a word inside of the same text object
     fn test_add_text_object(
         #[case] input: &str,
-        #[case] cursor_range: Range<usize>,
+        #[case] cursor: Cursor,
         #[case] object_type: TextObjectType,
         #[case] expected_output: &str,
     ) {
         let mut editor = editor_with(input);
-        editor.place(Cursor::new(cursor_range.start, cursor_range.end));
+        editor.place(cursor);
 
         editor.add_text_object(object_type);
         let result = editor.get_buffer();
         assert_eq!(result, expected_output);
     }
     #[rstest]
-    #[case("", 0..0, TextObjectType::Quotes(TextObjectQuote::DoubleQuote), "")] // remove text object in an empty buffer
-    #[case("", 0..0, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "")] // remove another type of text object in an empty buffer
-    #[case("{}", 0..1, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "")] // remove another type of text object in an empty buffer
-    #[case("{text}", 0..4, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text")] // remove a text object around a word
-    #[case("{t}ext", 0..1, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text")] // remove a text object around a character
-    #[case("{text}", 0..4, TextObjectType::Word, "{text}")] // Attempting to remove a "word" around a word, which won't do anything
-    #[case("{text}", 0..4, TextObjectType::BigWord, "{text}")] // Attempting to remove a "big word" around a word, which won't do anything
-    #[case("text1 {text2} text3", 6..11, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 text2 text3")] // remove a text object around a word in the middle of the buffer
-    #[case("text1 {{text2}} text3", 7..12, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {text2} text3")]
+    #[case(
+        "",
+        Cursor::new(0, 0),
+        TextObjectType::Quotes(TextObjectQuote::DoubleQuote),
+        ""
+    )] // remove text object in an empty buffer
+    #[case(
+        "",
+        Cursor::new(0, 0),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        ""
+    )] // remove another type of text object in an empty buffer
+    #[case(
+        "{}",
+        Cursor::new(0, 1),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        ""
+    )] // remove another type of text object in an empty buffer
+    #[case(
+        "{text}",
+        Cursor::new(0, 4),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "text"
+    )] // remove a text object around a word
+    #[case(
+        "{t}ext",
+        Cursor::new(0, 1),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "text"
+    )] // remove a text object around a character
+    #[case("{text}", Cursor::new(0, 4), TextObjectType::Word, "{text}")] // Attempting to remove a "word" around a word, which won't do anything
+    #[case("{text}", Cursor::new(0, 4), TextObjectType::BigWord, "{text}")] // Attempting to remove a "big word" around a word, which won't do anything
+    #[case(
+        "text1 {text2} text3",
+        Cursor::new(6, 11),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "text1 text2 text3"
+    )] // remove a text object around a word in the middle of the buffer
+    #[case(
+        "text1 {{text2}} text3",
+        Cursor::new(7, 12),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "text1 {text2} text3"
+    )]
     // remove a new text object around a word inside of the same text object
     // For the following test, removing a text object may occur only around the cursor head
-    #[case("text1 {text2} text3", 0..8, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 text2 text3")] // anchor outside (left), head inside
-    #[case("text1 {text2} text3", 18..8, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 text2 text3")]
+    #[case(
+        "text1 {text2} text3",
+        Cursor::new(0, 8),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "text1 text2 text3"
+    )] // anchor outside (left), head inside
+    #[case(
+        "text1 {text2} text3",
+        Cursor::new(18, 8),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "text1 text2 text3"
+    )]
     // anchor outside (right), head inside
-    // #[case("text1 {text2} text3", 0..2, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 text2 text3")] // anchor outside, head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
-    // #[case("text1 {text2} text3", 16..2, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {text2} text3")] // anchor outside (right), head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
-    #[case("text1 {text2} text3", 18..16, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {text2} text3")] // anchor outside, head outside (right)
-    #[case("text1 {text2} text3", 2..16, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {text2} text3")] // anchor outside (left), head outside (right)
+    // #[case("text1 {text2} text3", Cursor::new(0, 2), TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 text2 text3")] // anchor outside, head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
+    // #[case("text1 {text2} text3", Cursor::new(16, 2), TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {text2} text3")] // anchor outside (right), head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
+    #[case(
+        "text1 {text2} text3",
+        Cursor::new(18, 16),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "text1 {text2} text3"
+    )] // anchor outside, head outside (right)
+    #[case(
+        "text1 {text2} text3",
+        Cursor::new(2, 16),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        "text1 {text2} text3"
+    )] // anchor outside (left), head outside (right)
     fn test_remove_text_object(
         #[case] input: &str,
-        #[case] cursor_range: Range<usize>,
+        #[case] cursor: Cursor,
         #[case] object_type: TextObjectType,
         #[case] expected_output: &str,
     ) {
         let mut editor = editor_with(input);
-        editor.place(Cursor::new(cursor_range.start, cursor_range.end));
+        editor.place(cursor);
 
         editor.remove_text_object(object_type);
         let result = editor.get_buffer();
         assert_eq!(result, expected_output);
     }
     #[rstest]
-    #[case("", 0..0, TextObjectType::Quotes(TextObjectQuote::DoubleQuote), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "")] // replace text object in an empty buffer
-    #[case("", 0..0, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "")] // replace another type of text object in an empty buffer
-    #[case("{}", 0..1, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "()")] // replace a text object surrounded by nothing else
-    #[case("{text}", 0..4, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "(text)")] // replace a text object around a word
-    #[case("{t}ext", 0..1, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "(t)ext")] // replace a text object around a character
-    #[case("{text}", 0..4, TextObjectType::Word, TextObjectType::Brackets(TextObjectBracket::Parenthesis), "{text}")] // Attempting to replace a "word" around a word, which won't do anything
-    #[case("{text}", 0..4, TextObjectType::BigWord, TextObjectType::Brackets(TextObjectBracket::Parenthesis), "{text}")] // Attempting to replace a "big word" around a word, which won't do anything
-    #[case("text1 {text2} text3", 6..11, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 (text2) text3")] // replace a text object around a word in the middle of the buffer
-    #[case("text1 {{text2}} text3", 7..12, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 {(text2)} text3")]
+    #[case(
+        "",
+        Cursor::new(0, 0),
+        TextObjectType::Quotes(TextObjectQuote::DoubleQuote),
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        ""
+    )] // replace text object in an empty buffer
+    #[case(
+        "",
+        Cursor::new(0, 0),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        ""
+    )] // replace another type of text object in an empty buffer
+    #[case(
+        "{}",
+        Cursor::new(0, 1),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        "()"
+    )] // replace a text object surrounded by nothing else
+    #[case(
+        "{text}",
+        Cursor::new(0, 4),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        "(text)"
+    )] // replace a text object around a word
+    #[case(
+        "{t}ext",
+        Cursor::new(0, 1),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        "(t)ext"
+    )] // replace a text object around a character
+    #[case(
+        "{text}",
+        Cursor::new(0, 4),
+        TextObjectType::Word,
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        "{text}"
+    )] // Attempting to replace a "word" around a word, which won't do anything
+    #[case(
+        "{text}",
+        Cursor::new(0, 4),
+        TextObjectType::BigWord,
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        "{text}"
+    )] // Attempting to replace a "big word" around a word, which won't do anything
+    #[case(
+        "text1 {text2} text3",
+        Cursor::new(6, 11),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        "text1 (text2) text3"
+    )] // replace a text object around a word in the middle of the buffer
+    #[case(
+        "text1 {{text2}} text3",
+        Cursor::new(7, 12),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        "text1 {(text2)} text3"
+    )]
     // replace a new text object around a word inside of the same text object
     // For the following test, replacing a text object may occur only around the cursor head
-    #[case("text1 {text2} text3", 0..8, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 (text2) text3")] // anchor outside (left), head inside
-    #[case("text1 {text2} text3", 18..8, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 (text2) text3")]
+    #[case(
+        "text1 {text2} text3",
+        Cursor::new(0, 8),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        "text1 (text2) text3"
+    )] // anchor outside (left), head inside
+    #[case(
+        "text1 {text2} text3",
+        Cursor::new(18, 8),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        "text1 (text2) text3"
+    )]
     // anchor outside (right), head inside
-    // #[case("text1 {text2} text3", 0..2, (TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis)), "text1 {text2} text3")] // anchor outside, head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
-    // #[case("text1 {text2} text3", 16..2, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 {text2} text3")] // anchor outside (right), head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
-    #[case("text1 {text2} text3", 18..16, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 {text2} text3")] //
-    #[case("text1 {text2} text3", 2..16, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 {text2} text3")] // anchor outside (left), head outside (right)
+    // #[case("text1 {text2} text3", Cursor::new(0, 2), (TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis)), "text1 {text2} text3")] // anchor outside, head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
+    // #[case("text1 {text2} text3", Cursor::new(16, 2), TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 {text2} text3")] // anchor outside (right), head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
+    #[case(
+        "text1 {text2} text3",
+        Cursor::new(18, 16),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        "text1 {text2} text3"
+    )] //
+    #[case(
+        "text1 {text2} text3",
+        Cursor::new(2, 16),
+        TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+        TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+        "text1 {text2} text3"
+    )] // anchor outside (left), head outside (right)
     fn test_replace_text_object(
         #[case] input: &str,
-        #[case] cursor_range: Range<usize>,
+        #[case] cursor: Cursor,
         #[case] old: TextObjectType,
         #[case] new: TextObjectType,
         #[case] expected_output: &str,
     ) {
         let mut editor = editor_with(input);
-        editor.place(Cursor::new(cursor_range.start, cursor_range.end));
+        editor.place(cursor);
 
         editor.replace_text_object(old, new);
         let result = editor.get_buffer();

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -389,6 +389,9 @@ impl Editor {
         self.commit_cursor();
 
         let new_undo_behavior = match (command, command.edit_type()) {
+            (EditCommand::AddTextObject { .. }, EditType::MoveCursor { .. }) => {
+                UndoBehavior::CreateUndoPoint
+            }
             (_, EditType::MoveCursor { .. }) => UndoBehavior::MoveCursor,
             (EditCommand::InsertChar(c), EditType::EditText) => UndoBehavior::InsertCharacter(*c),
             (EditCommand::Delete, EditType::EditText) => {

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -4351,6 +4351,94 @@ mod test {
         assert_eq!(quote_result, expected_quote);
     }
 
+    #[rstest]
+    #[case("", 0..0, TextObjectType::Quotes(TextObjectQuote::DoubleQuote), "\"\"")] // add text object in an empty buffer
+    #[case("", 0..0, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "{}")] // add another type of text object in an empty buffer
+    #[case("text", 0..4, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "{text}")] // add a text object around a word
+    #[case("text", 0..1, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "{t}ext")] // add a text object around a character
+    #[case("text", 0..4, TextObjectType::Word, "text")] // Attempting to add a "word" around a word, which won't do anything
+    #[case("text", 0..4, TextObjectType::BigWord, "text")] // Attempting to add a "big word" around a word, which won't do anything
+    #[case("text1 text2 text3", 6..11, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {text2} text3")] // Add a text object around a word in the middle of the buffer
+    #[case("text1 {text2} text3", 7..12, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {{text2}} text3")] // Add a new text object around a word inside of the same text object
+    fn test_add_text_object(
+        #[case] input: &str,
+        #[case] cursor_range: Range<usize>,
+        #[case] object_type: TextObjectType,
+        #[case] expected_output: &str,
+    ) {
+        let mut editor = editor_with(input);
+        editor.place(Cursor::new(cursor_range.start, cursor_range.end));
+
+        editor.add_text_object(object_type);
+        let result = editor.get_buffer();
+        assert_eq!(result, expected_output);
+    }
+    #[rstest]
+    #[case("", 0..0, TextObjectType::Quotes(TextObjectQuote::DoubleQuote), "")] // remove text object in an empty buffer
+    #[case("", 0..0, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "")] // remove another type of text object in an empty buffer
+    #[case("{}", 0..1, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "")] // remove another type of text object in an empty buffer
+    #[case("{text}", 0..4, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text")] // remove a text object around a word
+    #[case("{t}ext", 0..1, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text")] // remove a text object around a character
+    #[case("{text}", 0..4, TextObjectType::Word, "{text}")] // Attempting to remove a "word" around a word, which won't do anything
+    #[case("{text}", 0..4, TextObjectType::BigWord, "{text}")] // Attempting to remove a "big word" around a word, which won't do anything
+    #[case("text1 {text2} text3", 6..11, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 text2 text3")] // remove a text object around a word in the middle of the buffer
+    #[case("text1 {{text2}} text3", 7..12, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {text2} text3")]
+    // remove a new text object around a word inside of the same text object
+    // For the following test, removing a text object may occur only around the cursor head
+    #[case("text1 {text2} text3", 0..8, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 text2 text3")] // anchor outside (left), head inside
+    #[case("text1 {text2} text3", 18..8, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 text2 text3")]
+    // anchor outside (right), head inside
+    // #[case("text1 {text2} text3", 0..2, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 text2 text3")] // anchor outside, head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
+    // #[case("text1 {text2} text3", 16..2, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {text2} text3")] // anchor outside (right), head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
+    #[case("text1 {text2} text3", 18..16, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {text2} text3")] // anchor outside, head outside (right)
+    #[case("text1 {text2} text3", 2..16, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), "text1 {text2} text3")] // anchor outside (left), head outside (right)
+    fn test_remove_text_object(
+        #[case] input: &str,
+        #[case] cursor_range: Range<usize>,
+        #[case] object_type: TextObjectType,
+        #[case] expected_output: &str,
+    ) {
+        let mut editor = editor_with(input);
+        editor.place(Cursor::new(cursor_range.start, cursor_range.end));
+
+        editor.remove_text_object(object_type);
+        let result = editor.get_buffer();
+        assert_eq!(result, expected_output);
+    }
+    #[rstest]
+    #[case("", 0..0, TextObjectType::Quotes(TextObjectQuote::DoubleQuote), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "")] // replace text object in an empty buffer
+    #[case("", 0..0, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "")] // replace another type of text object in an empty buffer
+    #[case("{}", 0..1, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "()")] // replace a text object surrounded by nothing else
+    #[case("{text}", 0..4, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "(text)")] // replace a text object around a word
+    #[case("{t}ext", 0..1, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "(t)ext")] // replace a text object around a character
+    #[case("{text}", 0..4, TextObjectType::Word, TextObjectType::Brackets(TextObjectBracket::Parenthesis), "{text}")] // Attempting to replace a "word" around a word, which won't do anything
+    #[case("{text}", 0..4, TextObjectType::BigWord, TextObjectType::Brackets(TextObjectBracket::Parenthesis), "{text}")] // Attempting to replace a "big word" around a word, which won't do anything
+    #[case("text1 {text2} text3", 6..11, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 (text2) text3")] // replace a text object around a word in the middle of the buffer
+    #[case("text1 {{text2}} text3", 7..12, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 {(text2)} text3")]
+    // replace a new text object around a word inside of the same text object
+    // For the following test, replacing a text object may occur only around the cursor head
+    #[case("text1 {text2} text3", 0..8, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 (text2) text3")] // anchor outside (left), head inside
+    #[case("text1 {text2} text3", 18..8, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 (text2) text3")]
+    // anchor outside (right), head inside
+    // #[case("text1 {text2} text3", 0..2, (TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis)), "text1 {text2} text3")] // anchor outside, head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
+    // #[case("text1 {text2} text3", 16..2, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 {text2} text3")] // anchor outside (right), head outside (left) TODO: Bug here, see https://github.com/nushell/reedline/issues/1195
+    #[case("text1 {text2} text3", 18..16, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 {text2} text3")] //
+    #[case("text1 {text2} text3", 2..16, TextObjectType::Brackets(TextObjectBracket::CurlyBracket), TextObjectType::Brackets(TextObjectBracket::Parenthesis), "text1 {text2} text3")] // anchor outside (left), head outside (right)
+    fn test_replace_text_object(
+        #[case] input: &str,
+        #[case] cursor_range: Range<usize>,
+        #[case] old: TextObjectType,
+        #[case] new: TextObjectType,
+        #[case] expected_output: &str,
+    ) {
+        let mut editor = editor_with(input);
+        editor.place(Cursor::new(cursor_range.start, cursor_range.end));
+
+        editor.replace_text_object(old, new);
+        let result = editor.get_buffer();
+        assert_eq!(result, expected_output);
+    }
+
     // --- MotionTarget verbs (Move / Extend / Cut / Copy / Erase) ---
     //
     // These drive the public verbs through the full lowering

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -392,7 +392,9 @@ impl Editor {
 
         let new_undo_behavior = match (command, command.edit_type()) {
             (
-                EditCommand::AddTextObject { .. } | EditCommand::RemoveTextObject { .. },
+                EditCommand::AddTextObject { .. }
+                | EditCommand::RemoveTextObject { .. }
+                | EditCommand::ReplaceTextObject { .. },
                 EditType::MoveCursor { .. },
             ) => UndoBehavior::CreateUndoPoint,
             (_, EditType::MoveCursor { .. }) => UndoBehavior::MoveCursor,

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -368,7 +368,6 @@ impl Editor {
             EditCommand::PasteSystem => self.paste_from_system(),
             EditCommand::CutInsidePair { left, right } => self.cut_inside_pair(*left, *right),
             EditCommand::CopyInsidePair { left, right } => self.copy_inside_pair(*left, *right),
-            EditCommand::SelectInsidePair { left, right } => self.select_inside_pair(*left, *right),
             EditCommand::CutAroundPair { left, right } => self.cut_around_pair(*left, *right),
             EditCommand::CopyAroundPair { left, right } => self.copy_around_pair(*left, *right),
             EditCommand::CutTextObject { text_object } => self.cut_text_object(*text_object),
@@ -1913,20 +1912,6 @@ impl Editor {
             })
         {
             self.copy_range(range);
-        }
-    }
-
-    /// Select text strictly between matching `open_char` and `close_char`.
-    fn select_inside_pair(&mut self, open_char: char, close_char: char) {
-        if let Some(range) = self
-            .line_buffer
-            .range_inside_current_pair(open_char, close_char)
-            .or_else(|| {
-                self.line_buffer
-                    .range_inside_next_pair(open_char, close_char)
-            })
-        {
-            self.place(Cursor::new(range.start, range.end));
         }
     }
 

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -1621,20 +1621,6 @@ impl Editor {
         }
     }
 
-    /// Delete text strictly between matching `open_char` and `close_char`.
-    fn cut_inside_pair(&mut self, open_char: char, close_char: char) {
-        if let Some(range) = self
-            .line_buffer
-            .range_inside_current_pair(open_char, close_char)
-            .or_else(|| {
-                self.line_buffer
-                    .range_inside_next_pair(open_char, close_char)
-            })
-        {
-            self.cut_range(range)
-        }
-    }
-
     /// Return the range of the word under the cursor.
     /// A word consists of a sequence of letters, digits and underscores,
     /// separated with white space.
@@ -1989,56 +1975,12 @@ impl Editor {
         }
     }
 
-    /// Copy text strictly between matching `open_char` and `close_char`.
-    fn copy_inside_pair(&mut self, open_char: char, close_char: char) {
-        if let Some(range) = self
-            .line_buffer
-            .range_inside_current_pair(open_char, close_char)
-            .or_else(|| {
-                self.line_buffer
-                    .range_inside_next_pair(open_char, close_char)
-            })
-        {
-            self.copy_range(range);
-        }
-    }
-
     /// Expand the range to include `open_char` and `close_char`
     fn expand_range_to_include_pair(&self, range: Range<usize>) -> Option<Range<usize>> {
         let start = self.line_buffer.grapheme_left_index_from_pos(range.start);
         let end = self.line_buffer.grapheme_right_index_from_pos(range.end);
 
         Some(start..end)
-    }
-
-    /// Delete text around matching `open_char` and `close_char` (including the pair characters).
-    fn cut_around_pair(&mut self, open_char: char, close_char: char) {
-        if let Some(around_range) = self
-            .line_buffer
-            .range_inside_current_pair(open_char, close_char)
-            .or_else(|| {
-                self.line_buffer
-                    .range_inside_next_pair(open_char, close_char)
-            })
-            .and_then(|range| self.expand_range_to_include_pair(range))
-        {
-            self.cut_range(around_range);
-        }
-    }
-
-    /// Copy text around matching `open_char` and `close_char` (including the pair characters).
-    fn copy_around_pair(&mut self, open_char: char, close_char: char) {
-        if let Some(around_range) = self
-            .line_buffer
-            .range_inside_current_pair(open_char, close_char)
-            .or_else(|| {
-                self.line_buffer
-                    .range_inside_next_pair(open_char, close_char)
-            })
-            .and_then(|range| self.expand_range_to_include_pair(range))
-        {
-            self.copy_range(around_range);
-        }
     }
 }
 
@@ -3605,131 +3547,6 @@ mod test {
             editor.run_edit_command(&EditCommand::PasteSystem);
             pretty_assertions::assert_eq!(editor.line_buffer.len(), s.len() * 2);
         }
-    }
-
-    #[test]
-    fn test_cut_inside_brackets() {
-        let mut editor = editor_with("foo(bar)baz");
-        editor.move_to_position(5, false); // Move inside brackets
-        editor.cut_inside_pair('(', ')');
-        assert_eq!(editor.get_buffer(), "foo()baz");
-        assert_eq!(editor.insertion_point(), 4);
-        assert_eq!(editor.cut_buffer.get().0, "bar");
-
-        // Test with cursor outside brackets
-        let mut editor = editor_with("foo(bar)baz");
-        editor.move_to_position(0, false);
-        editor.cut_inside_pair('(', ')');
-        assert_eq!(editor.get_buffer(), "foo()baz");
-        assert_eq!(editor.insertion_point(), 4);
-        assert_eq!(editor.cut_buffer.get().0, "bar");
-
-        // Test with no matching brackets
-        let mut editor = editor_with("foo bar baz");
-        editor.move_to_position(4, false);
-        editor.cut_inside_pair('(', ')');
-        assert_eq!(editor.get_buffer(), "foo bar baz");
-        assert_eq!(editor.insertion_point(), 4);
-        assert_eq!(editor.cut_buffer.get().0, "");
-    }
-
-    #[test]
-    fn test_cut_inside_quotes() {
-        let mut editor = editor_with("foo\"bar\"baz");
-        editor.move_to_position(5, false); // Move inside quotes
-        editor.cut_inside_pair('"', '"');
-        assert_eq!(editor.get_buffer(), "foo\"\"baz");
-        assert_eq!(editor.insertion_point(), 4);
-        assert_eq!(editor.cut_buffer.get().0, "bar");
-
-        // Test with cursor outside quotes
-        let mut editor = editor_with("foo\"bar\"baz");
-        editor.move_to_position(0, false);
-        editor.cut_inside_pair('"', '"');
-        assert_eq!(editor.get_buffer(), "foo\"\"baz");
-        assert_eq!(editor.insertion_point(), 4);
-        assert_eq!(editor.cut_buffer.get().0, "bar");
-
-        // Test with no matching quotes
-        let mut editor = editor_with("foo bar baz");
-        editor.move_to_position(4, false);
-        editor.cut_inside_pair('"', '"');
-        assert_eq!(editor.get_buffer(), "foo bar baz");
-        assert_eq!(editor.insertion_point(), 4);
-    }
-
-    #[test]
-    fn test_cut_inside_nested() {
-        let mut editor = editor_with("foo(bar(baz)qux)quux");
-        editor.move_to_position(8, false); // Move inside inner brackets
-        editor.cut_inside_pair('(', ')');
-        assert_eq!(editor.get_buffer(), "foo(bar()qux)quux");
-        assert_eq!(editor.insertion_point(), 8);
-        assert_eq!(editor.cut_buffer.get().0, "baz");
-
-        editor.move_to_position(4, false); // Move inside outer brackets
-        editor.cut_inside_pair('(', ')');
-        assert_eq!(editor.get_buffer(), "foo()quux");
-        assert_eq!(editor.insertion_point(), 4);
-        assert_eq!(editor.cut_buffer.get().0, "bar()qux");
-    }
-
-    #[test]
-    fn test_yank_inside_brackets() {
-        let mut editor = editor_with("foo(bar)baz");
-        editor.move_to_position(5, false); // Move inside brackets
-        editor.copy_inside_pair('(', ')');
-        assert_eq!(editor.get_buffer(), "foo(bar)baz"); // Buffer shouldn't change
-        assert_eq!(editor.insertion_point(), 5); // Cursor should return to original position
-
-        // Test yanked content by pasting
-        editor.paste_cut_buffer();
-        assert_eq!(editor.get_buffer(), "foo(bbarar)baz");
-
-        // Test with cursor outside brackets
-        let mut editor = editor_with("foo(bar)baz");
-        editor.move_to_position(0, false);
-        editor.copy_inside_pair('(', ')');
-        assert_eq!(editor.get_buffer(), "foo(bar)baz");
-        assert_eq!(editor.insertion_point(), 0);
-    }
-
-    #[test]
-    fn test_yank_inside_quotes() {
-        let mut editor = editor_with("foo\"bar\"baz");
-        editor.move_to_position(5, false); // Move inside quotes
-        editor.copy_inside_pair('"', '"');
-        assert_eq!(editor.get_buffer(), "foo\"bar\"baz"); // Buffer shouldn't change
-        assert_eq!(editor.insertion_point(), 5); // Cursor should return to original position
-        assert_eq!(editor.cut_buffer.get().0, "bar");
-
-        // Test with no matching quotes
-        let mut editor = editor_with("foo bar baz");
-        editor.move_to_position(4, false);
-        editor.copy_inside_pair('"', '"');
-        assert_eq!(editor.get_buffer(), "foo bar baz");
-        assert_eq!(editor.insertion_point(), 4);
-        assert_eq!(editor.cut_buffer.get().0, "");
-    }
-
-    #[test]
-    fn test_yank_inside_nested() {
-        let mut editor = editor_with("foo(bar(baz)qux)quux");
-        editor.move_to_position(8, false); // Move inside inner brackets
-        editor.copy_inside_pair('(', ')');
-        assert_eq!(editor.get_buffer(), "foo(bar(baz)qux)quux"); // Buffer shouldn't change
-        assert_eq!(editor.insertion_point(), 8);
-        assert_eq!(editor.cut_buffer.get().0, "baz");
-
-        // Test yanked content by pasting
-        editor.paste_cut_buffer();
-        assert_eq!(editor.get_buffer(), "foo(bar(bazbaz)qux)quux");
-
-        editor.move_to_position(4, false); // Move inside outer brackets
-        editor.copy_inside_pair('(', ')');
-        assert_eq!(editor.get_buffer(), "foo(bar(bazbaz)qux)quux");
-        assert_eq!(editor.insertion_point(), 4);
-        assert_eq!(editor.cut_buffer.get().0, "bar(bazbaz)qux");
     }
 
     #[test]

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -7,7 +7,7 @@ use crate::core_editor::graphemes::{next_grapheme_boundary, prev_grapheme_bounda
 use crate::core_editor::resolve::resolve_selection;
 use crate::core_editor::{commit, line, operator_span, resolve_motion, RestPolicy};
 use crate::enums::{
-    EditType, TextObject, TextObjectBrackets, TextObjectScope, TextObjectType, UndoBehavior,
+    EditType, TextObject, TextObjectBracket, TextObjectScope, TextObjectType, UndoBehavior,
 };
 use crate::prompt::PromptEditMode;
 use crate::{core_editor::get_local_clipboard, EditCommand};
@@ -1717,15 +1717,15 @@ impl Editor {
     fn bracket_text_object_range(
         &self,
         text_object_scope: TextObjectScope,
-        brackets_type: TextObjectBrackets,
+        brackets_type: TextObjectBracket,
     ) -> Option<Range<usize>> {
         const BRACKET_PAIRS: &[(char, char)] = &[('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')];
         let pairs = match brackets_type {
-            TextObjectBrackets::Parenthesis => &BRACKET_PAIRS[0..1],
-            TextObjectBrackets::SquareBrackets => &BRACKET_PAIRS[1..2],
-            TextObjectBrackets::CurlyBrackets => &BRACKET_PAIRS[2..3],
-            TextObjectBrackets::AngleBrackets => &BRACKET_PAIRS[3..4],
-            TextObjectBrackets::All => BRACKET_PAIRS,
+            TextObjectBracket::Parenthesis => &BRACKET_PAIRS[0..1],
+            TextObjectBracket::SquareBracket => &BRACKET_PAIRS[1..2],
+            TextObjectBracket::CurlyBracket => &BRACKET_PAIRS[2..3],
+            TextObjectBracket::AngleBracket => &BRACKET_PAIRS[3..4],
+            TextObjectBracket::All => BRACKET_PAIRS,
         };
         self.matching_pair_group_text_object_range(text_object_scope, pairs)
     }
@@ -4042,18 +4042,18 @@ mod test {
     #[rstest]
     // Test text object jumping behavior in various scenarios
     // Cursor inside empty pairs should operate on current pair (cursor stays, nothing cut)
-    #[case(r#"foo()bar"#, 4, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBrackets::All) }, "foo()bar", 4, "")] // inside empty brackets
+    #[case(r#"foo()bar"#, 4, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBracket::All) }, "foo()bar", 4, "")] // inside empty brackets
     #[case(r#"foo""bar"#, 4, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "foo\"\"bar", 4, "")] // inside empty quotes
     // Cursor outside pairs should jump to next pair (even if empty)
-    #[case(r#"foo ()bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBrackets::All) }, "foo ()bar", 5, "")] // jump to empty brackets
+    #[case(r#"foo ()bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBracket::All) }, "foo ()bar", 5, "")] // jump to empty brackets
     #[case(r#"foo ""bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "foo \"\"bar", 5, "")] // jump to empty quote
-    #[case(r#"foo (content)bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBrackets::All) }, "foo ()bar", 5, "content")] // jump to non-empty brackets
+    #[case(r#"foo (content)bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBracket::All) }, "foo ()bar", 5, "content")] // jump to non-empty brackets
     #[case(r#"foo "content"bar"#, 2, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "foo \"\"bar", 5, "content")] // jump to non-empty quotes
     // Cursor between pairs should jump to next pair
-    #[case(r#"(first) (second)"#, 8, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBrackets::All) }, "(first) ()", 9, "second")] // between brackets
+    #[case(r#"(first) (second)"#, 8, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Brackets(TextObjectBracket::All) }, "(first) ()", 9, "second")] // between brackets
     #[case(r#""first" "second""#, 8, TextObject { scope: TextObjectScope::Inner, object_type: TextObjectType::Quote }, "\"first\"\"second\"", 7, " ")] // between quotes
     // Around scope should include the pair characters
-    #[case(r#"foo (bar)"#, 2, TextObject { scope: TextObjectScope::Around, object_type: TextObjectType::Brackets(TextObjectBrackets::All) }, "foo ", 4, "(bar)")] // around includes parentheses
+    #[case(r#"foo (bar)"#, 2, TextObject { scope: TextObjectScope::Around, object_type: TextObjectType::Brackets(TextObjectBracket::All) }, "foo ", 4, "(bar)")] // around includes parentheses
     #[case(r#"foo "bar""#, 2, TextObject { scope: TextObjectScope::Around, object_type: TextObjectType::Quote }, "foo ", 4, "\"bar\"")] // around includes quotes
     fn test_text_object_jumping_behavior(
         #[case] input: &str,
@@ -4073,50 +4073,50 @@ mod test {
 
     #[rstest]
     // Test bracket_text_object_range with Inner scope - just the content inside brackets
-    #[case("foo(bar)baz", 5, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..7))] // cursor inside brackets
-    #[case("foo[bar]baz", 5, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..7))] // square brackets
-    #[case("foo{bar}baz", 5, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..7))] // curly brackets
-    #[case("foo<bar>baz", 5, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..7))] // angle brackets
-    #[case("foo(bar)baz", 5, TextObjectScope::Inner, TextObjectBrackets::Parenthesis, Some(4..7))] // cursor inside brackets
-    #[case("foo[bar]baz", 5, TextObjectScope::Inner, TextObjectBrackets::SquareBrackets, Some(4..7))] // square brackets
-    #[case("foo{bar}baz", 5, TextObjectScope::Inner, TextObjectBrackets::CurlyBrackets, Some(4..7))] // curly brackets
-    #[case("foo<bar>baz", 5, TextObjectScope::Inner, TextObjectBrackets::AngleBrackets, Some(4..7))] // angle brackets
-    #[case("foo()bar", 4, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..4))] // empty brackets
-    #[case("(nested[inner]outer)", 8, TextObjectScope::Inner, TextObjectBrackets::All, Some(8..13))] // nested, innermost
-    #[case("(nested[mixed{inner}brackets]outer)", 8, TextObjectScope::Inner, TextObjectBrackets::All, Some(8..28))] // nested, innermost
-    #[case("next(nested[mixed{inner}brackets]outer)", 0, TextObjectScope::Inner, TextObjectBrackets::All, Some(5..38))] // next nested mixed
-    #[case("foo (bar)baz", 0, TextObjectScope::Inner, TextObjectBrackets::All, Some(5..8))] // next pair from line start
-    #[case("    (bar)baz", 1, TextObjectScope::Inner, TextObjectBrackets::All, Some(5..8))] // next pair from whitespace
-    #[case("foo(bar)baz", 2, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..7))] // next pair from word
-    #[case("foo(bar\nbaz)qux", 8, TextObjectScope::Inner, TextObjectBrackets::All, Some(4..11))] // multi-line brackets
-    #[case("foo\n(bar\nbaz)qux", 0, TextObjectScope::Inner, TextObjectBrackets::All, Some(5..12))] // next multi-line brackets
-    #[case("foo\n(bar\nbaz)qux", 3, TextObjectScope::Around, TextObjectBrackets::All, Some(4..13))] // next multi-line brackets
-    #[case("{hello}", 3, TextObjectScope::Around, TextObjectBrackets::All, Some(0..7))] // includes curly brackets
-    #[case("foo()bar", 4, TextObjectScope::Around, TextObjectBrackets::All, Some(3..5))] // around empty brackets
-    #[case("(nested(inner)outer)", 8, TextObjectScope::Around, TextObjectBrackets::All, Some(7..14))] // nested around includes delimiters
-    #[case("start(nested(inner)outer)", 2, TextObjectScope::Around, TextObjectBrackets::All, Some(5..25))] // Next outer nested pair
-    #[case("(mixed{nested)brackets", 1, TextObjectScope::Inner, TextObjectBrackets::All, Some(1..13))] // mixed nesting
-    #[case("(unclosed(nested)brackets", 1, TextObjectScope::Inner, TextObjectBrackets::All, Some(10..16))] // unclosed bracket, find next closed
+    #[case("foo(bar)baz", 5, TextObjectScope::Inner, TextObjectBracket::All, Some(4..7))] // cursor inside brackets
+    #[case("foo[bar]baz", 5, TextObjectScope::Inner, TextObjectBracket::All, Some(4..7))] // square brackets
+    #[case("foo{bar}baz", 5, TextObjectScope::Inner, TextObjectBracket::All, Some(4..7))] // curly brackets
+    #[case("foo<bar>baz", 5, TextObjectScope::Inner, TextObjectBracket::All, Some(4..7))] // angle brackets
+    #[case("foo(bar)baz", 5, TextObjectScope::Inner, TextObjectBracket::Parenthesis, Some(4..7))] // cursor inside brackets
+    #[case("foo[bar]baz", 5, TextObjectScope::Inner, TextObjectBracket::SquareBracket, Some(4..7))] // square brackets
+    #[case("foo{bar}baz", 5, TextObjectScope::Inner, TextObjectBracket::CurlyBracket, Some(4..7))] // curly brackets
+    #[case("foo<bar>baz", 5, TextObjectScope::Inner, TextObjectBracket::AngleBracket, Some(4..7))] // angle brackets
+    #[case("foo()bar", 4, TextObjectScope::Inner, TextObjectBracket::All, Some(4..4))] // empty brackets
+    #[case("(nested[inner]outer)", 8, TextObjectScope::Inner, TextObjectBracket::All, Some(8..13))] // nested, innermost
+    #[case("(nested[mixed{inner}brackets]outer)", 8, TextObjectScope::Inner, TextObjectBracket::All, Some(8..28))] // nested, innermost
+    #[case("next(nested[mixed{inner}brackets]outer)", 0, TextObjectScope::Inner, TextObjectBracket::All, Some(5..38))] // next nested mixed
+    #[case("foo (bar)baz", 0, TextObjectScope::Inner, TextObjectBracket::All, Some(5..8))] // next pair from line start
+    #[case("    (bar)baz", 1, TextObjectScope::Inner, TextObjectBracket::All, Some(5..8))] // next pair from whitespace
+    #[case("foo(bar)baz", 2, TextObjectScope::Inner, TextObjectBracket::All, Some(4..7))] // next pair from word
+    #[case("foo(bar\nbaz)qux", 8, TextObjectScope::Inner, TextObjectBracket::All, Some(4..11))] // multi-line brackets
+    #[case("foo\n(bar\nbaz)qux", 0, TextObjectScope::Inner, TextObjectBracket::All, Some(5..12))] // next multi-line brackets
+    #[case("foo\n(bar\nbaz)qux", 3, TextObjectScope::Around, TextObjectBracket::All, Some(4..13))] // next multi-line brackets
+    #[case("{hello}", 3, TextObjectScope::Around, TextObjectBracket::All, Some(0..7))] // includes curly brackets
+    #[case("foo()bar", 4, TextObjectScope::Around, TextObjectBracket::All, Some(3..5))] // around empty brackets
+    #[case("(nested(inner)outer)", 8, TextObjectScope::Around, TextObjectBracket::All, Some(7..14))] // nested around includes delimiters
+    #[case("start(nested(inner)outer)", 2, TextObjectScope::Around, TextObjectBracket::All, Some(5..25))] // Next outer nested pair
+    #[case("(mixed{nested)brackets", 1, TextObjectScope::Inner, TextObjectBracket::All, Some(1..13))] // mixed nesting
+    #[case("(unclosed(nested)brackets", 1, TextObjectScope::Inner, TextObjectBracket::All, Some(10..16))] // unclosed bracket, find next closed
     #[case(
         "no brackets here",
         5,
         TextObjectScope::Inner,
-        TextObjectBrackets::All,
+        TextObjectBracket::All,
         None
     )] // no brackets found
-    #[case("(unclosed", 1, TextObjectScope::Inner, TextObjectBrackets::All, None)] // unclosed bracket
+    #[case("(unclosed", 1, TextObjectScope::Inner, TextObjectBracket::All, None)] // unclosed bracket
     #[case(
         "(mismatched}",
         1,
         TextObjectScope::Inner,
-        TextObjectBrackets::All,
+        TextObjectBracket::All,
         None
     )] // mismatched brackets
     fn test_bracket_text_object_range(
         #[case] input: &str,
         #[case] cursor_pos: usize,
         #[case] scope: TextObjectScope,
-        #[case] bracket_type: TextObjectBrackets,
+        #[case] bracket_type: TextObjectBracket,
         #[case] expected: Option<std::ops::Range<usize>>,
     ) {
         let mut editor = editor_with(input);
@@ -4164,19 +4164,19 @@ mod test {
 
     #[rstest]
     // Test edge cases and complex scenarios for both bracket and quote text objects
-    #[case("", 0, TextObjectScope::Inner, TextObjectBrackets::All, None, None)] // empty buffer
-    #[case("a", 0, TextObjectScope::Inner, TextObjectBrackets::All, None, None)] // single character
-    #[case("()", 1, TextObjectScope::Inner, TextObjectBrackets::All, Some(1..1), None)] // empty brackets, cursor inside
-    #[case(r#""""#, 1, TextObjectScope::Inner, TextObjectBrackets::All, None, Some(1..1))] // empty quotes, cursor inside
-    #[case("([{}])", 3, TextObjectScope::Inner, TextObjectBrackets::All, Some(3..3), None)] // deeply nested brackets
-    #[case(r#""'`text`'""#, 5, TextObjectScope::Inner, TextObjectBrackets::All, None, Some(3..7))] // deeply nested quotes
-    #[case("(text) and [more]", 5, TextObjectScope::Around, TextObjectBrackets::All, Some(0..6), None)] // multiple bracket types
-    #[case(r#""text" and 'more'"#, 5, TextObjectScope::Around, TextObjectBrackets::All, None, Some(0..6))] // multiple quote types
+    #[case("", 0, TextObjectScope::Inner, TextObjectBracket::All, None, None)] // empty buffer
+    #[case("a", 0, TextObjectScope::Inner, TextObjectBracket::All, None, None)] // single character
+    #[case("()", 1, TextObjectScope::Inner, TextObjectBracket::All, Some(1..1), None)] // empty brackets, cursor inside
+    #[case(r#""""#, 1, TextObjectScope::Inner, TextObjectBracket::All, None, Some(1..1))] // empty quotes, cursor inside
+    #[case("([{}])", 3, TextObjectScope::Inner, TextObjectBracket::All, Some(3..3), None)] // deeply nested brackets
+    #[case(r#""'`text`'""#, 5, TextObjectScope::Inner, TextObjectBracket::All, None, Some(3..7))] // deeply nested quotes
+    #[case("(text) and [more]", 5, TextObjectScope::Around, TextObjectBracket::All, Some(0..6), None)] // multiple bracket types
+    #[case(r#""text" and 'more'"#, 5, TextObjectScope::Around, TextObjectBracket::All, None, Some(0..6))] // multiple quote types
     fn test_text_object_edge_cases(
         #[case] input: &str,
         #[case] cursor_pos: usize,
         #[case] scope: TextObjectScope,
-        #[case] bracket_type: TextObjectBrackets,
+        #[case] bracket_type: TextObjectBracket,
         #[case] expected_bracket: Option<std::ops::Range<usize>>,
         #[case] expected_quote: Option<std::ops::Range<usize>>,
     ) {

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -373,6 +373,7 @@ impl Editor {
             EditCommand::CopyTextObject { text_object } => self.copy_text_object(*text_object),
             EditCommand::AddTextObject { text_object } => self.add_text_object(*text_object),
             EditCommand::RemoveTextObject { text_object } => self.remove_text_object(*text_object),
+            EditCommand::ReplaceTextObject { old, new } => self.replace_text_object(*old, *new),
         }
         let leaves_selection = matches!(command.edit_type(), EditType::MoveCursor { select: true })
             || matches!(command, EditCommand::PasteAtSelectionEdge { .. })
@@ -1832,6 +1833,31 @@ impl Editor {
             cursor.head() - 1,
         );
         self.place(new_cursor);
+    }
+    fn replace_text_object(&mut self, old: TextObjectType, new: TextObjectType) {
+        if !matches!(
+            (old, new),
+            (
+                TextObjectType::Brackets(_) | TextObjectType::Quotes(_),
+                TextObjectType::Brackets(_) | TextObjectType::Quotes(_)
+            )
+        ) {
+            return;
+        }
+        let cursor = self.line_buffer.cursor();
+        self.line_buffer.set_cursor(Cursor::point(cursor.head()));
+        let Some(range) = self.text_object_range(TextObject {
+            scope: TextObjectScope::Inner,
+            object_type: old,
+        }) else {
+            self.line_buffer.set_cursor(cursor);
+            return;
+        };
+        self.remove_text_object(old);
+        self.line_buffer
+            .set_cursor(Cursor::new(range.start - 1, range.end - 1));
+        self.add_text_object(new);
+        self.place(cursor);
     }
 
     fn select_text_object(&mut self, text_object: TextObject) {

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -12,7 +12,7 @@ use strum::EnumString;
 use super::{is_plain_char, is_text_char, parse_non_key_event};
 
 use crate::{
-    enums::{EventStatus, TextObjectBracket},
+    enums::{EventStatus, TextObjectBracket, TextObjectQuote},
     Direction, EditCommand, EditMode, FindStop, Granularity, Keybindings, MotionTarget,
     PromptEditMode, PromptHelixMode, ReedlineEvent, TextObject, TextObjectScope, TextObjectType,
     WordEdge, WordKind,
@@ -379,7 +379,9 @@ fn complete_pending(pending: Pending, count: usize, key: KeyEvent) -> Outcome {
                 '{' | '}' => TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
                 '[' | ']' => TextObjectType::Brackets(TextObjectBracket::SquareBracket),
                 '<' | '>' => TextObjectType::Brackets(TextObjectBracket::AngleBracket),
-                '\'' | '"' => TextObjectType::Quote,
+                '\'' => TextObjectType::Quotes(TextObjectQuote::SingleQuote),
+                '"' => TextObjectType::Quotes(TextObjectQuote::DoubleQuote),
+                '`' => TextObjectType::Quotes(TextObjectQuote::Tick),
                 _ => return Outcome::Reject,
             };
             exec(

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -631,11 +631,11 @@ fn lower(action: Action, mode: HelixMode) -> ReedlineEvent {
         Verb::SelectAll => ReedlineEvent::Edit(vec![EditCommand::SelectAll]),
         Verb::SelectLine => action.repeated(EditCommand::SelectLine),
         Verb::Match(m) => match m.action {
-            MatchAction::Inner => action.repeated(EditCommand::SelectPair(TextObject {
+            MatchAction::Inner => action.repeated(EditCommand::SelectTextObject(TextObject {
                 scope: TextObjectScope::Inner,
                 object_type: m.text_object,
             })),
-            MatchAction::Around => action.repeated(EditCommand::SelectPair(TextObject {
+            MatchAction::Around => action.repeated(EditCommand::SelectTextObject(TextObject {
                 scope: TextObjectScope::Around,
                 object_type: m.text_object,
             })),

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -9,8 +9,9 @@ pub use helix_keybindings::{
 use super::{is_plain_char, is_text_char, parse_non_key_event};
 
 use crate::{
-    Direction, EditCommand, EditMode, FindStop, Granularity, Keybindings, MotionTarget,
-    PromptEditMode, PromptHelixMode, ReedlineEvent, WordEdge, WordKind,
+    enums::TextObjectBrackets, Direction, EditCommand, EditMode, FindStop, Granularity,
+    Keybindings, MotionTarget, PromptEditMode, PromptHelixMode, ReedlineEvent, TextObject,
+    TextObjectScope, TextObjectType, WordEdge, WordKind,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,6 +35,10 @@ enum Pending {
     Replace,
     /// `g` is waiting for the goto target (`h`/`l`/`g`/`e`).
     Goto,
+    /// `m` is waiting for the matching action
+    MatchStepOne,
+    /// `m`-`a`/`i`/`s`/`d` is waiting for the surrounding character
+    MatchStepTwo(MatchAction),
 }
 
 /// Every parse_event will result in one of three outcomes:
@@ -70,6 +75,45 @@ enum Verb {
     /// of line movement and history traversal applies is decided by the engine
     /// against the *whole* buffer, above where a motion resolves.
     LineOrHistory(Direction),
+    /// `m`. Apply action onto surrounding characters
+    Match(Match),
+}
+
+/// Every matching action possible
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MatchAction {
+    /// `i`. Inside surrounding characters
+    Inner,
+    /// `a`. Around surrounding characters
+    Around,
+    /// `s`
+    Set,
+    /// `d`. Delete surrounding characters
+    Delete,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MatchSurroundingChar {
+    /// `(`/`)`
+    Parenthesis,
+    /// `{`/`}`
+    CurlyBrackets,
+    /// `[`/`]`
+    SquareBrackets,
+    /// `<`/`>`
+    AngleBrackets,
+    /// `'`
+    SingleQuote,
+    /// `"`
+    DoubleQuote,
+    /// any other character
+    Other(char),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Match {
+    text_object: TextObjectType,
+    action: MatchAction,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -133,7 +177,7 @@ pub struct Helix {
     mode: HelixMode,
     /// Count prefix being accumulated (`3w`).
     count: Option<usize>,
-    /// Prefix key waiting for its argument (`f`/`r`/`g`).
+    /// Prefix key waiting for its argument (`f`/`r`/`g`/`m`).
     pending: Option<Pending>,
 }
 
@@ -313,6 +357,34 @@ fn complete_pending(pending: Pending, count: usize, key: KeyEvent) -> Outcome {
             };
             exec(count, Verb::CollapsingMotion(target), None)
         }
+        Pending::MatchStepOne => {
+            let target = match ch {
+                'a' => MatchAction::Around,
+                'i' => MatchAction::Inner,
+                _ => return Outcome::Reject,
+            };
+            Outcome::Absorb(Pending::MatchStepTwo(target))
+        }
+        Pending::MatchStepTwo(action) => {
+            let text_object = match ch {
+                'w' => TextObjectType::Word,
+                'W' => TextObjectType::BigWord,
+                '(' | ')' => TextObjectType::Brackets(TextObjectBrackets::Parenthesis),
+                '{' | '}' => TextObjectType::Brackets(TextObjectBrackets::CurlyBrackets),
+                '[' | ']' => TextObjectType::Brackets(TextObjectBrackets::SquareBrackets),
+                '<' | '>' => TextObjectType::Brackets(TextObjectBrackets::AngleBrackets),
+                '\'' | '"' => TextObjectType::Quote,
+                _ => return Outcome::Reject,
+            };
+            exec(
+                count,
+                Verb::Match(Match {
+                    text_object,
+                    action,
+                }),
+                None,
+            )
+        }
     }
 }
 
@@ -353,6 +425,7 @@ fn interpret(mode: HelixMode, count: Option<usize>, key: KeyEvent) -> Outcome {
                 stop: FindStop::Before,
             }),
             'r' => Outcome::Absorb(Pending::Replace),
+            'm' => Outcome::Absorb(Pending::MatchStepOne),
             'w' => exec(
                 count,
                 Verb::SelectingMotion(word(WordKind::Word, WordEdge::Start, Direction::Forward)),
@@ -533,6 +606,18 @@ fn lower(action: Action, mode: HelixMode) -> ReedlineEvent {
         // command repeated: it re-reads the selection every time.
         Verb::SelectAll => ReedlineEvent::Edit(vec![EditCommand::SelectAll]),
         Verb::SelectLine => action.repeated(EditCommand::SelectLine),
+        Verb::Match(m) => match m.action {
+            MatchAction::Inner => action.repeated(EditCommand::SelectPair(TextObject {
+                scope: TextObjectScope::Inner,
+                object_type: m.text_object,
+            })),
+            MatchAction::Around => action.repeated(EditCommand::SelectPair(TextObject {
+                scope: TextObjectScope::Around,
+                object_type: m.text_object,
+            })),
+            MatchAction::Set => todo!(),
+            MatchAction::Delete => todo!(),
+        },
         Verb::Deselect => ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint]),
         Verb::ChangeMode => ReedlineEvent::None,
         // `Up`/`Down` already carry the whole rule: move by line while another

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -43,8 +43,10 @@ enum Pending {
     Goto,
     /// `m` is waiting for the matching action
     MatchStepOne,
-    /// `m`-`a`/`i`/`s`/`d` is waiting for the surrounding character
+    /// `m`-`a`/`i`/`s`/`d`/`r` is waiting for the surrounding character
     MatchStepTwo(MatchAction),
+    /// `mr` is waiting for the second text object
+    MatchReplace(TextObjectType),
 }
 
 /// Every parse_event will result in one of three outcomes:
@@ -88,19 +90,23 @@ enum Verb {
 /// Every matching action possible
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MatchAction {
-    /// `i`. Inside surrounding characters
+    /// `i`. Selects inside a text object
     Inner,
-    /// `a`. Around surrounding characters
+    /// `a`. Select around a text object
     Around,
-    /// `s`
+    /// `s`. Insert a text object around the selection
     Set,
-    /// `d`. Delete surrounding characters
+    /// `d`. Delete the nearest text object around the cursor head
     Delete,
+    /// `r`. Replace a text object by another around the cursor head
+    Replace,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Match {
     text_object: TextObjectType,
+    /// Useful for replace match action
+    text_object2: Option<TextObjectType>,
     action: MatchAction,
 }
 
@@ -149,6 +155,21 @@ fn word(kind: WordKind, edge: WordEdge, direction: Direction) -> MotionTarget {
         kind,
         edge,
         direction,
+    }
+}
+
+fn char_to_text_object(ch: char) -> Option<TextObjectType> {
+    match ch {
+        'w' => Some(TextObjectType::Word),
+        'W' => Some(TextObjectType::BigWord),
+        '(' | ')' => Some(TextObjectType::Brackets(TextObjectBracket::Parenthesis)),
+        '{' | '}' => Some(TextObjectType::Brackets(TextObjectBracket::CurlyBracket)),
+        '[' | ']' => Some(TextObjectType::Brackets(TextObjectBracket::SquareBracket)),
+        '<' | '>' => Some(TextObjectType::Brackets(TextObjectBracket::AngleBracket)),
+        '\'' => Some(TextObjectType::Quotes(TextObjectQuote::SingleQuote)),
+        '"' => Some(TextObjectType::Quotes(TextObjectQuote::DoubleQuote)),
+        '`' => Some(TextObjectType::Quotes(TextObjectQuote::Tick)),
+        _ => None,
     }
 }
 
@@ -369,28 +390,39 @@ fn complete_pending(pending: Pending, count: usize, key: KeyEvent) -> Outcome {
                 'i' => MatchAction::Inner,
                 's' => MatchAction::Set,
                 'd' => MatchAction::Delete,
+                'r' => MatchAction::Replace,
                 _ => return Outcome::Reject,
             };
             Outcome::Absorb(Pending::MatchStepTwo(target))
         }
         Pending::MatchStepTwo(action) => {
-            let text_object = match ch {
-                'w' => TextObjectType::Word,
-                'W' => TextObjectType::BigWord,
-                '(' | ')' => TextObjectType::Brackets(TextObjectBracket::Parenthesis),
-                '{' | '}' => TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
-                '[' | ']' => TextObjectType::Brackets(TextObjectBracket::SquareBracket),
-                '<' | '>' => TextObjectType::Brackets(TextObjectBracket::AngleBracket),
-                '\'' => TextObjectType::Quotes(TextObjectQuote::SingleQuote),
-                '"' => TextObjectType::Quotes(TextObjectQuote::DoubleQuote),
-                '`' => TextObjectType::Quotes(TextObjectQuote::Tick),
-                _ => return Outcome::Reject,
+            let Some(text_object) = char_to_text_object(ch) else {
+                return Outcome::Reject;
             };
+            if matches!(action, MatchAction::Replace) {
+                return Outcome::Absorb(Pending::MatchReplace(text_object));
+            }
             exec(
                 count,
                 Verb::Match(Match {
                     text_object,
+                    text_object2: None,
                     action,
+                }),
+                None,
+            )
+        }
+        Pending::MatchReplace(old) => {
+            let Some(new) = char_to_text_object(ch) else {
+                return Outcome::Reject;
+            };
+
+            exec(
+                count,
+                Verb::Match(Match {
+                    text_object: old,
+                    text_object2: Some(new),
+                    action: MatchAction::Replace,
                 }),
                 None,
             )
@@ -631,6 +663,16 @@ fn lower(action: Action, mode: HelixMode) -> ReedlineEvent {
             MatchAction::Delete => ReedlineEvent::Edit(vec![EditCommand::RemoveTextObject {
                 text_object: m.text_object,
             }]),
+            MatchAction::Replace => {
+                let Some(new) = m.text_object2 else {
+                    // Should not happened, but just in case...
+                    return ReedlineEvent::None;
+                };
+                ReedlineEvent::Edit(vec![EditCommand::ReplaceTextObject {
+                    old: m.text_object,
+                    new,
+                }])
+            }
         },
         Verb::Deselect => ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint]),
         Verb::ChangeMode => ReedlineEvent::None,

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -12,7 +12,7 @@ use strum::EnumString;
 use super::{is_plain_char, is_text_char, parse_non_key_event};
 
 use crate::{
-    enums::{EventStatus, TextObjectBrackets},
+    enums::{EventStatus, TextObjectBracket},
     Direction, EditCommand, EditMode, FindStop, Granularity, Keybindings, MotionTarget,
     PromptEditMode, PromptHelixMode, ReedlineEvent, TextObject, TextObjectScope, TextObjectType,
     WordEdge, WordKind,
@@ -96,24 +96,6 @@ enum MatchAction {
     Set,
     /// `d`. Delete surrounding characters
     Delete,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum MatchSurroundingChar {
-    /// `(`/`)`
-    Parenthesis,
-    /// `{`/`}`
-    CurlyBrackets,
-    /// `[`/`]`
-    SquareBrackets,
-    /// `<`/`>`
-    AngleBrackets,
-    /// `'`
-    SingleQuote,
-    /// `"`
-    DoubleQuote,
-    /// any other character
-    Other(char),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -393,10 +375,10 @@ fn complete_pending(pending: Pending, count: usize, key: KeyEvent) -> Outcome {
             let text_object = match ch {
                 'w' => TextObjectType::Word,
                 'W' => TextObjectType::BigWord,
-                '(' | ')' => TextObjectType::Brackets(TextObjectBrackets::Parenthesis),
-                '{' | '}' => TextObjectType::Brackets(TextObjectBrackets::CurlyBrackets),
-                '[' | ']' => TextObjectType::Brackets(TextObjectBrackets::SquareBrackets),
-                '<' | '>' => TextObjectType::Brackets(TextObjectBrackets::AngleBrackets),
+                '(' | ')' => TextObjectType::Brackets(TextObjectBracket::Parenthesis),
+                '{' | '}' => TextObjectType::Brackets(TextObjectBracket::CurlyBracket),
+                '[' | ']' => TextObjectType::Brackets(TextObjectBracket::SquareBracket),
+                '<' | '>' => TextObjectType::Brackets(TextObjectBracket::AngleBracket),
                 '\'' | '"' => TextObjectType::Quote,
                 _ => return Outcome::Reject,
             };

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -368,6 +368,7 @@ fn complete_pending(pending: Pending, count: usize, key: KeyEvent) -> Outcome {
                 'a' => MatchAction::Around,
                 'i' => MatchAction::Inner,
                 's' => MatchAction::Set,
+                'd' => MatchAction::Delete,
                 _ => return Outcome::Reject,
             };
             Outcome::Absorb(Pending::MatchStepTwo(target))
@@ -627,7 +628,9 @@ fn lower(action: Action, mode: HelixMode) -> ReedlineEvent {
             MatchAction::Set => ReedlineEvent::Edit(vec![EditCommand::AddTextObject {
                 text_object: m.text_object,
             }]),
-            MatchAction::Delete => todo!(),
+            MatchAction::Delete => ReedlineEvent::Edit(vec![EditCommand::RemoveTextObject {
+                text_object: m.text_object,
+            }]),
         },
         Verb::Deselect => ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint]),
         Verb::ChangeMode => ReedlineEvent::None,

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -367,6 +367,7 @@ fn complete_pending(pending: Pending, count: usize, key: KeyEvent) -> Outcome {
             let target = match ch {
                 'a' => MatchAction::Around,
                 'i' => MatchAction::Inner,
+                's' => MatchAction::Set,
                 _ => return Outcome::Reject,
             };
             Outcome::Absorb(Pending::MatchStepTwo(target))
@@ -623,7 +624,9 @@ fn lower(action: Action, mode: HelixMode) -> ReedlineEvent {
                 scope: TextObjectScope::Around,
                 object_type: m.text_object,
             })),
-            MatchAction::Set => todo!(),
+            MatchAction::Set => ReedlineEvent::Edit(vec![EditCommand::AddTextObject {
+                text_object: m.text_object,
+            }]),
             MatchAction::Delete => todo!(),
         },
         Verb::Deselect => ReedlineEvent::Multiple(vec![ReedlineEvent::Esc, ReedlineEvent::Repaint]),

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -12,10 +12,9 @@ use strum::EnumString;
 use super::{is_plain_char, is_text_char, parse_non_key_event};
 
 use crate::{
-    enums::{EventStatus, TextObjectBracket, TextObjectQuote},
-    Direction, EditCommand, EditMode, FindStop, Granularity, Keybindings, MotionTarget,
-    PromptEditMode, PromptHelixMode, ReedlineEvent, TextObject, TextObjectScope, TextObjectType,
-    WordEdge, WordKind,
+    enums::EventStatus, Direction, EditCommand, EditMode, FindStop, Granularity, Keybindings,
+    MotionTarget, PromptEditMode, PromptHelixMode, ReedlineEvent, TextObject, TextObjectScope,
+    TextObjectType, WordEdge, WordKind,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString)]

--- a/src/edit_mode/helix/mod.rs
+++ b/src/edit_mode/helix/mod.rs
@@ -158,21 +158,6 @@ fn word(kind: WordKind, edge: WordEdge, direction: Direction) -> MotionTarget {
     }
 }
 
-fn char_to_text_object(ch: char) -> Option<TextObjectType> {
-    match ch {
-        'w' => Some(TextObjectType::Word),
-        'W' => Some(TextObjectType::BigWord),
-        '(' | ')' => Some(TextObjectType::Brackets(TextObjectBracket::Parenthesis)),
-        '{' | '}' => Some(TextObjectType::Brackets(TextObjectBracket::CurlyBracket)),
-        '[' | ']' => Some(TextObjectType::Brackets(TextObjectBracket::SquareBracket)),
-        '<' | '>' => Some(TextObjectType::Brackets(TextObjectBracket::AngleBracket)),
-        '\'' => Some(TextObjectType::Quotes(TextObjectQuote::SingleQuote)),
-        '"' => Some(TextObjectType::Quotes(TextObjectQuote::DoubleQuote)),
-        '`' => Some(TextObjectType::Quotes(TextObjectQuote::Tick)),
-        _ => None,
-    }
-}
-
 /// This parses incoming input `Event`s like a Helix/Kakoune-style editor: motions are
 /// selection first, lowered onto the editor's [`MotionTarget`](crate::MotionTarget) verb vocabulary.
 #[derive(Debug, Clone)]
@@ -396,7 +381,7 @@ fn complete_pending(pending: Pending, count: usize, key: KeyEvent) -> Outcome {
             Outcome::Absorb(Pending::MatchStepTwo(target))
         }
         Pending::MatchStepTwo(action) => {
-            let Some(text_object) = char_to_text_object(ch) else {
+            let Some(text_object) = TextObjectType::from_char(ch) else {
                 return Outcome::Reject;
             };
             if matches!(action, MatchAction::Replace) {
@@ -413,7 +398,7 @@ fn complete_pending(pending: Pending, count: usize, key: KeyEvent) -> Outcome {
             )
         }
         Pending::MatchReplace(old) => {
-            let Some(new) = char_to_text_object(ch) else {
+            let Some(new) = TextObjectType::from_char(ch) else {
                 return Outcome::Reject;
             };
 

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -1,5 +1,7 @@
 use super::{motion::Motion, parser::ReedlineOption, ViMode};
-use crate::enums::{TextObject, TextObjectBracket, TextObjectScope, TextObjectType};
+use crate::enums::{
+    TextObject, TextObjectBracket, TextObjectQuote, TextObjectScope, TextObjectType,
+};
 use crate::{Direction, EditCommand, Granularity, MotionTarget, ReedlineEvent, Vi};
 use std::iter::Peekable;
 
@@ -589,7 +591,7 @@ fn char_to_text_object(c: char, scope: TextObjectScope) -> Option<TextObject> {
         }),
         'q' => Some(TextObject {
             scope,
-            object_type: TextObjectType::Quote,
+            object_type: TextObjectType::Quotes(TextObjectQuote::All),
         }),
         _ => None,
     }

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -1,5 +1,5 @@
 use super::{motion::Motion, parser::ReedlineOption, ViMode};
-use crate::enums::{TextObject, TextObjectBrackets, TextObjectScope, TextObjectType};
+use crate::enums::{TextObject, TextObjectBracket, TextObjectScope, TextObjectType};
 use crate::{Direction, EditCommand, Granularity, MotionTarget, ReedlineEvent, Vi};
 use std::iter::Peekable;
 
@@ -585,7 +585,7 @@ fn char_to_text_object(c: char, scope: TextObjectScope) -> Option<TextObject> {
         }),
         'b' => Some(TextObject {
             scope,
-            object_type: TextObjectType::Brackets(TextObjectBrackets::All),
+            object_type: TextObjectType::Brackets(TextObjectBracket::All),
         }),
         'q' => Some(TextObject {
             scope,

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -513,11 +513,9 @@ fn char_to_text_object(c: char, scope: TextObjectScope) -> Option<TextObject> {
             scope,
             object_type: TextObjectType::Quotes(TextObjectQuote::All),
         }),
-        _ => TextObjectType::from_char(c).and_then(|tot| {
-            Some(TextObject {
-                scope,
-                object_type: tot,
-            })
+        _ => TextObjectType::from_char(c).map(|tot| TextObject {
+            scope,
+            object_type: tot,
         }),
     }
 }

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -1,5 +1,5 @@
 use super::{motion::Motion, parser::ReedlineOption, ViMode};
-use crate::enums::{TextObject, TextObjectScope, TextObjectType};
+use crate::enums::{TextObject, TextObjectBrackets, TextObjectScope, TextObjectType};
 use crate::{Direction, EditCommand, Granularity, MotionTarget, ReedlineEvent, Vi};
 use std::iter::Peekable;
 
@@ -585,7 +585,7 @@ fn char_to_text_object(c: char, scope: TextObjectScope) -> Option<TextObject> {
         }),
         'b' => Some(TextObject {
             scope,
-            object_type: TextObjectType::Brackets,
+            object_type: TextObjectType::Brackets(TextObjectBrackets::All),
         }),
         'q' => Some(TextObject {
             scope,

--- a/src/edit_mode/vi/command.rs
+++ b/src/edit_mode/vi/command.rs
@@ -12,57 +12,16 @@ where
     match input.peek() {
         Some('d') => {
             let _ = input.next();
-            // Checking for "di(" or "diw" etc.
-            if let Some('i') = input.peek() {
-                let _ = input.next();
-                input.next().and_then(|c| {
-                    bracket_pair_for(*c)
-                        .map(|(left, right)| Command::DeleteInsidePair { left, right })
-                        .or_else(|| {
-                            char_to_text_object(*c, TextObjectScope::Inner)
-                                .map(|text_object| Command::DeleteTextObject { text_object })
-                        })
-                })
-            } else if let Some('a') = input.peek() {
-                let _ = input.next();
-                input.next().and_then(|c| {
-                    bracket_pair_for(*c)
-                        .map(|(left, right)| Command::DeleteAroundPair { left, right })
-                        .or_else(|| {
-                            char_to_text_object(*c, TextObjectScope::Around)
-                                .map(|text_object| Command::DeleteTextObject { text_object })
-                        })
-                })
-            } else {
-                Some(Command::Delete)
-            }
+            text_object_to_command(input, Command::Delete, |text_object| {
+                Command::DeleteTextObject { text_object }
+            })
         }
         // Checking for "yi(" or "yiw" etc.
         Some('y') => {
             let _ = input.next();
-            if let Some('i') = input.peek() {
-                let _ = input.next();
-                input.next().and_then(|c| {
-                    bracket_pair_for(*c)
-                        .map(|(left, right)| Command::YankInsidePair { left, right })
-                        .or_else(|| {
-                            char_to_text_object(*c, TextObjectScope::Inner)
-                                .map(|text_object| Command::YankTextObject { text_object })
-                        })
-                })
-            } else if let Some('a') = input.peek() {
-                let _ = input.next();
-                input.next().and_then(|c| {
-                    bracket_pair_for(*c)
-                        .map(|(left, right)| Command::YankAroundPair { left, right })
-                        .or_else(|| {
-                            char_to_text_object(*c, TextObjectScope::Around)
-                                .map(|text_object| Command::YankTextObject { text_object })
-                        })
-                })
-            } else {
-                Some(Command::Yank)
-            }
+            text_object_to_command(input, Command::Yank, |text_object| {
+                Command::YankTextObject { text_object }
+            })
         }
         Some('p') => {
             let _ = input.next();
@@ -87,25 +46,9 @@ where
         // Checking for "ci(" or "ciw" etc.
         Some('c') => {
             let _ = input.next();
-            if let Some('i') = input.peek() {
-                let _ = input.next();
-                input.next().and_then(|c| {
-                    bracket_pair_for(*c)
-                        .map(|(left, right)| Command::ChangeInsidePair { left, right })
-                        .or_else(|| {
-                            char_to_text_object(*c, TextObjectScope::Inner)
-                                .map(|text_object| Command::ChangeTextObject { text_object })
-                        })
-                })
-            } else if let Some('a') = input.peek() {
-                let _ = input.next();
-                input.next().and_then(|c| {
-                    char_to_text_object(*c, TextObjectScope::Around)
-                        .map(|text_object| Command::ChangeTextObject { text_object })
-                })
-            } else {
-                Some(Command::Change)
-            }
+            text_object_to_command(input, Command::Change, |text_object| {
+                Command::ChangeTextObject { text_object }
+            })
         }
         Some('x') => {
             let _ = input.next();
@@ -186,6 +129,27 @@ where
     }
 }
 
+pub fn text_object_to_command<'iter, I, F>(
+    input: &mut Peekable<I>,
+    incomplete_command: Command,
+    command_generator: F,
+) -> Option<Command>
+where
+    I: Iterator<Item = &'iter char>,
+    F: FnOnce(TextObject) -> Command,
+{
+    let scope = match input.peek() {
+        Some('i') => TextObjectScope::Inner,
+        Some('a') => TextObjectScope::Around,
+        _ => return Some(incomplete_command),
+    };
+    let _ = input.next();
+    input
+        .next()
+        .and_then(|c| char_to_text_object(*c, scope))
+        .map(command_generator)
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum Command {
     Incomplete,
@@ -213,12 +177,6 @@ pub enum Command {
     Switchcase,
     RepeatLastAction,
     Yank,
-    // These DoSthInsidePair commands are agnostic to whether user pressed the left char or right char
-    ChangeInsidePair { left: char, right: char },
-    DeleteInsidePair { left: char, right: char },
-    YankInsidePair { left: char, right: char },
-    DeleteAroundPair { left: char, right: char },
-    YankAroundPair { left: char, right: char },
     ChangeTextObject { text_object: TextObject },
     YankTextObject { text_object: TextObject },
     DeleteTextObject { text_object: TextObject },
@@ -318,36 +276,6 @@ impl Command {
                 Some(event) => vec![ReedlineOption::Event(event.clone())],
                 None => vec![],
             },
-            Self::ChangeInsidePair { left, right } => {
-                vec![ReedlineOption::Edit(EditCommand::CutInsidePair {
-                    left: *left,
-                    right: *right,
-                })]
-            }
-            Self::DeleteInsidePair { left, right } => {
-                vec![ReedlineOption::Edit(EditCommand::CutInsidePair {
-                    left: *left,
-                    right: *right,
-                })]
-            }
-            Self::YankInsidePair { left, right } => {
-                vec![ReedlineOption::Edit(EditCommand::CopyInsidePair {
-                    left: *left,
-                    right: *right,
-                })]
-            }
-            Self::DeleteAroundPair { left, right } => {
-                vec![ReedlineOption::Edit(EditCommand::CutAroundPair {
-                    left: *left,
-                    right: *right,
-                })]
-            }
-            Self::YankAroundPair { left, right } => {
-                vec![ReedlineOption::Edit(EditCommand::CopyAroundPair {
-                    left: *left,
-                    right: *right,
-                })]
-            }
             Self::ChangeTextObject { text_object } => {
                 vec![ReedlineOption::Edit(EditCommand::CutTextObject {
                     text_object: *text_object,
@@ -577,14 +505,6 @@ impl Command {
 
 fn char_to_text_object(c: char, scope: TextObjectScope) -> Option<TextObject> {
     match c {
-        'w' => Some(TextObject {
-            scope,
-            object_type: TextObjectType::Word,
-        }),
-        'W' => Some(TextObject {
-            scope,
-            object_type: TextObjectType::BigWord,
-        }),
         'b' => Some(TextObject {
             scope,
             object_type: TextObjectType::Brackets(TextObjectBracket::All),
@@ -593,20 +513,11 @@ fn char_to_text_object(c: char, scope: TextObjectScope) -> Option<TextObject> {
             scope,
             object_type: TextObjectType::Quotes(TextObjectQuote::All),
         }),
-        _ => None,
-    }
-}
-
-fn bracket_pair_for(c: char) -> Option<(char, char)> {
-    match c {
-        '(' | ')' => Some(('(', ')')),
-        '[' | ']' => Some(('[', ']')),
-        '{' | '}' => Some(('{', '}')),
-        '<' | '>' => Some(('<', '>')),
-        '"' => Some(('"', '"')),
-        '$' => Some(('$', '$')),
-        '\'' => Some(('\'', '\'')),
-        '`' => Some(('`', '`')),
-        _ => None,
+        _ => TextObjectType::from_char(c).and_then(|tot| {
+            Some(TextObject {
+                scope,
+                object_type: tot,
+            })
+        }),
     }
 }

--- a/src/edit_mode/vi/parser.rs
+++ b/src/edit_mode/vi/parser.rs
@@ -122,7 +122,6 @@ impl ParsedViSequence {
             // `r<char>` in Visual replaces and returns to Normal; without this it
             // would fall through to `None` and leave the editor stuck in Visual.
             (Some(Command::ReplaceChar(_)), _) if mode == ViMode::Visual => Some(ViMode::Normal),
-            (Some(Command::ChangeInsidePair { .. }), _) => Some(ViMode::Insert),
             (Some(Command::ChangeTextObject { .. }), _) => Some(ViMode::Insert),
             (Some(Command::Delete), ParseResult::Incomplete)
             | (Some(Command::DeleteChar), ParseResult::Incomplete)
@@ -132,8 +131,8 @@ impl ParsedViSequence {
             | (Some(Command::DeleteToEnd), ParseResult::Valid(_))
             | (Some(Command::Yank), ParseResult::Valid(_))
             | (Some(Command::Yank), ParseResult::Incomplete)
-            | (Some(Command::DeleteInsidePair { .. }), _)
-            | (Some(Command::YankInsidePair { .. }), _) => Some(ViMode::Normal),
+            | (Some(Command::DeleteTextObject { .. }), _)
+            | (Some(Command::YankTextObject { .. }), _) => Some(ViMode::Normal),
             _ => None,
         }
     }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -808,6 +808,11 @@ pub enum EditCommand {
         /// The text object to operate on
         text_object: TextObject,
     },
+    /// Add the specified text object around the selection
+    AddTextObject {
+        /// The text object to operate on
+        text_object: TextObjectType,
+    },
 }
 
 impl EditCommand {
@@ -930,7 +935,8 @@ impl EditCommand {
             | EditCommand::CopyLeftBefore(_)
             | EditCommand::CopyInsidePair { .. }
             | EditCommand::CopyAroundPair { .. }
-            | EditCommand::CopyTextObject { .. } => EditType::NoOp,
+            | EditCommand::CopyTextObject { .. }
+            | EditCommand::AddTextObject { .. } => EditType::NoOp,
 
             // The six MotionTarget verbs. `Move`/`Extend` carry the old `select`
             // bool in the verb itself (Extend must be `select: true` so the editor

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -410,7 +410,7 @@ pub enum EditCommand {
     Select(MotionTarget),
 
     /// Select a [`TextObject`]
-    SelectPair(TextObject),
+    SelectTextObject(TextObject),
 
     /// Cut like [`EditCommand::Cut`], except that a `LineWise` span keeps its
     /// line terminators: only the lines' *content* is consumed, so one blank
@@ -925,7 +925,7 @@ impl EditCommand {
             EditCommand::Move(_) => EditType::MoveCursor { select: false },
             EditCommand::Extend(_) => EditType::MoveCursor { select: true },
             EditCommand::CollapseSelection(_) => EditType::MoveCursor { select: false },
-            EditCommand::Select(_) | EditCommand::SelectPair(_) => {
+            EditCommand::Select(_) | EditCommand::SelectTextObject(_) => {
                 EditType::MoveCursor { select: true }
             }
             EditCommand::Cut { .. } => EditType::EditText,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -809,6 +809,11 @@ pub enum EditCommand {
         /// The text object to operate on
         text_object: TextObjectType,
     },
+    /// Remove the nearest specified text object around the cursor head
+    RemoveTextObject {
+        /// The text object to operate on
+        text_object: TextObjectType,
+    },
 }
 
 impl EditCommand {
@@ -930,7 +935,10 @@ impl EditCommand {
             | EditCommand::CopyInsidePair { .. }
             | EditCommand::CopyAroundPair { .. }
             | EditCommand::CopyTextObject { .. } => EditType::NoOp,
-            EditCommand::AddTextObject { .. } => EditType::MoveCursor { select: true },
+
+            EditCommand::AddTextObject { .. } | EditCommand::RemoveTextObject { .. } => {
+                EditType::MoveCursor { select: true }
+            }
 
             // The six MotionTarget verbs. `Move`/`Extend` carry the old `select`
             // bool in the verb itself (Extend must be `select: true` so the editor

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -814,6 +814,13 @@ pub enum EditCommand {
         /// The text object to operate on
         text_object: TextObjectType,
     },
+    /// Replace the nearest specified text object around the cursor head
+    ReplaceTextObject {
+        /// The old text object to replace
+        old: TextObjectType,
+        /// The new text object to replace with
+        new: TextObjectType,
+    },
 }
 
 impl EditCommand {
@@ -936,9 +943,9 @@ impl EditCommand {
             | EditCommand::CopyAroundPair { .. }
             | EditCommand::CopyTextObject { .. } => EditType::NoOp,
 
-            EditCommand::AddTextObject { .. } | EditCommand::RemoveTextObject { .. } => {
-                EditType::MoveCursor { select: true }
-            }
+            EditCommand::AddTextObject { .. }
+            | EditCommand::RemoveTextObject { .. }
+            | EditCommand::ReplaceTextObject { .. } => EditType::MoveCursor { select: true },
 
             // The six MotionTarget verbs. `Move`/`Extend` carry the old `select`
             // bool in the verb itself (Extend must be `select: true` so the editor

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -147,7 +147,9 @@ pub enum WordKind {
     LongWord,
     /// Emacs `M-f`/`M-b` — Unicode (UAX-29) word segmentation, so e.g. `can't`
     /// and `3.14` stay single words. The one flavor that isn't a thin char-class
-    /// predicate; see `locate_word`. (Follow-up: collapse onto a class predicate.)
+    /// predicate; see `locate_word`. Holding those together turns on the
+    /// characters flanking a `'` or a `.` rather than on their class, thus it
+    /// stays a separate scan instead of collapsing onto a boundary predicate.
     Unicode,
 }
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -57,6 +57,20 @@ pub enum TextObjectScope {
     Around,
 }
 
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum TextObjectBrackets {
+    /// (, )
+    Parenthesis,
+    /// \[, ]
+    SquareBrackets,
+    /// {, }
+    CurlyBrackets,
+    /// <, >
+    AngleBrackets,
+    /// (, ), \[, ], {, }, <, >
+    All,
+}
+
 /// Type of text object to operate on
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum TextObjectType {
@@ -64,8 +78,8 @@ pub enum TextObjectType {
     Word,
     /// WORD (delimited only by whitespace)
     BigWord,
-    /// (, ), \[, ], {, }
-    Brackets,
+    /// Brackets pairs (`(`, `)`, `[`, `]`, `{`, `}`, `<`, `>`)
+    Brackets(TextObjectBrackets),
     /// ", ', `
     Quote,
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -929,8 +929,8 @@ impl EditCommand {
             | EditCommand::CopyLeftBefore(_)
             | EditCommand::CopyInsidePair { .. }
             | EditCommand::CopyAroundPair { .. }
-            | EditCommand::CopyTextObject { .. }
-            | EditCommand::AddTextObject { .. } => EditType::NoOp,
+            | EditCommand::CopyTextObject { .. } => EditType::NoOp,
+            EditCommand::AddTextObject { .. } => EditType::MoveCursor { select: true },
 
             // The six MotionTarget verbs. `Move`/`Extend` carry the old `select`
             // bool in the verb itself (Extend must be `select: true` so the editor

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -57,6 +57,19 @@ pub enum TextObjectScope {
     Around,
 }
 
+/// Text object quote types
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum TextObjectQuote {
+    /// '
+    SingleQuote,
+    /// "
+    DoubleQuote,
+    /// \`
+    Tick,
+    /// (, ), \[, ], {, }, <, >
+    All,
+}
+
 /// Text object bracket types
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum TextObjectBracket {
@@ -81,8 +94,8 @@ pub enum TextObjectType {
     BigWord,
     /// Brackets pairs (`(`, `)`, `[`, `]`, `{`, `}`, `<`, `>`)
     Brackets(TextObjectBracket),
-    /// ", ', `
-    Quote,
+    /// Quotes pairs (`"`, `'`, `\``)
+    Quotes(TextObjectQuote),
 }
 
 /// Text objects that can be operated on with vim-style commands

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -98,6 +98,23 @@ pub enum TextObjectType {
     Quotes(TextObjectQuote),
 }
 
+impl TextObjectType {
+    pub fn from_char(ch: char) -> Option<Self> {
+        match ch {
+            'w' => Some(Self::Word),
+            'W' => Some(Self::BigWord),
+            '(' | ')' => Some(Self::Brackets(TextObjectBracket::Parenthesis)),
+            '[' | ']' => Some(Self::Brackets(TextObjectBracket::SquareBracket)),
+            '{' | '}' => Some(Self::Brackets(TextObjectBracket::CurlyBracket)),
+            '<' | '>' => Some(Self::Brackets(TextObjectBracket::AngleBracket)),
+            '"' => Some(Self::Quotes(TextObjectQuote::DoubleQuote)),
+            '\'' => Some(Self::Quotes(TextObjectQuote::SingleQuote)),
+            '`' => Some(Self::Quotes(TextObjectQuote::Tick)),
+            _ => None,
+        }
+    }
+}
+
 /// Text objects that can be operated on with vim-style commands
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct TextObject {
@@ -768,39 +785,12 @@ pub enum EditCommand {
     #[cfg(feature = "system_clipboard")]
     PasteSystem,
 
-    /// Delete text between matching characters atomically
-    CutInsidePair {
-        /// Left character of the pair
-        left: char,
-        /// Right character of the pair (usually matching bracket)
-        right: char,
-    },
-    /// Yank text between matching characters atomically
-    CopyInsidePair {
-        /// Left character of the pair
-        left: char,
-        /// Right character of the pair (usually matching bracket)
-        right: char,
-    },
-    /// Delete text around matching characters atomically (including the pair characters)
-    CutAroundPair {
-        /// Left character of the pair
-        left: char,
-        /// Right character of the pair (usually matching bracket)
-        right: char,
-    },
-    /// Yank text around matching characters atomically (including the pair characters)
-    CopyAroundPair {
-        /// Left character of the pair
-        left: char,
-        /// Right character of the pair (usually matching bracket)
-        right: char,
-    },
     /// Cut the specified text object
     CutTextObject {
         /// The text object to operate on
         text_object: TextObject,
     },
+
     /// Copy the specified text object
     CopyTextObject {
         /// The text object to operate on
@@ -908,8 +898,6 @@ impl EditCommand {
             | EditCommand::UppercaseSelection
             | EditCommand::SwitchcaseSelection
             | EditCommand::Paste
-            | EditCommand::CutInsidePair { .. }
-            | EditCommand::CutAroundPair { .. }
             | EditCommand::CutTextObject { .. }
             | EditCommand::PasteAtSelectionEdge { .. } => EditType::EditText,
 
@@ -941,8 +929,6 @@ impl EditCommand {
             | EditCommand::CopyRightBefore(_)
             | EditCommand::CopyLeftUntil(_)
             | EditCommand::CopyLeftBefore(_)
-            | EditCommand::CopyInsidePair { .. }
-            | EditCommand::CopyAroundPair { .. }
             | EditCommand::CopyTextObject { .. } => EditType::NoOp,
 
             EditCommand::AddTextObject { .. }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -99,6 +99,7 @@ pub enum TextObjectType {
 }
 
 impl TextObjectType {
+    /// Convert a character to its corresponding [`TextObjectType`](Self)
     pub fn from_char(ch: char) -> Option<Self> {
         match ch {
             'w' => Some(Self::Word),

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -57,16 +57,17 @@ pub enum TextObjectScope {
     Around,
 }
 
+/// Text object bracket types
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
-pub enum TextObjectBrackets {
+pub enum TextObjectBracket {
     /// (, )
     Parenthesis,
     /// \[, ]
-    SquareBrackets,
+    SquareBracket,
     /// {, }
-    CurlyBrackets,
+    CurlyBracket,
     /// <, >
-    AngleBrackets,
+    AngleBracket,
     /// (, ), \[, ], {, }, <, >
     All,
 }
@@ -79,7 +80,7 @@ pub enum TextObjectType {
     /// WORD (delimited only by whitespace)
     BigWord,
     /// Brackets pairs (`(`, `)`, `[`, `]`, `{`, `}`, `<`, `>`)
-    Brackets(TextObjectBrackets),
+    Brackets(TextObjectBracket),
     /// ", ', `
     Quote,
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -409,6 +409,9 @@ pub enum EditCommand {
     /// move the head to the target, so the selection covers the span just traveled.
     Select(MotionTarget),
 
+    /// Select a [`TextObject`]
+    SelectPair(TextObject),
+
     /// Cut like [`EditCommand::Cut`], except that a `LineWise` span keeps its
     /// line terminators: only the lines' *content* is consumed, so one blank
     /// line remains — the vi change operator's linewise semantics
@@ -922,7 +925,9 @@ impl EditCommand {
             EditCommand::Move(_) => EditType::MoveCursor { select: false },
             EditCommand::Extend(_) => EditType::MoveCursor { select: true },
             EditCommand::CollapseSelection(_) => EditType::MoveCursor { select: false },
-            EditCommand::Select(_) => EditType::MoveCursor { select: true },
+            EditCommand::Select(_) | EditCommand::SelectPair(_) => {
+                EditType::MoveCursor { select: true }
+            }
             EditCommand::Cut { .. } => EditType::EditText,
             EditCommand::Copy { .. } => EditType::NoOp,
             EditCommand::Change { .. } => EditType::EditText,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,8 @@ mod enums;
 pub use enums::{
     Direction, EditCommand, EditCommandDiscriminants, FindStop, Granularity, MotionTarget,
     MouseButton, ReedlineEvent, ReedlineEventDiscriminants, ReedlineRawEvent, Signal, TextObject,
-    TextObjectBracket, TextObjectScope, TextObjectType, UndoBehavior, WordEdge, WordKind,
+    TextObjectBracket, TextObjectQuote, TextObjectScope, TextObjectType, UndoBehavior, WordEdge,
+    WordKind,
 };
 
 mod painting;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ mod enums;
 pub use enums::{
     Direction, EditCommand, EditCommandDiscriminants, FindStop, Granularity, MotionTarget,
     MouseButton, ReedlineEvent, ReedlineEventDiscriminants, ReedlineRawEvent, Signal, TextObject,
-    TextObjectScope, TextObjectType, UndoBehavior, WordEdge, WordKind,
+    TextObjectBracket, TextObjectScope, TextObjectType, UndoBehavior, WordEdge, WordKind,
 };
 
 mod painting;


### PR DESCRIPTION
<!-- Thanks for contributing to Reedline! -->

## Summary

Add match actions from helix to reedline, and bind the new behaviors to the helix mode.

Keybindings:
- `mi<TextObject>` : select inside a text object
- `ma<TextObject>` : select around a text object
- `ms<TextObject>` : add the specified text object around the selection
- `md<TextObject>` : remove the nearest specified text object around the selection
- `mr<old TextObject><new TextObject>` : replace the nearest specified text object around the cursor with another text object

This includes the following new EditCommand: 
- `SelectTextObject`
- `AddTextObject`
- `RemoveTextObject`
- `ReplaceTextObject`

Moreover, brackets and quotes are more granular in TextObjectType by differentiating each text object.

## Additional notes

Redundant code has been removed, replaced by existing or new functions. In a nutshell, `<Cut/Copy><Inside/Around>Pair` had been replaced by `<Cut/Copy>TextObject`.

<details>
<summary>Detail here</summary>

Among that, the following EditCommand has been replaced:
- `EditCommand::CutInsidePair{start: char, end: char)` => `EditCommand::CutTextObject{scope: TextObjectScope::Inner, object_type: TextObjectType::XXX}`
- `EditCommand::CutAroundPair{start: char, end: char)` => `EditCommand::CutTextObject{scope: TextObjectScope::Around, object_type: TextObjectType::XXX}`
- `EditCommand::CopyInsidePair{start: char, end: char)` => `EditCommand::CopyTextObject{scope: TextObjectScope::Inner, object_type: TextObjectType::XXX}`
- `EditCommand::CopyAroundPair{start: char, end: char)` => `EditCommand::CopyTextObject{scope: TextObjectScope::Around, object_type: TextObjectType::XXX}`

In `core_editor::editor::Editor`, the following functions have been replaced: 
- `cut_inside_pair` => `cut_text_object`
- `cut_around_pair` => `cut_text_object`
- `copy_inside_pair` => `copy_text_object`
- `copy_around_pair` => `copy_text_object`

Vi mode implementation has been updated towards that.

All tests passes.
</details>