### PR TITLE
docs(enums): record why WordKind::Unicode is not collapsing

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -119,7 +119,9 @@ pub enum WordKind {
     LongWord,
     /// Emacs `M-f`/`M-b` — Unicode (UAX-29) word segmentation, so e.g. `can't`
     /// and `3.14` stay single words. The one flavor that isn't a thin char-class
-    /// predicate; see `locate_word`. (Follow-up: collapse onto a class predicate.)
+    /// predicate; see `locate_word`. Holding those together turns on the
+    /// characters flanking a `'` or a `.` rather than on their class, thus it
+    /// stays a separate scan instead of collapsing onto a boundary predicate.
     Unicode,
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Reedline! -->

## Summary <!-- Must Have -->
<!--
Motivate this PR: why did you open it, how did you arrive at this solution?
Mention any changes to Reedline's public API or observable behavior, or mention that there are none.
-->
Follow-up note asked for `Unicode` variant to fold onto a char-class boundary predicate like `Word` and `LongWord`. It cannot: keeping `can't` and `3.14` whole turns on what flanks the `'` or the `.`, which is context rather than class, thus UAX-29 segmentation stays its own scan.

Needs a follow-up in nushell to allow configuring it.