### PR TITLE
fix(helix): count the resting block caret as end of buffer

### DIFF
--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -823,25 +823,24 @@ impl Editor {
     pub(crate) fn is_cursor_at_buffer_end(&self) -> bool {
         let buf = self.get_buffer();
         let cursor = self.line_buffer.cursor();
-        // An active selection is never a clean end-of-buffer point. Completing a
-        // history hint (or appending) here would run through `delete_selection`
-        // and clobber the selection — so report `false`, matching the old
-        // caret-based check, which a forward selection's caret (one inward from
-        // `len`) already failed.
-        if !cursor.is_empty() {
+        // An intentional selection is never a clean end-of-buffer point:
+        // accepting a hint here would silently drop it. A resting caret is
+        // fine, but a block mode rests as a min-width-1 range, not an empty
+        // point, and shape alone cannot tell that from a `v`-started
+        // one-grapheme selection covering the last grapheme. Only the mode can.
+        let multi_grapheme = next_grapheme_boundary(buf, cursor.start()) < cursor.end();
+        let active_selection = !cursor.is_empty() && self.edit_mode.is_selection_mode();
+        if multi_grapheme || active_selection {
             return false;
         }
+        // Measure from the visible caret: `insertion_point` already resolves
+        // the covered grapheme for Block and the trailing gap for Bar, whether
+        // the cursor is a point or a min-width-1 block.
+        let caret = self.insertion_point();
         if self.caret_geometry() == CaretGeometry::Block {
-            // Cell caret (vi normal): the resting point sits *on* the last
-            // grapheme, one inward from `len`. "At the end" means that cell is the
-            // final one — nothing lies to its right. (A bare `head == len` check
-            // never holds here, which is why a history hint stopped completing in
-            // normal mode after the cursor became the single source of truth.)
-            next_grapheme_boundary(buf, cursor.head()) == buf.len()
+            next_grapheme_boundary(buf, caret) == buf.len()
         } else {
-            // Bar caret (emacs / vi insert): at the end iff the head rests past
-            // the last grapheme.
-            cursor.head() == buf.len()
+            caret == buf.len()
         }
     }
 
@@ -3342,6 +3341,21 @@ mod test {
         for _ in 0..3 {
             editor.run_edit_command(&EditCommand::MoveRight { select: true });
         }
+        assert!(!editor.is_cursor_at_buffer_end());
+    }
+
+    #[test]
+    fn cursor_at_buffer_end_holds_for_helix_block_caret() {
+        // Regression: in helix normal mode the resting cursor is a min-width-1
+        // block `[len-1, len)`, not an empty point, so "at buffer end" must
+        // still hold there, or up/`k` does plain history traversal instead of
+        // the prefix search vi normal gets.
+        let mut editor = editor_with("abc");
+        editor.set_edit_mode(PromptEditMode::Helix(crate::PromptHelixMode::Normal));
+        editor.run_edit_command(&EditCommand::MoveToLineEnd { select: false });
+        assert!(editor.is_cursor_at_buffer_end());
+        // Not at the end: a min-width-1 block on the first grapheme.
+        editor.run_edit_command(&EditCommand::MoveToLineStart { select: false });
         assert!(!editor.is_cursor_at_buffer_end());
     }
 

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -823,14 +823,21 @@ impl Editor {
     pub(crate) fn is_cursor_at_buffer_end(&self) -> bool {
         let buf = self.get_buffer();
         let cursor = self.line_buffer.cursor();
-        // An intentional selection is never a clean end-of-buffer point:
-        // accepting a hint here would silently drop it. A resting caret is
-        // fine, but a block mode rests as a min-width-1 range, not an empty
-        // point, and shape alone cannot tell that from a `v`-started
-        // one-grapheme selection covering the last grapheme. Only the mode can.
-        let multi_grapheme = next_grapheme_boundary(buf, cursor.start()) < cursor.end();
-        let active_selection = !cursor.is_empty() && self.edit_mode.is_selection_mode();
-        if multi_grapheme || active_selection {
+        // A selection is never a clean end-of-buffer point: accepting a hint
+        // here would run through `prepare_append_at_buffer_end` and silently
+        // drop it. Under a bar caret the resting cursor is an empty point, so
+        // any non-empty cursor is a selection and shape settles it. A block
+        // caret rests as a min-width-1 range, so shape alone cannot tell a
+        // resting caret from a `v`-started one-grapheme selection covering the
+        // last grapheme; only the mode can. Asking the mode under a bar caret
+        // too would miss the shift-selections emacs and vi insert can hold.
+        let selection = if self.caret_geometry() == CaretGeometry::Block {
+            next_grapheme_boundary(buf, cursor.start()) < cursor.end()
+                || (!cursor.is_empty() && self.edit_mode.is_selection_mode())
+        } else {
+            !cursor.is_empty()
+        };
+        if selection {
             return false;
         }
         // Measure from the visible caret: `insertion_point` already resolves
@@ -3345,18 +3352,25 @@ mod test {
     }
 
     #[test]
-    fn cursor_at_buffer_end_holds_for_helix_block_caret() {
-        // Regression: in helix normal mode the resting cursor is a min-width-1
-        // block `[len-1, len)`, not an empty point, so "at buffer end" must
-        // still hold there, or up/`k` does plain history traversal instead of
-        // the prefix search vi normal gets.
-        let mut editor = editor_with("abc");
-        editor.set_edit_mode(PromptEditMode::Helix(crate::PromptHelixMode::Normal));
-        editor.run_edit_command(&EditCommand::MoveToLineEnd { select: false });
-        assert!(editor.is_cursor_at_buffer_end());
-        // Not at the end: a min-width-1 block on the first grapheme.
-        editor.run_edit_command(&EditCommand::MoveToLineStart { select: false });
-        assert!(!editor.is_cursor_at_buffer_end());
+    fn cursor_at_buffer_end_fails_on_a_bar_caret_selection() {
+        // A bar caret rests as an empty point, so any non-empty cursor is a
+        // real selection however narrow: a one-grapheme shift-selection covering
+        // the last grapheme is not `multi_grapheme` and emacs is not a selection
+        // mode, so shape and mode each miss it on their own. Completing a hint
+        // here would collapse the cursor and drop the selection.
+        for mode in [
+            PromptEditMode::Emacs,
+            PromptEditMode::Default,
+            PromptEditMode::Vi(PromptViMode::Insert),
+        ] {
+            let mut editor = editor_with("abc");
+            editor.set_edit_mode(mode.clone());
+            editor.run_edit_command(&EditCommand::MoveToLineEnd { select: false });
+            editor.run_edit_command(&EditCommand::MoveLeft { select: false });
+            editor.run_edit_command(&EditCommand::MoveRight { select: true });
+            assert_eq!(editor.get_selection(), Some((2, 3)), "{mode:?}");
+            assert!(!editor.is_cursor_at_buffer_end(), "{mode:?}");
+        }
     }
 
     #[test]
@@ -4355,6 +4369,20 @@ mod test {
             let mut editor = editor_with(buffer);
             editor.set_edit_mode(PromptEditMode::Helix(crate::PromptHelixMode::Normal));
             editor
+        }
+
+        #[test]
+        fn cursor_at_buffer_end_holds_for_the_resting_block_caret() {
+            // Regression: the resting cursor is a min-width-1 block
+            // `[len-1, len)`, not an empty point, so "at buffer end" must still
+            // hold there, or up/`k` does plain history traversal instead of the
+            // prefix search vi normal gets.
+            let mut editor = helix_editor("abc");
+            editor.run_edit_command(&EditCommand::MoveToLineEnd { select: false });
+            assert!(editor.is_cursor_at_buffer_end());
+            // Not at the end: a min-width-1 block on the first grapheme.
+            editor.run_edit_command(&EditCommand::MoveToLineStart { select: false });
+            assert!(!editor.is_cursor_at_buffer_end());
         }
 
         #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4653,6 +4653,83 @@ mod tests {
         assert_eq!(rl.editor.get_buffer(), "abc");
     }
 
+    /// Helix normal rests as a min-width-1 block, not an empty point. The
+    /// buffer-end guard must read that as a resting caret, not a selection, or
+    /// a history hint never completes in normal mode.
+    #[test]
+    fn helix_normal_history_hint_appends_at_buffer_end() {
+        let mut rl =
+            seam_engine(Box::<crate::Helix>::default()).with_hinter(Box::new(FixedHinter("def")));
+        type_each(&mut rl, &[ch('a'), ch('b'), ch('c'), key(KeyCode::Esc)]);
+        assert!(
+            !rl.editor.line_buffer().cursor().is_empty(),
+            "setup: the helix block caret is a one-grapheme range"
+        );
+        rl.handle_event(
+            &DefaultPrompt::default(),
+            ReedlineEvent::HistoryHintComplete,
+        )
+        .unwrap();
+        assert_eq!(rl.editor.get_buffer(), "abcdef");
+    }
+
+    /// A `v`-started helix selection is still protected, like vi visual.
+    #[test]
+    fn helix_select_selection_blocks_hint_completion() {
+        let mut rl =
+            seam_engine(Box::<crate::Helix>::default()).with_hinter(Box::new(FixedHinter("def")));
+        type_each(
+            &mut rl,
+            &[ch('a'), ch('b'), ch('c'), key(KeyCode::Esc), ch('v')],
+        );
+        rl.handle_event(
+            &DefaultPrompt::default(),
+            ReedlineEvent::HistoryHintComplete,
+        )
+        .unwrap();
+        assert_eq!(rl.editor.get_buffer(), "abc");
+    }
+
+    /// A retained motion selection in helix *normal* (here `b` sweeping back
+    /// over the word) is multi-grapheme, so it blocks completion even though
+    /// normal is not a selection mode.
+    #[test]
+    fn helix_normal_motion_selection_blocks_hint_completion() {
+        let mut rl =
+            seam_engine(Box::<crate::Helix>::default()).with_hinter(Box::new(FixedHinter("def")));
+        type_each(
+            &mut rl,
+            &[ch('a'), ch('b'), ch('c'), key(KeyCode::Esc), ch('b')],
+        );
+        let cursor = rl.editor.line_buffer().cursor();
+        assert!(
+            cursor.end() - cursor.start() > 1,
+            "setup: `b` leaves a multi-grapheme selection standing"
+        );
+        rl.handle_event(
+            &DefaultPrompt::default(),
+            ReedlineEvent::HistoryHintComplete,
+        )
+        .unwrap();
+        assert_eq!(rl.editor.get_buffer(), "abc");
+    }
+
+    /// The prefix-search side of the same guard: helix normal's resting block
+    /// still counts as "at buffer end", so `k` prefix-searches history like vi
+    /// normal instead of walking it plainly.
+    #[test]
+    fn helix_normal_k_uses_prefix_search() {
+        let mut rl = seam_engine(Box::<crate::Helix>::default());
+        for entry in ["ls -la", "ls /tmp", "echo hi"] {
+            rl.history
+                .save(HistoryItem::from_command_line(entry))
+                .unwrap();
+        }
+        type_each(&mut rl, &[ch('l'), ch('s'), key(KeyCode::Esc)]);
+        drive(&mut rl, &[ch('k')]);
+        assert_eq!(rl.editor.get_buffer(), "ls /tmp");
+    }
+
     #[test]
     fn undo_removes_accepted_history_hint() {
         let mut rl = vi_with_hint("def");

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4623,6 +4623,10 @@ mod tests {
         seam_engine(Box::<crate::Vi>::default()).with_hinter(Box::new(FixedHinter(hint)))
     }
 
+    fn helix_with_hint(hint: &'static str) -> Reedline {
+        seam_engine(Box::<crate::Helix>::default()).with_hinter(Box::new(FixedHinter(hint)))
+    }
+
     #[test]
     fn vi_normal_history_hint_appends_at_buffer_end() {
         // The reported bug: a block caret rests on the last grapheme, so the
@@ -4658,8 +4662,7 @@ mod tests {
     /// a history hint never completes in normal mode.
     #[test]
     fn helix_normal_history_hint_appends_at_buffer_end() {
-        let mut rl =
-            seam_engine(Box::<crate::Helix>::default()).with_hinter(Box::new(FixedHinter("def")));
+        let mut rl = helix_with_hint("def");
         type_each(&mut rl, &[ch('a'), ch('b'), ch('c'), key(KeyCode::Esc)]);
         assert!(
             !rl.editor.line_buffer().cursor().is_empty(),
@@ -4676,8 +4679,7 @@ mod tests {
     /// A `v`-started helix selection is still protected, like vi visual.
     #[test]
     fn helix_select_selection_blocks_hint_completion() {
-        let mut rl =
-            seam_engine(Box::<crate::Helix>::default()).with_hinter(Box::new(FixedHinter("def")));
+        let mut rl = helix_with_hint("def");
         type_each(
             &mut rl,
             &[ch('a'), ch('b'), ch('c'), key(KeyCode::Esc), ch('v')],
@@ -4695,8 +4697,7 @@ mod tests {
     /// normal is not a selection mode.
     #[test]
     fn helix_normal_motion_selection_blocks_hint_completion() {
-        let mut rl =
-            seam_engine(Box::<crate::Helix>::default()).with_hinter(Box::new(FixedHinter("def")));
+        let mut rl = helix_with_hint("def");
         type_each(
             &mut rl,
             &[ch('a'), ch('b'), ch('c'), key(KeyCode::Esc), ch('b')],
@@ -4712,6 +4713,17 @@ mod tests {
         )
         .unwrap();
         assert_eq!(rl.editor.get_buffer(), "abc");
+    }
+
+    /// The issue as filed pressed a key, not an event: `Right` reaches
+    /// `HistoryHintComplete` through the keymap's `UntilFound` chain, so this
+    /// covers the wiring the event-level tests above skip past.
+    #[test]
+    fn helix_normal_right_key_completes_the_hint() {
+        let mut rl = helix_with_hint("def");
+        type_each(&mut rl, &[ch('a'), ch('b'), ch('c'), key(KeyCode::Esc)]);
+        drive(&mut rl, &[key(KeyCode::Right)]);
+        assert_eq!(rl.editor.get_buffer(), "abcdef");
     }
 
     /// The prefix-search side of the same guard: helix normal's resting block

--- a/src/prompt/base.rs
+++ b/src/prompt/base.rs
@@ -95,6 +95,24 @@ impl PromptEditMode {
         }
     }
 
+    /// Whether a non-empty cursor in this mode is an *intentional selection*
+    /// rather than the resting caret.
+    ///
+    /// A block mode rests one grapheme wide, so cursor shape alone cannot tell
+    /// vi visual's `v`-started selection from helix normal's resting block;
+    /// the mode has to answer.
+    pub(crate) fn is_selection_mode(&self) -> bool {
+        match self {
+            PromptEditMode::Vi(PromptViMode::Visual)
+            | PromptEditMode::Helix(PromptHelixMode::Select) => true,
+            PromptEditMode::Vi(PromptViMode::Normal | PromptViMode::Insert)
+            | PromptEditMode::Helix(PromptHelixMode::Normal | PromptHelixMode::Insert)
+            | PromptEditMode::Default
+            | PromptEditMode::Emacs
+            | PromptEditMode::Custom(_) => false,
+        }
+    }
+
     /// Whether an operation *on* the selection leaves it standing.
     ///
     /// Helix keeps it, so a yank or a case change can be followed by another


### PR DESCRIPTION
## Summary

`is_cursor_at_buffer_end` rejected any non-empty cursor, and helix normal rests as a min-width-1 block rather than an empty point.
The guard was thus never true there, so both history hint completion and the fish-style prefix search on up/k were silently inapplicable in helix normal, while vi normal (an empty point under OnGrapheme) kept working.

Cursor shape alone cannot decide this.
A v-started one-grapheme selection covering the last grapheme and helix normal's resting block are the same range, thus only the mode knows which one it is looking at.
That is what `PromptEditMode::is_selection_mode` asks it.

No public API change.

Observable behavior: `HistoryHintComplete`, `HistoryHintWordComplete` and the prefix search now work in helix normal.

## Additional notes

closes #1185