### PR TITLE
refactor(menu)!: require Menu::settings instead of panicking in a default

### DIFF
--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -76,14 +76,10 @@ pub enum MenuEvent {
 /// Trait that defines how a menu will be printed by the painter
 pub trait Menu: Send {
     /// Get MenuSettings
-    fn settings(&self) -> &MenuSettings {
-        // We panic here, so this function has base implementation
-        // so existing menus will not break.
-        // if a breaking change is ok, this can be removed
-        panic!(
-            "`settings` requires a manual implementation per menu. It has a base implementation to not break existing menus"
-        )
-    }
+    ///
+    /// Every default method on this trait reads through here, so a menu has
+    /// to own a [`MenuSettings`] and hand it out.
+    fn settings(&self) -> &MenuSettings;
 
     /// Menu name
     fn name(&self) -> &str {

--- a/src/painting/painter.rs
+++ b/src/painting/painter.rs
@@ -1334,7 +1334,7 @@ impl Painter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::menu::MenuEvent;
+    use crate::menu::{MenuEvent, MenuSettings};
     use crate::{Color, Completer, Editor, PromptHistorySearch, Suggestion};
     use pretty_assertions::assert_eq;
     use rstest::rstest;
@@ -2022,6 +2022,9 @@ mod tests {
     struct TestMenu(String);
 
     impl Menu for TestMenu {
+        fn settings(&self) -> &MenuSettings {
+            unimplemented!()
+        }
         fn menu_string(&self, _available_lines: u16, _use_ansi_coloring: bool) -> String {
             self.0.clone()
         }


### PR DESCRIPTION
## Summary

`Menu::settings` ships a default body that panics, added so menus written before `MenuSettings` kept compiling.
The default `name` and `indicator` read through `settings()`, and the engine looks a menu up by `name` on every menu event, so a menu that takes the default compiles and then panics the first time it is triggered.

Making the method required turns that guaranteed runtime panic into a compile error.

Breaking for `Menu` implementors outside reedline.
Every in-tree menu already implements it, and nushell has no `Menu` impls of its own.

### Before

```rust
fn settings(&self) -> &MenuSettings {
    panic!("`settings` requires a manual implementation per menu. ...")
}
```

### After

```rust
fn settings(&self) -> &MenuSettings;
```

## Additional notes

The second commit gives the painter's `TestMenu` a real `MenuSettings` instead of an `unimplemented!()`, since the point is to stop menus carrying a panic where their settings should be.