### PR TITLE
fix(helix): rebuild a backward extend through put_cursor

### DIFF
--- a/src/core_editor/cursor.rs
+++ b/src/core_editor/cursor.rs
@@ -686,10 +686,11 @@ mod tests {
 
     #[test]
     fn extend_span_block_flip_forward_to_backward_keeps_anchor_grapheme() {
-        // Helix groundwork (no current mode pairs Span with Block): a Span that
-        // reverses past the anchor still hops it onto the far edge — the same
-        // flip_anchor as put_cursor — but the head lands exactly on op_end with
-        // no widening. [2,4) → op_end 0 → [3,0).
+        // Helix pairs Span with Block for forward travel only (a backward Extend
+        // rebuilds through put_cursor), thus this reversal is reached from the
+        // primitive rather than from a mode. It still hops the anchor onto the far
+        // edge — the same flip_anchor as put_cursor — but the head lands exactly
+        // on op_end with no widening. [2,4) → op_end 0 → [3,0).
         let c = Cursor::new(2, 4).extend_span("hello", 0, CaretGeometry::Block);
         assert_eq!(c, Cursor::new(3, 0));
         assert!(c.contains(2)); // start grapheme survives the reversal

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -137,6 +137,20 @@ impl Editor {
                     let head = self.resolve_head(*t);
                     self.move_head_to(head, true);
                 }
+                // `motion_origin` departs backward travel from the visible
+                // caret, which under a block caret already sits one grapheme
+                // inside the head. `extend_span` would park the head on `op_end`
+                // and the caret is rendered one grapheme back again, so that
+                // offset lands twice and one press moves two cells (#1190).
+                // `put_cursor` instead places the head so the caret comes to rest
+                // exactly on the resolved target.
+                //
+                // Forward keeps `extend_span`, since it departs from the head and
+                // has no offset to undo.
+                SelectionExtent::Span if t.direction() == Some(Direction::Backward) => {
+                    let head = self.resolve_head(*t);
+                    self.move_head_to(head, true);
+                }
                 SelectionExtent::Span => {
                     let geom = self.caret_geometry();
                     let origin = self.motion_origin(*t);
@@ -774,6 +788,9 @@ impl Editor {
     /// Which way `target` travels is read against the *visible* cursor, so the
     /// answer never depends on the edge being picked. Under `Between` both edges
     /// are the head, so this is a no-op there.
+    ///
+    /// Only half the answer: which rebuild consumes the origin matters just as
+    /// much, see the `Span` arms of the `Extend` dispatch.
     fn motion_origin(&self, target: MotionTarget) -> usize {
         let reference = self.insertion_point();
         match target.direction() {
@@ -4773,10 +4790,53 @@ mod test {
             let mut editor = helix_select_editor("foo bar baz");
             editor.move_to_position(4, false);
             editor.run_edit_command(&EditCommand::Extend(word_start_fwd()));
+            // "bar " with the caret on the trailing space, thus one `h` walks it
+            // onto `r` and the selection reads "bar". Pinned 6 while the backward
+            // rebuild still moved the caret two cells (#1190).
             editor.run_edit_command(&EditCommand::Extend(MotionTarget::Grapheme(
                 Direction::Backward,
             )));
-            assert_eq!(editor.line_buffer.cursor(), Cursor::new(4, 6));
+            assert_eq!(editor.line_buffer.cursor(), Cursor::new(4, 7));
+            assert_eq!(editor.get_selection(), Some((4, 7)));
+        }
+
+        // --- one cell per backward press (#1190) ---
+        //
+        // Every case starts from a selection left *forward* and wider than one
+        // grapheme, since that is the only shape the two-cell step shows up in.
+        // From the resting block the first press reverses the cursor, and a
+        // backward cursor's caret is its head, thus the doubling cancels there.
+
+        #[rstest]
+        #[case::grapheme(MotionTarget::Grapheme(Direction::Backward), vec![4, 3, 2, 1, 0])]
+        #[case::word_start(word_start_bwd(), vec![4, 0, 0])]
+        #[case::line_start(MotionTarget::LineEdge(Direction::Backward), vec![0, 0])]
+        fn helix_extend_backward_walks_one_cell_per_press(
+            #[case] target: MotionTarget,
+            #[case] carets: Vec<usize>,
+        ) {
+            let mut editor = helix_select_editor("abc de");
+            editor.run_edit_command(&EditCommand::SelectAll);
+            assert_eq!(editor.insertion_point(), 5);
+            for expected in carets {
+                editor.run_edit_command(&EditCommand::Extend(target));
+                assert_eq!(editor.insertion_point(), expected);
+            }
+        }
+
+        #[test]
+        fn helix_extend_backward_still_flips_the_resting_block() {
+            // The case that was already right, pinned so the backward rebuild
+            // cannot regress it: the press reverses the cursor and keeps `e`
+            // covered rather than shrinking to a point.
+            let mut editor = helix_select_editor("abc de");
+            editor.run_edit_command(&EditCommand::MoveToLineEnd { select: false });
+            assert_eq!(editor.line_buffer.cursor(), Cursor::new(5, 6));
+            editor.run_edit_command(&EditCommand::Extend(MotionTarget::Grapheme(
+                Direction::Backward,
+            )));
+            assert_eq!(editor.line_buffer.cursor(), Cursor::new(6, 4));
+            assert_eq!(editor.insertion_point(), 4);
         }
 
         // --- the newline as a cell (helix `l` / `h`) ---

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -128,32 +128,42 @@ impl Editor {
             // covered turns on which side of the *anchor* it falls, which only
             // `put_cursor` can see. Helix lowers its own (`gs`) through
             // `put_cursor` in select mode too, so take that path either way.
-            EditCommand::Extend(t) if t.direction().is_none() => {
-                let head = self.resolve_head(*t);
-                self.move_head_to(head, true);
-            }
+            EditCommand::Extend(t) if t.direction().is_none() => self.apply_move(*t, true),
             EditCommand::Extend(t) => match self.caret_extent() {
-                SelectionExtent::CoverLanding => {
-                    let head = self.resolve_head(*t);
-                    self.move_head_to(head, true);
-                }
-                // `motion_origin` departs backward travel from the visible
-                // caret, which under a block caret already sits one grapheme
-                // inside the head. `extend_span` would park the head on `op_end`
-                // and the caret is rendered one grapheme back again, so that
-                // offset lands twice and one press moves two cells (#1190).
+                SelectionExtent::CoverLanding => self.apply_move(*t, true),
+                // Backward travel departs from the visible caret, which under a
+                // block caret already sits one grapheme inside the head.
+                // `extend_span` would park the head on `op_end` and the caret is
+                // rendered one grapheme back again, so that offset lands twice
+                // and one press moves two cells (#1190). Only while the cursor
+                // is still forward: once a press reverses it the caret *is* the
+                // head and the offset cancels, which is why the doubling shows
+                // up on the first press out of a forward selection and not after.
+                //
                 // `put_cursor` instead places the head so the caret comes to rest
-                // exactly on the resolved target.
+                // exactly on the resolved target. That is `CoverLanding`'s head
+                // placement inside a `Span` mode, which the two are otherwise
+                // orthogonal to (see `SelectionExtent`): backward travel is the
+                // one direction where `Span` has no inclusivity of its own to
+                // encode, since `op_end` and the caret disagree about the same
+                // grapheme.
                 //
                 // Forward keeps `extend_span`, since it departs from the head and
                 // has no offset to undo.
                 SelectionExtent::Span if t.direction() == Some(Direction::Backward) => {
-                    let head = self.resolve_head(*t);
-                    self.move_head_to(head, true);
+                    self.apply_move(*t, true)
                 }
                 SelectionExtent::Span => {
+                    // Only forward travel reaches here: the arms above take the
+                    // directionless and backward targets. Forward departs from
+                    // the head rather than the visible caret, since a forward
+                    // block selection puts the caret on the near edge of its head
+                    // grapheme and the head on the far edge. Departing from the
+                    // caret would make an exclusive forward motion a no-op,
+                    // landing on the boundary the previous `Extend` parked the
+                    // head on.
                     let geom = self.caret_geometry();
-                    let origin = self.motion_origin(*t);
+                    let origin = self.line_buffer.cursor().head();
                     let op_end = resolve_motion(self.get_buffer(), origin, *t, geom).op_end;
                     let next =
                         self.line_buffer
@@ -772,30 +782,6 @@ impl Editor {
             cursor.head()
         } else {
             cursor.caret(self.line_buffer.get_buffer())
-        }
-    }
-
-    /// The edge `target` departs from — the origin an `Extend` resolves against,
-    /// as opposed to [`insertion_point`](Self::insertion_point)'s *where the
-    /// cursor is*.
-    ///
-    /// A forward block selection puts the caret on the near edge of its head
-    /// grapheme and the head on the far edge, so forward travel departs from the
-    /// head and backward travel from the caret. Departing from the caret both
-    /// ways makes an exclusive forward motion a no-op — it lands on the very
-    /// boundary the previous `Extend` parked the head on.
-    ///
-    /// Which way `target` travels is read against the *visible* cursor, so the
-    /// answer never depends on the edge being picked. Under `Between` both edges
-    /// are the head, so this is a no-op there.
-    ///
-    /// Only half the answer: which rebuild consumes the origin matters just as
-    /// much, see the `Span` arms of the `Extend` dispatch.
-    fn motion_origin(&self, target: MotionTarget) -> usize {
-        let reference = self.insertion_point();
-        match target.direction() {
-            Some(Direction::Forward) => self.line_buffer.cursor().head(),
-            _ => reference,
         }
     }
 
@@ -4791,8 +4777,8 @@ mod test {
             editor.move_to_position(4, false);
             editor.run_edit_command(&EditCommand::Extend(word_start_fwd()));
             // "bar " with the caret on the trailing space, thus one `h` walks it
-            // onto `r` and the selection reads "bar". Pinned 6 while the backward
-            // rebuild still moved the caret two cells (#1190).
+            // onto `r` and the selection reads "bar". This pinned 6 back when the
+            // backward rebuild moved the caret two cells (#1190).
             editor.run_edit_command(&EditCommand::Extend(MotionTarget::Grapheme(
                 Direction::Backward,
             )));
@@ -4800,18 +4786,24 @@ mod test {
             assert_eq!(editor.get_selection(), Some((4, 7)));
         }
 
-        // --- one cell per backward press (#1190) ---
+        // --- the caret rests on the resolved target (#1190) ---
         //
         // Every case starts from a selection left *forward* and wider than one
         // grapheme, since that is the only shape the two-cell step shows up in.
         // From the resting block the first press reverses the cursor, and a
         // backward cursor's caret is its head, thus the doubling cancels there.
+        //
+        // For a grapheme target that reads as one cell per press; for the word
+        // and line targets it reads as landing on the target rather than one
+        // past it. Both are the same invariant. The anchor is pinned alongside,
+        // since a rebuild that got the caret right and the anchor wrong would
+        // draw the wrong highlight.
 
         #[rstest]
         #[case::grapheme(MotionTarget::Grapheme(Direction::Backward), vec![4, 3, 2, 1, 0])]
         #[case::word_start(word_start_bwd(), vec![4, 0, 0])]
         #[case::line_start(MotionTarget::LineEdge(Direction::Backward), vec![0, 0])]
-        fn helix_extend_backward_walks_one_cell_per_press(
+        fn helix_extend_backward_rests_the_caret_on_the_target(
             #[case] target: MotionTarget,
             #[case] carets: Vec<usize>,
         ) {
@@ -4821,6 +4813,11 @@ mod test {
             for expected in carets {
                 editor.run_edit_command(&EditCommand::Extend(target));
                 assert_eq!(editor.insertion_point(), expected);
+                assert_eq!(
+                    editor.get_selection(),
+                    Some((0, expected + 1)),
+                    "the anchor stays where `%` left it"
+                );
             }
         }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3474,6 +3474,41 @@ mod tests {
         assert_eq!(rl.editor.get_selection(), Some((0, 3)));
     }
 
+    /// `#1190`: `%` leaves a forward selection wider than one grapheme, and a
+    /// backward extend from one used to move the caret two cells per press.
+    #[rstest]
+    #[case::h(ch('h'))]
+    #[case::left(key(KeyCode::Left))]
+    fn helix_select_left_walks_one_cell_after_select_all(#[case] left: KeyEvent) {
+        let mut rl = seam_engine(Box::<crate::Helix>::default());
+        drive_until_signal(
+            &mut rl,
+            &[
+                ch('a'),
+                ch('b'),
+                ch('c'),
+                ch('d'),
+                key(KeyCode::Esc),
+                ch('%'),
+                ch('v'),
+            ],
+        );
+        assert_eq!(rl.editor.get_selection(), Some((0, 4)));
+        assert_eq!(
+            rl.editor.insertion_point(),
+            3,
+            "caret rests on the final `d`"
+        );
+        for expected in [2, 1, 0] {
+            drive_until_signal(&mut rl, &[left]);
+            assert_eq!(
+                rl.editor.insertion_point(),
+                expected,
+                "one cell per press, not two"
+            );
+        }
+    }
+
     /// Appending has to land *past* the last grapheme: the block cursor rests on
     /// it, while insert mode sits between graphemes.
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3474,12 +3474,18 @@ mod tests {
         assert_eq!(rl.editor.get_selection(), Some((0, 3)));
     }
 
-    /// `#1190`: `%` leaves a forward selection wider than one grapheme, and a
-    /// backward extend from one used to move the caret two cells per press.
+    /// `#1190`: `%` and `x` both leave a forward selection wider than one
+    /// grapheme, and a backward extend from one used to move the caret two
+    /// cells per press.
     #[rstest]
-    #[case::h(ch('h'))]
-    #[case::left(key(KeyCode::Left))]
-    fn helix_select_left_walks_one_cell_after_select_all(#[case] left: KeyEvent) {
+    #[case::select_all_h(ch('%'), ch('h'))]
+    #[case::select_all_left(ch('%'), key(KeyCode::Left))]
+    #[case::select_line_h(ch('x'), ch('h'))]
+    #[case::select_line_left(ch('x'), key(KeyCode::Left))]
+    fn helix_select_left_walks_one_cell_after_a_wide_selection(
+        #[case] select: KeyEvent,
+        #[case] left: KeyEvent,
+    ) {
         let mut rl = seam_engine(Box::<crate::Helix>::default());
         drive_until_signal(
             &mut rl,
@@ -3489,7 +3495,7 @@ mod tests {
                 ch('c'),
                 ch('d'),
                 key(KeyCode::Esc),
-                ch('%'),
+                select,
                 ch('v'),
             ],
         );


### PR DESCRIPTION
## Summary

In helix select mode a backward press moved the caret two cells whenever the selection was left forward and wider than one grapheme, thus after `%`, `x` or any word motion.
`v` then `h` was always correct, which is why this survived: that first press reverses the cursor past its anchor, and a backward cursor's caret is its head, so the doubling cancels.
Only a selection that stays forward shows it, and it repeats on every press rather than jumping once.

`motion_origin` departs backward travel from the visible caret, which under a block caret already sits one grapheme inside the head.
`extend_span` then parks the head on `op_end` and the caret is rendered one grapheme back again, thus that offset lands twice.
The origins were right; the rebuild consuming them was not.

No public API change.

## Before

Buffer `abc de`, `Esc % v` then `h`:

[0,6) caret 5   ->   [0,4) caret 3   ->   [0,2) caret 1

## After

Backward rebuilds through `put_cursor`, which places the head so the caret comes to rest exactly on the resolved target:

[0,6) caret 5   ->   [0,5) caret 4   ->   [0,4) caret 3

## Additional notes

closes #1190