### PR TITLE
Don't fail read_line when the cursor-position query times out at prompt init

### DIFF
--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -497,7 +497,39 @@ impl Painter {
                 size
             }
         };
-        let prompt_selector = select_prompt_row(suspended_state, self.stdout.cursor_position()?);
+        self.anchor_prompt(suspended_state)
+    }
+
+    /// Establishes the prompt's start row for a new line editor invocation by
+    /// asking the terminal where the cursor is.
+    fn anchor_prompt(&mut self, suspended_state: Option<&PainterSuspendedState>) -> Result<()> {
+        // The terminal may not answer the cursor-position query in time
+        // (crossterm gives it a fixed 2s): a terminal busy repainting, a
+        // multiplexer briefly holding the reply, a slow remote link. That is
+        // a transient condition, not a broken terminal, and this was the only
+        // query site that still aborted `read_line` on it -- every other one
+        // degrades to its last-known row. Do the same: print a newline so the
+        // prompt at least starts at column 0 on a row of its own, keep the
+        // row as `Stale` so the next paint's drift check asks again (and
+        // itself tolerates no answer), and carry on.
+        //
+        // With no row known at all, assume the bottom of the screen: the
+        // drift check only re-anchors when the cursor turns out to be
+        // *above* the cached row, so a guess that errs high self-heals on
+        // the next answered query, whereas row 0 would never be corrected.
+        let position = match self.stdout.cursor_position() {
+            Ok(position) => position,
+            Err(_) => {
+                self.print_crlf()?;
+                let row = match self.prompt_start_row {
+                    PromptStartRow::Verified(row) | PromptStartRow::Stale(row) => row,
+                    PromptStartRow::Unverified => self.screen_height().saturating_sub(1),
+                };
+                self.prompt_start_row = PromptStartRow::Stale(row);
+                return Ok(());
+            }
+        };
+        let prompt_selector = select_prompt_row(suspended_state, position);
         let new_row = match prompt_selector {
             PromptRowSelector::UseExistingPrompt { start_row } => start_row,
             PromptRowSelector::MakeNewPrompt { new_row } => {
@@ -1527,6 +1559,32 @@ mod tests {
             painter.state_before_suspension().was_flush_at_bottom,
             expected
         );
+    }
+
+    // Test writers never answer the cursor-position query (see
+    // `W::cursor_position`), which is exactly the terminal-didn't-reply case.
+    // Anchoring must then degrade rather than fail the whole `read_line`.
+    #[test]
+    fn test_anchor_prompt_without_answer_keeps_last_known_row_as_stale() {
+        let mut painter = Painter::new(W::capture());
+        painter.terminal_size = (20, 10);
+        painter.prompt_start_row.mark_verified(4);
+
+        painter.anchor_prompt(None).unwrap();
+
+        assert_eq!(painter.prompt_start_row, PromptStartRow::Stale(4));
+        assert_eq!(painter.stdout.captured(), b"\r\n");
+    }
+
+    #[test]
+    fn test_anchor_prompt_without_answer_and_no_row_assumes_bottom() {
+        let mut painter = Painter::new(W::capture());
+        painter.terminal_size = (20, 10);
+
+        painter.anchor_prompt(None).unwrap();
+
+        assert_eq!(painter.prompt_start_row, PromptStartRow::Stale(9));
+        assert_eq!(painter.stdout.captured(), b"\r\n");
     }
 
     fn base_snapshot() -> RenderSnapshot {


### PR DESCRIPTION
## Summary

`initialize_prompt_position` asks the terminal for the cursor position before painting a prompt. crossterm waits a fixed 2s for the reply and then fails; a terminal busy repainting, a multiplexer briefly holding the reply, or a slow remote link is enough to trip it. That's a transient condition, not a broken terminal — but this was the only `cursor_position()` call site in the painter that still propagated the error, so it aborted the whole `read_line()`, and a host typically treats that as fatal (reubeno/brush#1329: one late reply exits the interactive shell).

No public API change; observable behavior changes only in the failure case described.

### Before

`read_line()` returns `Err("The cursor position could not be read within a normal duration")` if the terminal doesn't answer the pre-prompt DSR query within 2s. Nothing was consumed from the user's input; the host just loses the editor.

### After

On no answer: print `\r\n` so the prompt at least starts at column 0 on a row of its own, set the row to the bottom of the screen as `Stale` so the next paint's drift check asks again (and itself tolerates no answer), and carry on.

The substitute is always the bottom row, never the last-known one. The drift check only re-anchors when the cursor turns out to be *above* the cached row, so a guess is only repairable if it errs high. The newline just printed has already moved the cursor past the last-known row in the common REPL case, and `clear_from_anchor` erases down from the anchor, so reusing it would wipe the output above the prompt with no way to recover. No row is greater than the bottom, so it is the only guess that always lands on the repairable side.

The query is split out into `anchor_prompt` so it can be unit-tested without a tty; the test writers already return an error from `cursor_position()`, which is exactly the case handled. Two tests added.

## Additional notes

Verified against a real host: brush at `main` (which has no retry of its own) built against 0.49.0 + this change — a pty harness that withholds the reply to exactly one query no longer ends the session, where stock 0.49.0 does. Ported cleanly to `main`; the only difference is `self.stdout.cursor_position()` vs `cursor::position()`.

`cargo test --lib` on `main`: 1662 pass, 1 pre-existing failure unrelated to this change (`crossterm_defaults_were_the_bright_palette_entries`, fails identically on clean `main` with rustc 1.98).

Complementary, not a substitute, for a host-side retry — reubeno/brush#1331 adds one there.

