### PR TITLE
fix(painter): resolve the cursor's row from the wrap walk

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -3,7 +3,9 @@ use crate::PromptHelixMode;
 use crate::{CursorConfig, PromptEditMode, PromptViMode};
 
 use {
-    super::utils::{coerce_crlf, deferred_wrap_row, estimate_required_lines, line_width},
+    super::utils::{
+        advance_grapheme, coerce_crlf, deferred_wrap_row, line_width, resolve_wrap, wrap_position,
+    },
     crate::{
         menu::{Menu, ReedlineMenu},
         painting::PromptLines,
@@ -18,7 +20,6 @@ use {
     std::io::{Result, Write},
     std::ops::RangeInclusive,
     unicode_segmentation::UnicodeSegmentation,
-    unicode_width::UnicodeWidthStr,
 };
 #[cfg(feature = "external_printer")]
 use {crate::LineBuffer, crossterm::cursor::MoveUp};
@@ -789,14 +790,19 @@ impl Painter {
                     .unwrap_or(snapshot.after_cursor.len());
                 (0, end)
             } else {
-                let cursor_distance = estimate_required_lines(
-                    &format!(
-                        "{}{}{}",
-                        snapshot.prompt_str_left, snapshot.prompt_indicator, snapshot.before_cursor
-                    ),
+                // The same walk `PromptLines::distance_from_prompt` uses, on
+                // the snapshot's pieces: a division here would disagree with
+                // the layout by a row on a trailing newline or an exactly
+                // filled row, and clip `after_cursor` at the wrong place.
+                let cursor_distance = wrap_position(
+                    [
+                        snapshot.prompt_str_left.as_str(),
+                        snapshot.prompt_indicator.as_str(),
+                        snapshot.before_cursor.as_str(),
+                    ],
                     screen_width,
                 )
-                .saturating_sub(1) as u16;
+                .map_or(0, |end| resolve_wrap(end, screen_width).1);
                 let remaining_lines = snapshot.screen_height.saturating_sub(cursor_distance);
                 let offset = remaining_lines.saturating_sub(1) as usize;
                 skip_buffer_lines_range(&snapshot.after_cursor, 0, Some(offset))
@@ -820,19 +826,16 @@ impl Painter {
 
         let mut check_segment = |segment: &str, base_offset: usize| -> Option<usize> {
             for (index, grapheme) in segment.grapheme_indices(true) {
-                if grapheme == "\n" {
-                    current_row = current_row.saturating_add(1);
-                    current_col = 0;
-                    continue;
-                }
+                // Same rule as the layout walk, so the offset this maps back to
+                // is the grapheme the layout put under the click. A zero-width
+                // grapheme occupies no column and so is never the target; the
+                // base grapheme it combines with already matched.
+                let (at, width) =
+                    advance_grapheme((current_row, current_col), grapheme, screen_width);
+                (current_row, current_col) = at;
 
-                let width = grapheme.width().max(1) as u16;
-                if current_col.saturating_add(width) > screen_width {
-                    current_row = current_row.saturating_add(1);
-                    current_col = 0;
-                }
-
-                if current_row == target_row
+                if width > 0
+                    && current_row == target_row
                     && column >= current_col
                     && column < current_col.saturating_add(width)
                 {

--- a/src/painting/prompt_lines.rs
+++ b/src/painting/prompt_lines.rs
@@ -54,9 +54,13 @@ impl<'prompt> PromptLines<'prompt> {
         }
     }
 
-    /// The required lines to paint the buffer are calculated by counting the
-    /// number of newlines in all the strings that form the prompt and buffer.
-    /// The plus 1 is to indicate that there should be at least one line.
+    /// Rows to reserve for the prompt and buffer, laid out end to end.
+    ///
+    /// Floored at [`Self::distance_from_prompt`] plus one: the cursor can rest
+    /// on a row no glyph reaches, since a filled row or a trailing newline
+    /// leaves it one past the last drawn one, and `menu_start_row` opens the
+    /// menu below *that*. Reserving only the rows text occupies runs the menu
+    /// past the reservation.
     pub(crate) fn required_lines(
         &self,
         terminal_columns: u16,
@@ -73,10 +77,6 @@ impl<'prompt> PromptLines<'prompt> {
             }
         }
 
-        // The cursor can rest on a row no glyph reaches: a filled row or a
-        // trailing newline leaves it one past the last drawn one, and
-        // `menu_start_row` opens the menu below *that*. Reserving only the
-        // rows text occupies runs the menu past the reservation.
         let lines = estimate_required_lines(&input, terminal_columns)
             .max(self.distance_from_prompt(terminal_columns) as usize + 1);
 
@@ -365,10 +365,12 @@ mod tests {
     #[case("", "> ", "ab\ncd\n", 20, 2)]
     // "> " plus 18 columns fills the row exactly.
     #[case("", "> ", &"a".repeat(18), 20, 1)]
-    // A wide grapheme cannot straddle the margin, so the run takes a row
-    // division could not see.
+    // A wide grapheme cannot straddle the margin, so the walk spends a row on
+    // the one that will not fit where division reads an exact fit: eleven of
+    // them on eleven columns is five per row, not five and a half.
     #[case("", "> ", "日本語日本語", 11, 1)]
-    // A multiline prompt puts its own wrapped rows between the two.
+    #[case("", "", &"日".repeat(11), 11, 2)]
+    // A multiline prompt puts its own rows between the two.
     #[case("~/p\n", "> ", "abc", 20, 1)]
     // Mid-resize width (#842).
     #[case("", "> ", "abc", 0, 0)]

--- a/src/painting/prompt_lines.rs
+++ b/src/painting/prompt_lines.rs
@@ -1,4 +1,4 @@
-use super::utils::{coerce_crlf, estimate_required_lines, line_width};
+use super::utils::{coerce_crlf, estimate_required_lines, line_width, resolve_wrap, wrap_position};
 use crate::{
     menu::{Menu, ReedlineMenu},
     prompt::PromptEditMode,
@@ -73,7 +73,12 @@ impl<'prompt> PromptLines<'prompt> {
             }
         }
 
-        let lines = estimate_required_lines(&input, terminal_columns);
+        // The cursor can rest on a row no glyph reaches: a filled row or a
+        // trailing newline leaves it one past the last drawn one, and
+        // `menu_start_row` opens the menu below *that*. Reserving only the
+        // rows text occupies runs the menu past the reservation.
+        let lines = estimate_required_lines(&input, terminal_columns)
+            .max(self.distance_from_prompt(terminal_columns) as usize + 1);
 
         if let Some(menu) = menu {
             lines as u16 + menu.menu_required_lines(terminal_columns)
@@ -82,12 +87,23 @@ impl<'prompt> PromptLines<'prompt> {
         }
     }
 
-    /// Estimated distance of the cursor to the prompt.
-    /// This considers line wrapping
+    /// Rows from the prompt's first row to the row the cursor rests on.
+    ///
+    /// Places a cursor, so a filled row resolves to the next one. That row is
+    /// what `menu_start_row` opens the menu below.
     pub(crate) fn distance_from_prompt(&self, terminal_columns: u16) -> u16 {
-        let input = self.prompt_str_left.to_string() + &self.prompt_indicator + &self.before_cursor;
-        let lines = estimate_required_lines(&input, terminal_columns);
-        lines.saturating_sub(1) as u16
+        let Some(end) = wrap_position(
+            [
+                &*self.prompt_str_left,
+                &self.prompt_indicator,
+                &self.before_cursor,
+            ],
+            terminal_columns,
+        ) else {
+            return 0;
+        };
+
+        resolve_wrap(end, terminal_columns).1
     }
 
     /// Calculate the cursor pos, based on the buffer and prompt.
@@ -98,26 +114,12 @@ impl<'prompt> PromptLines<'prompt> {
         // The Cursor position will be relative to this
         let last_prompt_str = prompt_str.lines().last().unwrap_or_default();
 
-        let is_multiline = self.before_cursor.contains('\n');
-        let buffer_width = line_width(self.before_cursor.lines().last().unwrap_or_default());
-
-        let total_width = if is_multiline {
-            // The buffer already contains the multiline prompt
-            buffer_width
-        } else {
-            buffer_width + line_width(last_prompt_str)
+        let Some(end) = wrap_position([last_prompt_str, &self.before_cursor], terminal_columns)
+        else {
+            return (0, 0);
         };
 
-        let buffer_width_prompt = format!("{}{}", last_prompt_str, self.before_cursor);
-
-        let cursor_y = (estimate_required_lines(&buffer_width_prompt, terminal_columns) as u16)
-            .saturating_sub(1); // 0 based
-
-        // Floored: terminals report a 0 width mid-resize (#842), like
-        // `estimate_single_line_wraps` already handles.
-        let cursor_x = (total_width % terminal_columns.max(1) as usize) as u16;
-
-        (cursor_x, cursor_y as u16)
+        resolve_wrap(end, terminal_columns)
     }
 
     /// Total lines that the prompt uses considering that it may wrap the screen
@@ -243,6 +245,56 @@ mod tests {
         0,
         (0, 0)
     )]
+    // A filled row leaves the cursor pending at the margin, which resolves to
+    // the home column of the next row (#1141), not of the row it filled.
+    #[case(
+        "",
+        "",
+        "hello",
+        5,
+        (0, 1)
+    )]
+    // Wide graphemes cannot straddle the margin, so the terminal blanks the
+    // trailing column and wraps early. Division read these as exact rows:
+    // (1, 1) and (0, 1), the second a whole row adrift.
+    #[case(
+        "",
+        "",
+        "日本語日本語",
+        11,
+        (2, 1)
+    )]
+    #[case(
+        "",
+        "",
+        "日本語日本語日本語日本",
+        11,
+        (2, 2)
+    )]
+    #[case(
+        "",
+        "",
+        "日a日a日a日a",
+        7,
+        (6, 1)
+    )]
+    // A ZWJ sequence is one grapheme two columns wide, not three of six.
+    #[case(
+        "",
+        "",
+        "👨‍👩‍👧👨‍👩‍👧👨‍👩‍👧",
+        5,
+        (2, 1)
+    )]
+    // The prompt tail and the buffer lay out end to end, so the indicator
+    // pushes the first wide grapheme off the row it would otherwise fit.
+    #[case(
+        "",
+        "❯ ",
+        "日本語",
+        5,
+        (4, 1)
+    )]
 
     fn test_cursor_pos(
         #[case] prompt_str_left: &str,
@@ -264,5 +316,82 @@ mod tests {
         let pos = prompt_lines.cursor_pos(terminal_columns);
 
         assert_eq!(pos, expected);
+    }
+
+    /// The reservation has to cover the row the cursor rests on, since
+    /// `menu_start_row` opens the menu below it. A filled row and a trailing
+    /// newline both put the cursor past the last row any glyph reaches, so
+    /// counting drawn rows alone leaves the menu hanging off the end.
+    #[rstest]
+    #[case("> ", "abc", "", 20, 1)]
+    // "> " plus 18 columns fills the row; the cursor is on the next one.
+    #[case("> ", &"a".repeat(18), "", 20, 2)]
+    // Same buffer, but text after the cursor already reaches that row.
+    #[case("> ", &"a".repeat(18), "xyz", 20, 2)]
+    #[case("> ", "ab\n", "", 20, 2)]
+    // One column short of the margin, so nothing extra is owed.
+    #[case("> ", &"a".repeat(17), "", 20, 1)]
+    fn test_required_lines_covers_the_cursor_row(
+        #[case] prompt_indicator: &str,
+        #[case] before_cursor: &str,
+        #[case] after_cursor: &str,
+        #[case] terminal_columns: u16,
+        #[case] expected: u16,
+    ) {
+        let prompt_lines = PromptLines {
+            prompt_str_left: Cow::Borrowed(""),
+            prompt_str_right: Cow::Borrowed(""),
+            prompt_indicator: Cow::Borrowed(prompt_indicator),
+            before_cursor: Cow::Borrowed(before_cursor),
+            after_cursor: Cow::Borrowed(after_cursor),
+            hint: Cow::Borrowed(""),
+            right_prompt_on_last_line: false,
+        };
+
+        assert_eq!(
+            prompt_lines.required_lines(terminal_columns, false, None),
+            expected
+        );
+    }
+
+    /// Rows down to the cursor, not rows the text occupies: a buffer ending on
+    /// a newline draws nothing on the row the cursor sits on, and one filling
+    /// the width exactly draws nothing on the row the wrap resolves to.
+    #[rstest]
+    #[case("", "> ", "abc", 20, 0)]
+    // `.lines()` drops a trailing newline, so counting lines missed the row
+    // the cursor had already moved to.
+    #[case("", "> ", "abc\n", 20, 1)]
+    #[case("", "> ", "ab\ncd\n", 20, 2)]
+    // "> " plus 18 columns fills the row exactly.
+    #[case("", "> ", &"a".repeat(18), 20, 1)]
+    // A wide grapheme cannot straddle the margin, so the run takes a row
+    // division could not see.
+    #[case("", "> ", "日本語日本語", 11, 1)]
+    // A multiline prompt puts its own wrapped rows between the two.
+    #[case("~/p\n", "> ", "abc", 20, 1)]
+    // Mid-resize width (#842).
+    #[case("", "> ", "abc", 0, 0)]
+    fn test_distance_from_prompt(
+        #[case] prompt_str_left: &str,
+        #[case] prompt_indicator: &str,
+        #[case] before_cursor: &str,
+        #[case] terminal_columns: u16,
+        #[case] expected: u16,
+    ) {
+        let prompt_lines = PromptLines {
+            prompt_str_left: Cow::Borrowed(prompt_str_left),
+            prompt_str_right: Cow::Borrowed(""),
+            prompt_indicator: Cow::Borrowed(prompt_indicator),
+            before_cursor: Cow::Borrowed(before_cursor),
+            after_cursor: Cow::Borrowed(""),
+            hint: Cow::Borrowed(""),
+            right_prompt_on_last_line: false,
+        };
+
+        assert_eq!(
+            prompt_lines.distance_from_prompt(terminal_columns),
+            expected
+        );
     }
 }

--- a/src/painting/utils.rs
+++ b/src/painting/utils.rs
@@ -136,35 +136,56 @@ pub(crate) fn wrap_position<'a>(
     pieces: impl IntoIterator<Item = &'a str>,
     terminal_columns: u16,
 ) -> Option<(u16, u16)> {
-    let columns: usize = terminal_columns.into();
-    if columns == 0 {
+    if terminal_columns == 0 {
         return None;
     }
-    let (mut row, mut col) = (0u16, 0usize);
+    let (mut row, mut col) = (0u16, 0u16);
     for piece in pieces {
         for grapheme in strip_ansi(piece).graphemes(true) {
-            match grapheme {
-                "\n" => (row, col) = (row.saturating_add(1), 0),
-                "\r" => col = 0,
-                _ => {
-                    let width = grapheme.width();
-                    // The wrap this grapheme's arrival was deferred until.
-                    // Both checks can fire for one grapheme, so a single `||`
-                    // loses a row: a zero-width one trips only this.
-                    if col >= columns {
-                        (row, col) = (row.saturating_add(1), 0);
-                    }
-                    // No room for the whole grapheme: the trailing column stays
-                    // blank and the terminal wraps before drawing it.
-                    if col + width > columns {
-                        (row, col) = (row.saturating_add(1), 0);
-                    }
-                    col += width;
-                }
-            }
+            let (at, width) = advance_grapheme((row, col), grapheme, terminal_columns);
+            (row, col) = at;
+            col = col.saturating_add(width);
         }
     }
-    Some((col as u16, row))
+    Some((col, row))
+}
+
+/// One step of the [`wrap_position`] walk: where `grapheme` is drawn starting
+/// from `(row, col)`, and how many columns it occupies.
+///
+/// The caller advances by adding the returned width, so the returned position
+/// is where the grapheme *is*, not where the cursor ends up. Split out because
+/// the reverse mapping in `Painter::screen_to_buffer_offset` has to walk the
+/// same rule to turn a screen position back into a buffer offset, and the two
+/// disagreeing is how a click lands on the wrong grapheme.
+pub(crate) fn advance_grapheme(
+    (row, col): (u16, u16),
+    grapheme: &str,
+    terminal_columns: u16,
+) -> ((u16, u16), u16) {
+    match grapheme {
+        "\n" => ((row.saturating_add(1), 0), 0),
+        "\r" => ((row, 0), 0),
+        _ => {
+            let width = grapheme.width() as u16;
+            let (mut row, mut col) = (row, col);
+            // The wrap this grapheme's arrival was deferred until.
+            // Both checks can fire for one grapheme, so a single `||`
+            // loses a row: a zero-width one trips only this.
+            if col >= terminal_columns {
+                (row, col) = (row.saturating_add(1), 0);
+            }
+            // No room for the whole grapheme: the trailing column stays
+            // blank and the terminal wraps before drawing it. Only from a
+            // column the run has already reached, since a grapheme wider
+            // than the whole terminal has no row it would fit on and
+            // wrapping it again would spend a row per glyph.
+            if col > 0 && col.saturating_add(width) > terminal_columns {
+                (row, col) = (row.saturating_add(1), 0);
+            }
+            ((row, col), width)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -280,9 +301,10 @@ mod test {
     // A zero-width grapheme at the margin, which the straddle check cannot
     // see since adding nothing never exceeds the width.
     #[case(&format!("{}\u{200b}", "a".repeat(20)), 20, Some((0, 1)))]
-    // Wider than the whole terminal, so the column ends past the margin and
-    // the next grapheme spends a row on each check.
-    #[case("日日", 1, Some((2, 3)))]
+    // Wider than the whole terminal: there is no row it would fit on, so it
+    // overflows the one it is on rather than wrapping to another. The column
+    // ends past the margin and `resolve_wrap` moves the cursor off it.
+    #[case("日日", 1, Some((2, 1)))]
     // No layout exists without columns to lay out in.
     #[case(&"a".repeat(20), 0, None)]
     fn wrap_position_reports_the_landing_column(

--- a/src/painting/utils.rs
+++ b/src/painting/utils.rs
@@ -55,19 +55,19 @@ pub(crate) fn estimate_required_lines(input: &str, screen_width: u16) -> usize {
 
 /// Reports the additional lines needed due to wrapping for the given line.
 ///
-/// Does not account for any potential line breaks in `line`
+/// Callers pre-split, so `line` is not expected to contain a line break;
+/// [`wrap_position`] would count one as a row.
 ///
 /// If `line` fits in `terminal_columns` returns 0. A zero-width
-/// `terminal_columns` can be reported by terminals mid-resize or when
-/// the size is unknown; return 0 in that case rather than dividing by
-/// zero (see #842).
+/// `terminal_columns` can be reported by terminals mid-resize or when the
+/// size is unknown; there is no layout to report, so [`wrap_position`]
+/// answers `None` and this reports 0 (see #842).
 ///
-/// Dividing assumes glyphs pack a row exactly, which a double-width
-/// grapheme at the margin does not. A reserved row too few or too many is
-/// recoverable, so the cheap model stays here; [`deferred_wrap_row`] pays
-/// for an exact one where the error would land on screen.
+/// Rows the line *wraps onto*, not rows the cursor reaches: a line filling
+/// the width exactly wraps onto none and leaves the cursor pending on the
+/// next. Only the callers placing a cursor count that row.
 ///
-/// FIXME: The zero-column guard below papers over a caller bug, it
+/// FIXME: the zero-column guard papers over a caller bug, it
 /// doesn't solve it. `menu::list_menu::ListMenu::menu_required_lines`
 /// passes `terminal_columns.saturating_sub(indicator_width + count_digits)`,
 /// so on a terminal whose width is not greater than the indicator plus
@@ -77,17 +77,10 @@ pub(crate) fn estimate_required_lines(input: &str, screen_width: u16) -> usize {
 /// subtracting the indicator width from the entry width). Tracked in
 /// #842 / #428; remove this comment once the caller is fixed.
 pub(crate) fn estimate_single_line_wraps(line: &str, terminal_columns: u16) -> usize {
-    let terminal_columns: usize = terminal_columns.into();
-    if terminal_columns == 0 {
+    let Some((_, row)) = wrap_position([line], terminal_columns) else {
         return 0;
-    }
-    let estimated_width = line_width(line);
-
-    // integer ceiling rounding division for positive divisors
-    let estimated_line_count = estimated_width.div_ceil(terminal_columns);
-
-    // Any wrapping will add to our overall line count
-    estimated_line_count.saturating_sub(1)
+    };
+    row as usize
 }
 
 /// Compute the line width for ANSI escaped text
@@ -95,8 +88,8 @@ pub(crate) fn line_width(line: &str) -> usize {
     strip_ansi(line).width()
 }
 
-/// Where printing `pieces` leaves the cursor, when it lands on the terminal's
-/// right margin in the *deferred wrap* state.
+/// Which row to move to when printing `pieces` lands the cursor on the
+/// terminal's right margin, in the *deferred wrap* state.
 ///
 /// A terminal does not move to the next row when a glyph lands in the final
 /// column; it flags the cursor pending and only wraps once the next glyph
@@ -106,25 +99,47 @@ pub(crate) fn line_width(line: &str) -> usize {
 /// the run that row is, or `None` off the margin, where restoring is already
 /// unambiguous. `pieces` are laid out end to end, since the walk is a fold and
 /// never looks backwards.
-///
-/// Counted a grapheme at a time rather than by dividing the run's width, which
-/// [`estimate_required_lines`] and friends still do. A double-width grapheme
-/// with one column left cannot be split, so the terminal blanks that column and
-/// wraps early: division reads a 42-column run on a 21-column terminal as two
-/// exact rows ending on the margin, when the terminal needs three and leaves
-/// the cursor mid-row. That is the difference between restoring the cursor and
-/// moving it somewhere it never was.
 pub(crate) fn deferred_wrap_row<'a>(
     pieces: impl IntoIterator<Item = &'a str>,
     terminal_columns: u16,
 ) -> Option<u16> {
+    let end = wrap_position(pieces, terminal_columns)?;
+    (end.0 >= terminal_columns).then(|| resolve_wrap(end, terminal_columns).1)
+}
+
+/// Where the cursor rests once a [`wrap_position`] landing is resolved: a run
+/// ending on the margin left the wrap pending, and that belongs to the home
+/// column of the next row (#1141), not to the column it filled.
+///
+/// The single owner of that rule, since every caller placing a cursor needs it
+/// and one of them getting the saturation wrong is a panic, not a drawing bug.
+pub(crate) fn resolve_wrap((col, row): (u16, u16), terminal_columns: u16) -> (u16, u16) {
+    if col >= terminal_columns {
+        (0, row.saturating_add(1))
+    } else {
+        (col, row)
+    }
+}
+
+/// Where printing `pieces` leaves the cursor, walked a grapheme at a time
+/// rather than divided out of the run's width. A double-width grapheme with
+/// one column left cannot be split, so the terminal blanks that column and
+/// wraps early: division reads a 42-column run on a 21-column terminal as two
+/// exact rows ending on the margin, when the terminal needs three.
+///
+/// Returns `(column, rows past the start of the run)`. The column may equal
+/// `terminal_columns`: the *deferred wrap* state, where the run has filled the
+/// row but nothing has arrived to push it over. Resolving that is the caller's
+/// job: [`resolve_wrap`] for the cursor-placing ones, and the estimators do
+/// not count it at all.
+pub(crate) fn wrap_position<'a>(
+    pieces: impl IntoIterator<Item = &'a str>,
+    terminal_columns: u16,
+) -> Option<(u16, u16)> {
     let columns: usize = terminal_columns.into();
     if columns == 0 {
         return None;
     }
-
-    // `col == columns` *is* the deferred wrap: the run has filled the row but
-    // nothing has arrived to push it over yet.
     let (mut row, mut col) = (0u16, 0usize);
     for piece in pieces {
         for grapheme in strip_ansi(piece).graphemes(true) {
@@ -134,6 +149,8 @@ pub(crate) fn deferred_wrap_row<'a>(
                 _ => {
                     let width = grapheme.width();
                     // The wrap this grapheme's arrival was deferred until.
+                    // Both checks can fire for one grapheme, so a single `||`
+                    // loses a row: a zero-width one trips only this.
                     if col >= columns {
                         (row, col) = (row.saturating_add(1), 0);
                     }
@@ -147,8 +164,7 @@ pub(crate) fn deferred_wrap_row<'a>(
             }
         }
     }
-
-    (col >= columns).then(|| row.saturating_add(1))
+    Some((col as u16, row))
 }
 
 #[cfg(test)]
@@ -243,6 +259,59 @@ mod test {
         assert_eq!(deferred_wrap_row([printed], columns), expected);
     }
 
+    /// The column [`deferred_wrap_row`] throws away: it only asks whether the
+    /// run reached the margin, so the cases above prove one bit of this tuple.
+    /// The two `"hello"` cases are that tuple at two widths, since a column is
+    /// only a margin relative to what it is compared against.
+    #[rstest]
+    #[case("hello", 5, Some((5, 0)))]
+    #[case("hello", 6, Some((5, 0)))]
+    // Wide graphemes straddling an odd margin, which division reads as an
+    // exact row and gets both axes wrong on.
+    #[case("日本語日本語", 11, Some((2, 1)))]
+    #[case("日本語日本語日本語日本", 11, Some((2, 2)))]
+    #[case("日a日a日a日a", 7, Some((6, 1)))]
+    #[case("aaa日本語", 7, Some((2, 1)))]
+    #[case("hello world", 5, Some((1, 2)))]
+    // A hard break lands on column 0 of the next row without touching the
+    // margin, so the column alone cannot stand in for the deferred wrap.
+    #[case("ab\n", 5, Some((0, 1)))]
+    #[case("ab\nc", 5, Some((1, 1)))]
+    // A zero-width grapheme at the margin, which the straddle check cannot
+    // see since adding nothing never exceeds the width.
+    #[case(&format!("{}\u{200b}", "a".repeat(20)), 20, Some((0, 1)))]
+    // Wider than the whole terminal, so the column ends past the margin and
+    // the next grapheme spends a row on each check.
+    #[case("日日", 1, Some((2, 3)))]
+    // No layout exists without columns to lay out in.
+    #[case(&"a".repeat(20), 0, None)]
+    fn wrap_position_reports_the_landing_column(
+        #[case] printed: &str,
+        #[case] columns: u16,
+        #[case] expected: Option<(u16, u16)>,
+    ) {
+        assert_eq!(wrap_position([printed], columns), expected);
+    }
+
+    /// A margin landing on the last row a `u16` can name. `wrap_position`
+    /// saturates `row`, so the resolver has to as well, or it panics in debug
+    /// on a buffer long enough to reach it.
+    #[test]
+    fn resolve_wrap_saturates_at_the_last_row() {
+        assert_eq!(resolve_wrap((20, u16::MAX), 20), (0, u16::MAX));
+        assert_eq!(resolve_wrap((20, 3), 20), (0, 4));
+        // Off the margin the landing passes through untouched.
+        assert_eq!(resolve_wrap((5, u16::MAX), 20), (5, u16::MAX));
+    }
+
+    /// `pieces` are laid end to end, not measured one at a time: `"ab"` and
+    /// `"cd"` each fit three columns alone, and together they do not.
+    #[test]
+    fn wrap_position_lays_pieces_end_to_end() {
+        assert_eq!(wrap_position(["ab", "cd"], 3), Some((1, 1)));
+        assert_eq!(wrap_position(["abcd"], 3), Some((1, 1)));
+    }
+
     /// Regression: no-color rendering strips ANSI bytes before CRLF coercion,
     /// so text after the cursor can start with the raw LF that moves to the
     /// next continuation prompt. The leading replacement was lost before
@@ -266,6 +335,11 @@ mod test {
     #[case("hello", 80, 0)]
     #[case("abcdefghij", 5, 1)]
     #[case("abcdefghijk", 5, 2)]
+    // Wide graphemes straddle the margin instead of packing it, so the text
+    // takes a row division cannot see: 22 columns across 11 is two exact rows
+    // by division and three by layout, 10 across 5 is two and three.
+    #[case("日本語日本語日本語日本", 11, 2)]
+    #[case(&"あ".repeat(5), 5, 2)]
     fn estimate_single_line_wraps_basic(
         #[case] line: &str,
         #[case] columns: u16,


### PR DESCRIPTION
## Summary

The terminal wrap rule was implemented three times with three different semantics: `estimate_single_line_wraps` divided the run's width by the terminal width, `deferred_wrap_row` walked graphemes, and `screen_to_buffer_offset` walked them differently again.
Division assumes glyphs pack a row exactly, which a double-width grapheme at the margin does not, since it cannot be split and the terminal wraps early.
`cursor_pos` was the worst of it, taking its row from a ceiling division and its column from a modulo of the same width.

This unifies the rule on one grapheme walk, `wrap_position`, with the margin rule in its own resolver, `resolve_wrap`, so the #1141 convention lives in one place rather than at every call site.

No public API change.

### Before

`cursor_pos` against what the terminal actually does, at 11 columns:

| buffer | model | terminal |
| --- | --- | --- |
| `"日本語日本語"` | `(1, 1)` | `(2, 1)` |
| `"日本語日本語日本語日本"` | `(0, 1)` | `(2, 2)` |

`distance_from_prompt` counted `.lines()`, which drops a trailing newline, so a cursor on a fresh continuation row reported the row above it.
`menu_start_row` is `prompt_start_row + cursor_distance + 1`, thus the completion menu was drawn on top of the cursor's own line.

### After

Both land where the terminal holds the cursor.
A run ending on the margin resolves to the home column of the next row, as `deferred_wrap_row` has since #1141, and `required_lines` reserves that row so the menu below it stays inside the reservation.

`estimate_single_line_wraps` deliberately does not count that row, since it measures rows the text wraps onto and `list_menu::menu_required_lines` uses it for drawn entry height, where no cursor lands.

