### PR TITLE
Add access to the command line selection

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -933,6 +933,11 @@ impl Reedline {
         self.editor.get_buffer()
     }
 
+    /// Returns the current selection range of the input buffer, otherwise None.
+    pub fn current_selection(&self) -> Option<(usize, usize)> {
+        self.editor.get_selection()
+    }
+
     /// Writes `msg` to the terminal with a following carriage return and newline
     fn print_line(&mut self, msg: &str) -> Result<()> {
         self.painter.paint_line(msg)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2812,6 +2812,7 @@ mod tests {
             .edit_buffer(|b| b.set_insertion_point(2), UndoBehavior::MoveCursor); // at len, legal under Between
         drive(&mut rl, &[ch('x')]); // flipts to OnGrapheme, emits nothing
         assert_eq!(rl.current_insertion_point(), 1);
+        assert_eq!(rl.current_selection(), None);
     }
 
     #[test]
@@ -2822,6 +2823,23 @@ mod tests {
         drive(&mut rl, &[ch('h'), ch('i')]);
         assert_eq!(rl.editor.get_buffer(), "hi");
         assert_eq!(rl.current_insertion_point(), 2);
+        assert_eq!(rl.current_selection(), None);
+    }
+
+    #[test]
+    fn test_current_selection() {
+        let mut rl = seam_engine(Box::<crate::Emacs>::default());
+        drive(
+            &mut rl,
+            &[
+                ch('h'),
+                ch('i'),
+                KeyEvent::new(KeyCode::Left, KeyModifiers::SHIFT),
+            ],
+        );
+        assert_eq!(rl.editor.get_buffer(), "hi");
+        assert_eq!(rl.current_insertion_point(), 1);
+        assert_eq!(rl.current_selection(), Some((1, 2)));
     }
 
     #[test]


### PR DESCRIPTION

<!-- Thanks for contributing to Reedline! -->

## Summary <!-- Must Have -->

<!--
Motivate this PR: why did you open it, how did you arrive at this solution?
Mention any changes to Reedline's public API or observable behavior, or mention that there are none.
-->
Allows nushell to get the current selection for `commandline get-selection`

New function `current_selection`.

### After <!-- Much Appreciated -->
<!--
Describe behavior, function or implementation AFTER your changes.
If not applicable, just remove the heading.
-->
`editor.get_selection` is exposed as `current_selection`, inspired by `current_insert_point`

Add `test_current_selection` and add `current_selection` asserts in existing tests.

## Additional notes <!-- Optional -->
<!--
Anything else worth knowing. Link related issues with `closes #123` / `fixes #456` to auto-close them on merge.
-->
closes #829 at least for the getter
Tested in emacs and vi.

The "Add tests or current_selection" commit can be improved or discarded.